### PR TITLE
Cache all uploads and downloads to GCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,11 +316,12 @@ flank:
   ## Default: false  
   # keep-file-path: false
     
-  ## Include additional app/test apk pairs in the run. If app is omitted, then the top level app is used for that pair.
+  ## Include additional app/test apk pairs in the run. Apks are unique by just filename and not by path!
+  ## If app is omitted, then the top level app is used for that pair.
   # additional-app-test-apks:
   #  - app: ../test_app/apks/app-debug.apk
-  #    test: ../test_app/apks/app-debug-androidTest.apk
-  #  - test: ../test_app/apks/app-debug-androidTest.apk
+  #    test: ../test_app/apks/app1-debug-androidTest.apk
+  #  - test: ../test_app/apks/app2-debug-androidTest.apk
 ```
 
 ### Android code coverage

--- a/test_runner/src/main/kotlin/ftl/args/yml/AndroidFlankYml.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/AndroidFlankYml.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class AppTestPair(
-    val app: String?,
+    val app: String,
     val test: String
 )
 

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -132,10 +132,11 @@ object GcStorage {
 
             try {
                 val blob = storage.get(bucket, path)
-                val readChannel = blob.reader()
-                val output = FileOutputStream(outputFile)
-                output.channel.transferFrom(readChannel, 0, Long.MAX_VALUE)
-                output.close()
+                blob.reader().use { readChannel ->
+                    FileOutputStream(outputFile).use {
+                        it.channel.transferFrom(readChannel, 0, Long.MAX_VALUE)
+                    }
+                }
             } catch (e: Exception) {
                 if (ignoreError) return@computeIfAbsent ""
                 fatalError(e)

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -20,8 +20,12 @@ import java.io.FileOutputStream
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
 
 object GcStorage {
+
+    private val uploadCache: ConcurrentHashMap<String, String> = ConcurrentHashMap()
+    private val downloadCache: ConcurrentHashMap<String, String> = ConcurrentHashMap()
 
     val storageOptions: StorageOptions by lazy {
         val builder = StorageOptions.newBuilder()
@@ -99,43 +103,44 @@ object GcStorage {
 
     private fun upload(file: String, fileBytes: ByteArray, rootGcsBucket: String, runGcsPath: String): String {
         val fileName = Paths.get(file).fileName.toString()
-        val gcsFilePath = GCS_PREFIX + join(rootGcsBucket, runGcsPath, fileName)
+        return uploadCache[fileName] ?: uploadCache.computeIfAbsent(fileName) {
+            val gcsFilePath = GCS_PREFIX + join(rootGcsBucket, runGcsPath, fileName)
 
-        // 404 Not Found error when rootGcsBucket does not exist
-        val fileBlob = BlobInfo.newBuilder(rootGcsBucket, join(runGcsPath, fileName)).build()
+            // 404 Not Found error when rootGcsBucket does not exist
+            val fileBlob = BlobInfo.newBuilder(rootGcsBucket, join(runGcsPath, fileName)).build()
 
-        val progress = ProgressBar()
-        try {
-            progress.start("Uploading $fileName")
-            storage.create(fileBlob, fileBytes)
-        } catch (e: Exception) {
-            fatalError(e)
-        } finally {
-            progress.stop()
+            val progress = ProgressBar()
+            try {
+                progress.start("Uploading $fileName")
+                storage.create(fileBlob, fileBytes)
+            } catch (e: Exception) {
+                fatalError(e)
+            } finally {
+                progress.stop()
+            }
+            gcsFilePath
         }
-
-        return gcsFilePath
     }
 
     fun download(gcsUriString: String, ignoreError: Boolean = false): String {
         val gcsURI = URI.create(gcsUriString)
         val bucket = gcsURI.authority
         val path = gcsURI.path.drop(1) // Drop leading slash
+        return downloadCache[path] ?: downloadCache.computeIfAbsent(path) {
+            val outputFile = File.createTempFile("tmp", null)
+            outputFile.deleteOnExit()
 
-        val outputFile = File.createTempFile("tmp", null)
-        outputFile.deleteOnExit()
-
-        try {
-            val blob = storage.get(bucket, path)
-            val readChannel = blob.reader()
-            val output = FileOutputStream(outputFile)
-            output.channel.transferFrom(readChannel, 0, Long.MAX_VALUE)
-            output.close()
-        } catch (e: Exception) {
-            if (ignoreError) return ""
-            fatalError(e)
+            try {
+                val blob = storage.get(bucket, path)
+                val readChannel = blob.reader()
+                val output = FileOutputStream(outputFile)
+                output.channel.transferFrom(readChannel, 0, Long.MAX_VALUE)
+                output.close()
+            } catch (e: Exception) {
+                if (ignoreError) return@computeIfAbsent ""
+                fatalError(e)
+            }
+            outputFile.path
         }
-
-        return outputFile.path
     }
 }


### PR DESCRIPTION
Currently, when using local apk artifacts, Flank always uploads every
app/test apk pair even if the app apk has already been uploaded. This is
also true for pulling the old JUnitReport from GCS for smart flank where
every test apk re-downloads the results. To fix this we simply cache
uploads and downloads in a ConcurrentHashMap where the key is the GCS
path for downloads and the filename for uploads.

This change also fixes a bug where local test apks would be uploaded and
then re-downloaded to parse their tests. The sharding loop now loops over
the local AppTestPair where it uploads them if necessary and scans for
tests on the local test apk.

All in all this shaves almost 4 minutes off of shard generation for a
project with 20+ modules. There is also likely more work that can be
done to parallelize matrix creation (uploading apks, parsing tests,
creating the shard), but it is out of scope of this change.

Matrix/shard generation output (truncated and sanitized)
Before (60s smart flank shard time):
```      ...
      additional-app-test-apks:
        - app: output/app.apk
          test: output/app1-dev-debug-androidTest.apk
        - app: output/app.apk
          test: output/app2-dev-debug-androidTest.apk
        - app: output/app.apk
          test: output/app3-dev-debug-androidTest.apk
        ...
        - app: output/app.apk
          test: output/app19-dev-debug-androidTest.apk
        - app: output/app.apk
          test: output/app20-dev-debug-androidTest.apk
