### PR TITLE
Flank should exit with code 1 when validation issues

### DIFF
--- a/test_runner/flank-invalid.yml
+++ b/test_runner/flank-invalid.yml
@@ -1,0 +1,7 @@
+gcloud:
+  app: ../test_app/apks/app-debug.apk
+  test: ../test_app/apks/app-debug-androidTest.apk
+
+flank:
+  incorrect: fields
+  

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -132,7 +132,7 @@ flank:
 
   ## Local folder to store the test result. Folder is DELETED before each run to ensure only artifacts from the new run are saved.
   # local-result-dir: flank
-  
+
   ## Downloaded files preserves the original path of file. Required when file names are not unique.
   ## Default: false
   # keep-file-path: false

--- a/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
@@ -122,16 +122,15 @@ object YamlDeprecated {
 
     private val yamlWriter by lazy { yamlMapper.writerWithDefaultPrettyPrinter() }
 
-    fun modify(yamlPath: Path, fix: Boolean = false): Boolean {
+    fun modify(yamlPath: Path): Boolean {
         if (yamlPath.toFile().exists().not()) fatalError("Flank yml doesn't exist at path $yamlPath")
-        val data = String(Files.readAllBytes(yamlPath))
 
+        val data = String(Files.readAllBytes(yamlPath))
         val (errorDetected, string) = modify(data)
 
-        if (fix) {
-            Files.write(yamlPath, string.toByteArray())
-            println("\nUpdated ${yamlPath.fileName} file")
-        }
+        Files.write(yamlPath, string.toByteArray())
+        println("\nUpdated ${yamlPath.fileName} file")
+
         return errorDetected
     }
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/CommandUtil.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/CommandUtil.kt
@@ -1,0 +1,23 @@
+package ftl.cli.firebase.test
+
+import ftl.args.yml.YamlDeprecated
+import java.nio.file.Path
+import kotlin.system.exitProcess
+
+fun processValidation(validationResult: String, shouldFix: Boolean, ymlPath: Path) {
+    when {
+        validationResult.isBlank() -> println("Valid yml file")
+        !shouldFix -> {
+            println(validationResult)
+            exitProcess(1)
+        }
+        else -> {
+            println(validationResult)
+            println("Trying to fix yml file")
+            if (YamlDeprecated.modify(ymlPath)) {
+                println("Unable to fix yml file")
+                exitProcess(1)
+            }
+        }
+    }
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidDoctorCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidDoctorCommand.kt
@@ -1,7 +1,7 @@
 package ftl.cli.firebase.test.android
 
 import ftl.args.AndroidArgs
-import ftl.args.yml.YamlDeprecated
+import ftl.cli.firebase.test.processValidation
 import ftl.doctor.Doctor.validateYaml
 import java.nio.file.Paths
 import picocli.CommandLine.Command
@@ -23,9 +23,8 @@ import picocli.CommandLine.Option
 class AndroidDoctorCommand : Runnable {
     override fun run() {
         val ymlPath = Paths.get(configPath)
-        println(validateYaml(AndroidArgs, ymlPath))
-
-        YamlDeprecated.modify(ymlPath, fix)
+        val validationResult = validateYaml(AndroidArgs, ymlPath)
+        processValidation(validationResult, fix, ymlPath)
     }
 
     @Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosDoctorCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosDoctorCommand.kt
@@ -1,7 +1,7 @@
 package ftl.cli.firebase.test.ios
 
 import ftl.args.IosArgs
-import ftl.args.yml.YamlDeprecated
+import ftl.cli.firebase.test.processValidation
 import ftl.doctor.Doctor.validateYaml
 import java.nio.file.Paths
 import picocli.CommandLine.Command
@@ -23,9 +23,8 @@ import picocli.CommandLine.Option
 class IosDoctorCommand : Runnable {
     override fun run() {
         val ymlPath = Paths.get(configPath)
-        println(validateYaml(IosArgs, Paths.get(configPath)))
-
-        YamlDeprecated.modify(ymlPath, fix)
+        val validationResult = validateYaml(IosArgs, Paths.get(configPath))
+        processValidation(validationResult, fix, ymlPath)
     }
 
     @Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/TestCommandUtils.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/TestCommandUtils.kt
@@ -1,0 +1,4 @@
+package ftl.cli.firebase.test
+
+const val SUCCESS_VALIDATION_MESSAGE = "Valid yml file\n"
+const val INVALID_YML_PATH = "./flank-invalid.yml"

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidDoctorCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidDoctorCommandTest.kt
@@ -1,12 +1,14 @@
 package ftl.cli.firebase.test.android
 
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
+import ftl.cli.firebase.test.INVALID_YML_PATH
+import ftl.cli.firebase.test.SUCCESS_VALIDATION_MESSAGE
 import ftl.config.FtlConstants
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.normalizeLineEnding
 import org.junit.Rule
 import org.junit.Test
+import org.junit.contrib.java.lang.system.ExpectedSystemExit
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
 import picocli.CommandLine
@@ -17,6 +19,10 @@ class AndroidDoctorCommandTest {
     @JvmField
     val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
 
+    @Rule
+    @JvmField
+    val exit = ExpectedSystemExit.none()
+
     @Test
     fun androidDoctorCommandPrintsHelp() {
         val doctor = AndroidDoctorCommand()
@@ -24,7 +30,7 @@ class AndroidDoctorCommandTest {
         CommandLine(doctor).execute("-h")
 
         val output = systemOutRule.log.normalizeLineEnding()
-        Truth.assertThat(output).startsWith(
+        assertThat(output).startsWith(
             "Verifies flank firebase is setup correctly\n" +
                 "\n" +
                 "doctor [-fh] [-c=<configPath>]\n" +
@@ -48,7 +54,7 @@ class AndroidDoctorCommandTest {
         AndroidDoctorCommand().run()
         // When there are no lint errors, output is a newline.
         val output = systemOutRule.log.normalizeLineEnding()
-        Truth.assertThat(output).isEqualTo("\n")
+        assertThat(output).isEqualTo(SUCCESS_VALIDATION_MESSAGE)
     }
 
     @Test
@@ -65,5 +71,14 @@ class AndroidDoctorCommandTest {
         assertThat(cmd.fix).isFalse()
         cmd.fix = true
         assertThat(cmd.fix).isTrue()
+    }
+
+    @Test
+    fun `should terminate with exit code 1 when yml validation fails`() {
+        exit.expectSystemExitWithStatus(1)
+        AndroidDoctorCommand().run {
+            configPath = INVALID_YML_PATH
+            run()
+        }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosDoctorCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosDoctorCommandTest.kt
@@ -1,12 +1,15 @@
 package ftl.cli.firebase.test.ios
 
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
+import ftl.cli.firebase.test.INVALID_YML_PATH
+import ftl.cli.firebase.test.SUCCESS_VALIDATION_MESSAGE
+import ftl.cli.firebase.test.android.AndroidDoctorCommand
 import ftl.config.FtlConstants
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.normalizeLineEnding
 import org.junit.Rule
 import org.junit.Test
+import org.junit.contrib.java.lang.system.ExpectedSystemExit
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
 import picocli.CommandLine
@@ -17,6 +20,10 @@ class IosDoctorCommandTest {
     @JvmField
     val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
 
+    @Rule
+    @JvmField
+    val exit = ExpectedSystemExit.none()
+
     @Test
     fun iosDoctorCommandPrintsHelp() {
         val doctor = IosDoctorCommand()
@@ -24,7 +31,7 @@ class IosDoctorCommandTest {
         CommandLine(doctor).execute("-h")
 
         val output = systemOutRule.log.normalizeLineEnding()
-        Truth.assertThat(output).startsWith(
+        assertThat(output).startsWith(
             "Verifies flank firebase is setup correctly\n" +
                 "\n" +
                 "doctor [-fh] [-c=<configPath>]\n" +
@@ -46,6 +53,8 @@ class IosDoctorCommandTest {
     @Test
     fun iosDoctorCommandRuns() {
         IosDoctorCommand().run()
+        val output = systemOutRule.log.normalizeLineEnding()
+        assertThat(output).isEqualTo(SUCCESS_VALIDATION_MESSAGE)
     }
 
     @Test
@@ -62,5 +71,14 @@ class IosDoctorCommandTest {
         assertThat(cmd.fix).isFalse()
         cmd.fix = true
         assertThat(cmd.fix).isTrue()
+    }
+
+    @Test
+    fun `should terminate with exit code 1 when yml validation fails`() {
+        exit.expectSystemExitWithStatus(1)
+        AndroidDoctorCommand().run {
+            configPath = INVALID_YML_PATH
+            run()
+        }
     }
 }


### PR DESCRIPTION
Fixes #448 

When validation of yml file fail, process ends with exit code (1). 
Prints `Valid yml file` message otherwise.