### PR TITLE
Flank should not skip tests annotated with @Ignored

### DIFF
--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -23,6 +23,7 @@ import ftl.reports.xml.model.JUnitTestResult
 import ftl.shard.Shard
 import ftl.shard.StringShards
 import ftl.shard.stringShards
+import ftl.util.FlankTestMethod
 import ftl.util.Utils
 import java.io.File
 import java.net.URI
@@ -55,7 +56,7 @@ object ArgsHelper {
     fun assertCommonProps(args: IArgs) {
         Utils.assertNotEmpty(
             args.project, "The project is not set. Define GOOGLE_CLOUD_PROJECT, set project in flank.yml\n" +
-                    "or save service account credential to ${FtlConstants.defaultCredentialPath}\n" +
+                    "or save service account credential to ${defaultCredentialPath}\n" +
                     " See https://github.com/GoogleCloudPlatform/google-cloud-java#specifying-a-project-id"
         )
 
@@ -114,7 +115,7 @@ object ArgsHelper {
         testTargets: List<String>,
         validTestMethods: Collection<String>,
         from: String,
-        skipValidation: Boolean = FtlConstants.useMock
+        skipValidation: Boolean = useMock
     ) {
         val missingMethods = testTargets - validTestMethods
 
@@ -123,7 +124,7 @@ object ArgsHelper {
     }
 
     fun createJunitBucket(projectId: String, junitGcsPath: String) {
-        if (FtlConstants.useMock || junitGcsPath.isEmpty()) return
+        if (useMock || junitGcsPath.isEmpty()) return
         val bucket = junitGcsPath.drop(GCS_PREFIX.length).substringBefore('/')
         createGcsBucket(projectId, bucket)
     }
@@ -190,7 +191,7 @@ object ArgsHelper {
     }
 
     fun getDefaultProjectId(): String? {
-        if (FtlConstants.useMock) return "mockProjectId"
+        if (useMock) return "mockProjectId"
 
         // Allow users control over project by checking using Google's logic first before falling back to JSON.
         return ServiceOptions.getDefaultProjectId() ?: serviceAccountProjectId()
@@ -220,9 +221,9 @@ object ArgsHelper {
         return ArgsFileVisitor("glob:$filePath").walk(searchDir)
     }
 
-    fun calculateShards(filteredTests: List<String>, args: IArgs): List<List<String>> {
+    fun calculateShards(filteredTests: List<FlankTestMethod>, args: IArgs): List<List<String>> {
         val shards = if (args.disableSharding) {
-            mutableListOf(filteredTests as MutableList<String>)
+            mutableListOf(filteredTests.map { it.testName } as MutableList<String>)
         } else {
             val oldTestResult = GcStorage.downloadJunitXml(args) ?: JUnitTestResult(mutableListOf())
             val shardCount = Shard.shardCountByTime(filteredTests, oldTestResult, args)

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -21,6 +21,7 @@ import ftl.config.Device
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog
 import ftl.ios.Xctestrun
+import ftl.util.FlankTestMethod
 import ftl.util.Utils.fatalError
 import java.nio.file.Files
 import java.nio.file.Path
@@ -69,7 +70,7 @@ class IosArgs(
         if (disableSharding) return@lazy listOf(emptyList<String>())
 
         val validTestMethods = Xctestrun.findTestNames(xctestrunFile)
-        val testsToShard = filterTests(validTestMethods, testTargets).distinct()
+        val testsToShard = filterTests(validTestMethods, testTargets).distinct().map { FlankTestMethod(it, ignored = false) }
 
         ArgsHelper.calculateShards(testsToShard, this)
     }

--- a/test_runner/src/main/kotlin/ftl/util/FlankTestMethod.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankTestMethod.kt
@@ -1,0 +1,3 @@
+package ftl.util
+
+data class FlankTestMethod(val testName: String, val ignored: Boolean = false)

--- a/test_runner/src/test/kotlin/ftl/filter/TestFiltersTest.kt
+++ b/test_runner/src/test/kotlin/ftl/filter/TestFiltersTest.kt
@@ -6,6 +6,7 @@ import com.linkedin.dex.parser.TestMethod
 import ftl.filter.TestFilters.fromTestTargets
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -14,31 +15,56 @@ val BAR_PACKAGE = TestMethod("bar.ClassName#testName", emptyList())
 val FOO_CLASSNAME = TestMethod("whatever.Foo#testName", emptyList())
 val BAR_CLASSNAME = TestMethod("whatever.Bar#testName", emptyList())
 val WITHOUT_IGNORE_ANNOTATION = TestMethod("whatever.Foo#testName", emptyList())
-val WITH_IGNORE_ANNOTATION = TestMethod("whatever.Foo#testName", listOf(TestAnnotation("org.junit.Ignore", emptyMap(), false)))
+val WITH_IGNORE_ANNOTATION =
+    TestMethod("whatever.Foo#testName", listOf(TestAnnotation("org.junit.Ignore", emptyMap(), false)))
 val WITH_FOO_ANNOTATION = TestMethod("whatever.Foo#testName", listOf(TestAnnotation("Foo", emptyMap(), false)))
 val WITH_BAR_ANNOTATION = TestMethod("whatever.Foo#testName", listOf(TestAnnotation("Bar", emptyMap(), false)))
 val WITHOUT_FOO_ANNOTATION = TestMethod("whatever.Foo#testName", emptyList())
 val WITH_FOO_ANNOTATION_AND_PACKAGE = TestMethod("foo.Bar#testName", listOf(TestAnnotation("Foo", emptyMap(), false)))
 val WITH_LARGE_ANNOTATION = TestMethod("whatever.Foo#testName", listOf(TestAnnotation("LargeTest", emptyMap(), false)))
-val WITH_MEDIUM_ANNOTATION = TestMethod("whatever.Foo#testName", listOf(TestAnnotation("MediumTest", emptyMap(), false)))
+val WITH_MEDIUM_ANNOTATION =
+    TestMethod("whatever.Foo#testName", listOf(TestAnnotation("MediumTest", emptyMap(), false)))
 val WITH_SMALL_ANNOTATION = TestMethod("whatever.Foo#testName", listOf(TestAnnotation("SmallTest", emptyMap(), false)))
 val WITHOUT_LARGE_ANNOTATION = TestMethod("whatever.Foo#testName", emptyList())
 val WITHOUT_MEDIUM_ANNOTATION = TestMethod("whatever.Foo#testName", emptyList())
 val WITHOUT_SMALL_ANNOTATION = TestMethod("whatever.Foo#testName", emptyList())
 const val TEST_FILE = "src/test/kotlin/ftl/filter/fixtures/dummy-tests-file.txt"
+private const val IGNORE_ANNOTATION = "org.junit.Ignore"
 
 @RunWith(FlankTestRunner::class)
 class TestFiltersTest {
 
+    private val targets = listOf(
+        TargetsHelper(
+            pack = "anyPackage_1",
+            cl = "anyClass_1",
+            m = "anyMethod_1",
+            annotation = IGNORE_ANNOTATION
+        ),
+        TargetsHelper(pack = "anyPackage_2", cl = "anyClass_2", m = "anyMethod_2", annotation = "Foo"),
+        TargetsHelper(pack = "anyPackage_3", cl = "anyClass_3", m = "anyMethod_3", annotation = "Bar"),
+        TargetsHelper(
+            pack = "anyPackage_4",
+            cl = "anyClass_4",
+            m = "anyMethod_4",
+            annotation = IGNORE_ANNOTATION
+        )
+    )
+
+    private val testMethodSet = targets.map { getDefaultTestMethod(it.fullView, it.annotation) }
+    private val commonExpected = targets.map { it.fullView }
+
     @Test
     fun testIgnoreMultipleAnnotations() {
-        val m1 = TestMethod("com.example.app.ExampleUiTest#testFails", listOf(
-            TestAnnotation("org.junit.runner.RunWith", emptyMap(), false),
-            TestAnnotation("org.junit.Ignore", emptyMap(), false),
-            TestAnnotation("org.junit.Test", emptyMap(), false)
-        ))
+        val m1 = TestMethod(
+            "com.example.app.ExampleUiTest#testFails", listOf(
+                TestAnnotation("org.junit.runner.RunWith", emptyMap(), false),
+                TestAnnotation("org.junit.Ignore", emptyMap(), false),
+                TestAnnotation("org.junit.Test", emptyMap(), false)
+            )
+        )
 
-        val filter = fromTestTargets(listOf("class com.example.app.ExampleUiTest#testFails"))
+        val filter = fromTestTargets(listOf("notAnnotation org.junit.Ignore"))
 
         assertThat(filter.shouldRun(m1)).isFalse()
     }
@@ -76,10 +102,10 @@ class TestFiltersTest {
     }
 
     @Test
-    fun emptyTargetsShouldFilterTestsWithTheIgnoreAnnotation() {
+    fun `empty targets should not filter @Ignore annotated tests`() {
         val filter = fromTestTargets(listOf())
 
-        assertThat(filter.shouldRun(WITH_IGNORE_ANNOTATION)).isFalse()
+        assertThat(filter.shouldRun(WITH_IGNORE_ANNOTATION)).isTrue()
         assertThat(filter.shouldRun(WITHOUT_IGNORE_ANNOTATION)).isTrue()
     }
 
@@ -165,7 +191,7 @@ class TestFiltersTest {
 
     @Test
     fun allOfProperlyChecksAllFilters() {
-        val filter = TestFilters.fromTestTargets(listOf("package foo,bar", "annotation Foo"))
+        val filter = fromTestTargets(listOf("package foo,bar", "annotation Foo"))
 
         assertThat(filter.shouldRun(FOO_PACKAGE)).isFalse()
         assertThat(filter.shouldRun(BAR_PACKAGE)).isFalse()
@@ -205,77 +231,127 @@ class TestFiltersTest {
         fromTestTargets(listOf("invalidCommand com.my.package"))
     }
 
-    private fun getTestMethodSet(): List<TestMethod> {
-        val m1 = TestMethod("a.b#c", listOf(TestAnnotation("org.junit.Ignore", emptyMap(), false)))
-        val m2 = TestMethod("d.e#f", listOf(TestAnnotation("Foo", emptyMap(), false)))
-        val m3 = TestMethod("h.i#j", listOf(TestAnnotation("Bar", emptyMap(), false)))
-        return listOf(m1, m2, m3)
-    }
-
     @Test
     fun classFilterOverridesNotAnnotation() {
-        val testMethods = getTestMethodSet()
-        val filter = fromTestTargets(listOf("notAnnotation Foo", "class d.e#f", "class h.i#j"))
+        val filter = fromTestTargets(
+            listOf(
+                "notAnnotation Foo",
+                "class anyPackage_2.anyClass_2#anyMethod_2",
+                "class anyPackage_3.anyClass_3#anyMethod_3"
+            )
+        )
 
         val output = mutableListOf<String>()
-        val filtered = testMethods.asSequence().filter { test ->
+        val filtered = testMethodSet.asSequence().filter { test ->
             val result = filter.shouldRun(test)
             output.add("""$result ${test.testName} [${filter.describe}]""")
             result
         }.map { "class ${it.testName}" }.toList()
 
-        // @Ignore a.b#c
-        // @Foo d.e#f
-        // @Bar h.i#j
         val expected = listOf(
-            "false a.b#c [allOf [notIgnored, not withAnnotation Foo, anyOf [withClassName d.e#f, withClassName h.i#j]]]",
-            "false d.e#f [allOf [notIgnored, not withAnnotation Foo, anyOf [withClassName d.e#f, withClassName h.i#j]]]",
-            "true h.i#j [allOf [notIgnored, not withAnnotation Foo, anyOf [withClassName d.e#f, withClassName h.i#j]]]"
+            "false anyPackage_1.anyClass_1#anyMethod_1 [allOf [not withAnnotation Foo, anyOf [withClassName anyPackage_2.anyClass_2#anyMethod_2, withClassName anyPackage_3.anyClass_3#anyMethod_3]]]",
+            "false anyPackage_2.anyClass_2#anyMethod_2 [allOf [not withAnnotation Foo, anyOf [withClassName anyPackage_2.anyClass_2#anyMethod_2, withClassName anyPackage_3.anyClass_3#anyMethod_3]]]",
+            "true anyPackage_3.anyClass_3#anyMethod_3 [allOf [not withAnnotation Foo, anyOf [withClassName anyPackage_2.anyClass_2#anyMethod_2, withClassName anyPackage_3.anyClass_3#anyMethod_3]]]",
+            "false anyPackage_4.anyClass_4#anyMethod_4 [allOf [not withAnnotation Foo, anyOf [withClassName anyPackage_2.anyClass_2#anyMethod_2, withClassName anyPackage_3.anyClass_3#anyMethod_3]]]"
         )
 
         assertThat(output).isEqualTo(expected)
-        assertThat(filtered).isEqualTo(listOf("class h.i#j"))
+        assertThat(filtered).isEqualTo(listOf("class anyPackage_3.anyClass_3#anyMethod_3"))
     }
 
     @Test
     fun notAnnotationFiltersWithClass() {
-        val testMethods = getTestMethodSet()
-        val filter = fromTestTargets(listOf("notAnnotation Foo", "class h.i#j"))
+        val filter = fromTestTargets(listOf("notAnnotation Foo", "class anyPackage_1.anyClass_1#anyMethod_1"))
+        val filtered = testMethodSet.withFilter(filter)
 
-        val filtered = testMethods.asSequence().filter(filter.shouldRun).map { it.testName }.toList()
-        assertThat(filtered).isEqualTo(listOf("h.i#j"))
+        assertEquals(listOf("anyPackage_1.anyClass_1#anyMethod_1"), filtered)
     }
 
     @Test
     fun notAnnotationFilters() {
-        val testMethods = getTestMethodSet()
         val filter = fromTestTargets(listOf("notAnnotation Moo"))
+        val filtered = testMethodSet.withFilter(filter, enrich = false)
 
-        val filtered = testMethods.asSequence().filter(filter.shouldRun).map { it.testName }.toList()
-        assertThat(filtered).isEqualTo(listOf("d.e#f", "h.i#j"))
+        assertEquals(commonExpected, filtered)
     }
 
     @Test
     fun methodOverrideIgnored() {
-        val filter = fromTestTargets(listOf("class a.b#c", "class d.e#f", "class h.i#j"))
+        val filter = fromTestTargets(targets.map { it.methodView })
+        val filtered = testMethodSet.withFilter(filter)
 
-        val filtered = getTestMethodSet().asSequence().filter(filter.shouldRun).map { it.testName }.toList()
-        assertThat(filtered).isEqualTo(listOf("d.e#f", "h.i#j"))
+        assertEquals(commonExpected, filtered)
     }
 
     @Test
     fun multipleClassesResolveToMethods() {
-        val filter = fromTestTargets(listOf("class a.b", "class d.e", "class h.i"))
+        val filter = fromTestTargets(targets.map { it.classView })
+        val filtered = testMethodSet.withFilter(filter)
 
-        val filtered = getTestMethodSet().asSequence().filter(filter.shouldRun).map { it.testName }.toList()
-        assertThat(filtered).isEqualTo(listOf("d.e#f", "h.i#j"))
+        assertEquals(commonExpected, filtered)
     }
 
     @Test
     fun multiplePackagesResolveToMethods() {
-        val filter = fromTestTargets(listOf("package a", "package d", "package h"))
+        val filter = fromTestTargets(targets.map { it.packageView })
+        val filtered = testMethodSet.withFilter(filter)
 
-        val filtered = getTestMethodSet().asSequence().filter(filter.shouldRun).map { it.testName }.toList()
-        assertThat(filtered).isEqualTo(listOf("d.e#f", "h.i#j"))
+        assertEquals(commonExpected, filtered)
     }
+
+    @Test
+    fun `by default - should contain method annotated with @Ignore`() {
+        val byPackageFilter = fromTestTargets(targets.map { it.packageView })
+        val byClassFilter = fromTestTargets(targets.map { it.classView })
+        val byNotAnnotationFilter = fromTestTargets(listOf("notAnnotation ThereIsNoSuchAnnotation"))
+
+        val byPackage = testMethodSet.withFilter(byPackageFilter)
+        val byClass = testMethodSet.withFilter(byClassFilter)
+        val byNotAnnotation = testMethodSet.withFilter(byNotAnnotationFilter, enrich = false)
+
+        assertEquals(commonExpected, byPackage)
+        assertEquals(commonExpected, byClass)
+        assertEquals(commonExpected, byNotAnnotation)
+    }
+
+    @Test
+    fun `should filter tests annotated with @Ignore if user explicitly want to do so`() {
+        val byNotAnnotationFilter = fromTestTargets(listOf("notAnnotation $IGNORE_ANNOTATION"))
+        val byNotAnnotation = testMethodSet.withFilter(byNotAnnotationFilter, enrich = false)
+        val expected = targets.filterNot { it.annotation == IGNORE_ANNOTATION }.map { it.fullView }
+
+        assertEquals(byNotAnnotation, expected)
+    }
+}
+
+private fun getDefaultTestMethod(testName: String, annotation: String) =
+    TestMethod(testName, listOf(TestAnnotation(annotation, emptyMap(), false)))
+
+private fun List<TestMethod>.add(method: TestMethod) = listOf(*this.toTypedArray() + method)
+
+private fun List<TestMethod>.withFilter(filter: TestFilter, enrich: Boolean = true) =
+    if (enrich)
+        add(getDefaultTestMethod("should.be#filtered", "AnyAnnotation"))
+            .filter(filter.shouldRun)
+            .map { it.testName }
+    else
+        filter(filter.shouldRun).map { it.testName }
+
+private class TargetsHelper(
+    private val pack: String,
+    private val cl: String,
+    private val m: String,
+    val annotation: String
+) {
+    val classView: String
+        get() = "class $pack.$cl"
+
+    val packageView: String
+        get() = "package $pack"
+
+    val methodView: String
+        get() = "class $fullView"
+
+    val fullView: String
+        get() = "$pack.$cl#$m"
 }


### PR DESCRIPTION
Fixes #629 

## Changes
* tests annotated with `@Ignore` are included in test matrix by default (TL skips them anyway)
* user still can filter tests with `@Ignore` with `notAnnotation org.junit.Ignore`
* Ignored tests now have time = 0 (regardless previous results)
* update and refactor unit tests

## Checklist

- [x] Documented
- [x] Unit tested