RunTests
  Uploading app.apk .  Uploading app-dev-debug-androidTest.apk .

  Uploading app.apk .  Uploading app1-dev-debug-androidTest.apk .

  Uploading app.apk .  Uploading app2-dev-debug-androidTest.apk .

  Uploading app.apk .  Uploading app3-dev-debug-androidTest.apk .

  ...

  Uploading app.apk .  Uploading app19-dev-debug-androidTest.apk .

  Uploading app.apk .  Uploading app20-dev-debug-androidTest.apk


  Smart Flank cache hit: 81% (29 / 36)
  Shard times: 31s, 40s

  ...

  2593 tests / 153 shards

  153 matrix ids created in 6m 12s
```

After (45s smart flank shard time hence more shards):
```      ...
      additional-app-test-apks:
        - app: output/app.apk
          test: output/app1-dev-debug-androidTest.apk
        - app: output/app.apk
          test: output/app2-dev-debug-androidTest.apk
        - app: output/app.apk
          test: output/app3-dev-debug-androidTest.apk
        ...
        - app: output/app.apk
          test: output/app19-dev-debug-androidTest.apk
        - app: output/app.apk
          test: output/app20-dev-debug-androidTest.apk
RunTests
  Uploading app.apk .  Uploading app-dev-debug-androidTest.apk .


  Smart Flank cache hit: 81% (29 / 36)
  Shard times: 30s, 40s

  Uploading app1-dev-debug-androidTest.apk .

  Smart Flank cache hit: 84% (21 / 25)
  Shard times: 40s, 40s, 40s, 41s

  Uploading app2-dev-debug-androidTest.apk .

  Smart Flank cache hit: 100% (197 / 197)
  Shard times: 41s, 41s, 41s, 41s, 41s, 41s, 41s, 41s

  Uploading app3-dev-debug-androidTest.apk .

  Smart Flank cache hit: 100% (7 / 7)
  Shard times: 12s

  ...

  Smart Flank cache hit: 100% (7 / 7)
  Shard times: 2s

  Uploading app20-dev-debug-androidTest.apk .

  Smart Flank cache hit: 67% (2 / 3)
  Shard times: 11s

  2594 tests / 206 shards

  206 matrix ids created in 2m 25s
```