### PR TITLE
Pass test time estimate arg to stabilize smart flank without cached results

### DIFF
--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -1,5 +1,6 @@
 package ftl.shard
 
+import com.google.common.annotations.VisibleForTesting
 import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
@@ -44,6 +45,9 @@ class com.foo.ClassName#testMethodToSkip
 */
 
 object Shard {
+    // When a test does not have previous results to reference, fall back to this run time.
+    @VisibleForTesting
+    const val DEFAULT_TEST_TIME_SEC: Double = 120.0
 
     private fun JUnitTestCase.androidKey(): String {
         return "class $classname#$name"
@@ -66,7 +70,7 @@ object Shard {
         if (args.shardTime < -1 || args.shardTime == 0) fatalError("Invalid shard time ${args.shardTime}")
 
         val junitMap = createJunitMap(oldTestResult, args)
-        val testsTotalTime = testsToRun.sumByDouble { junitMap[it] ?: 10.0 }
+        val testsTotalTime = testsToRun.sumByDouble { junitMap[it] ?: DEFAULT_TEST_TIME_SEC }
 
         val shardsByTime = ceil(testsTotalTime / args.shardTime).toInt()
 
@@ -104,7 +108,7 @@ object Shard {
 
         testsToRun.forEach { key ->
             val previousTime = junitMap[key]
-            val time = previousTime ?: 10.0
+            val time = previousTime ?: DEFAULT_TEST_TIME_SEC
 
             if (previousTime == null) {
                 cacheMiss += 1


### PR DESCRIPTION
Context: https://github.com/Flank/flank/issues/632

Ran into some local issues running all of the tests (stacktrace below[1]), but I think I covered most if not all of the places that this change touches.

Please leave comments on what I missed, or what I need to get a local build working. I can run unit tests in Android Studio, but hit some issues[2] running `./gradlew build`


[1]
```
java.lang.VerifyError: Stack map does not match the one at exception handler 77
Exception Details:
  Location:
    com/fasterxml/jackson/databind/deser/std/StdDeserializer._parseDate(Lcom/fasterxml/jackson/core/JsonParser;Lcom/fasterxml/jackson/databind/DeserializationContext;)Ljava/util/Date; @77: astore
  Reason:
    Type 'com/fasterxml/jackson/core/JsonParseException' (current frame, stack[0]) is not assignable to 'com/fasterxml/jackson/core/exc/StreamReadException' (stack map, stack[0])
```

[2]
```
ftl.args.GcloudYmlTest > initializationError FAILED
    java.lang.NoClassDefFoundError: Could not initialize class ftl.test.util.FlankTestRunner
```