### PR TITLE
Skip Bugsnag initialisation if user disabled gcloud analytics

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,7 @@
 ## next (unreleased)
 
-- [#672](https://github.com/Flank/flank/pull/672) Flank timeout feature. ([pawelpasterz](https://github.com/pawelpasterz)) 
+- [#678](https://github.com/Flank/flank/pull/678) Skip Bugsnag initialization if user disabled gcloud analytics. ([pawelpasterz](https://github.com/pawelpasterz)) 
+- [#672](https://github.com/Flank/flank/pull/672) Flank timeout feature. ([pawelpasterz](https://github.com/pawelpasterz))
 - [#657](https://github.com/Flank/flank/pull/657) Fix execution hangs. ([pawelpasterz](https://github.com/pawelpasterz))
 - [#654](https://github.com/Flank/flank/pull/654) Fix test filters when using both notPackage and notClass. ([jan-gogo](https://github.com/jan-gogo))
 - [#648](https://github.com/Flank/flank/pull/648) Include @Ignore JUnit tests in JUnit XML. ([pawelpasterz](https://github.com/pawelpasterz))

--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -183,6 +183,7 @@ dependencies {
     testImplementation(Libs.MOCKITO_INLINE)
     implementation(Libs.SYSTEM_RULES)
     testImplementation(Libs.TRUTH)
+    testImplementation(Libs.MOCKK)
 }
 
 // Fix Exception in thread "main" java.lang.NoSuchMethodError: com.google.common.hash.Hashing.crc32c()Lcom/google/common/hash/HashFunction;
@@ -202,3 +203,8 @@ tasks.withType<KotlinCompile> {
 // https://github.com/gradle/kotlin-dsl/blob/master/samples/task-dependencies/build.gradle.kts#L41
 // https://github.com/codecov/example-gradle/blob/master/build.gradle#L25
 tasks["check"].dependsOn(tasks["jacocoTestReport"], tasks["detekt"])
+
+tasks.create("updateFlank", Exec::class.java) {
+    description = "Update flank jar"
+    commandLine = listOf("./bash/update_flank.sh")
+}

--- a/test_runner/buildSrc/src/main/kotlin/Deps.kt
+++ b/test_runner/buildSrc/src/main/kotlin/Deps.kt
@@ -47,7 +47,7 @@ object Versions {
     const val JSOUP = "1.12.1"
 
     // https://github.com/ktorio/ktor/releases
-    const val KTOR ="1.2.5"
+    const val KTOR = "1.2.5"
 
     // https://github.com/qos-ch/logback/releases
     const val LOGBACK = "1.2.3"
@@ -69,6 +69,9 @@ object Versions {
     const val WOODSTOX = "6.0.1"
 
     const val KOTLIN_LOGGING = "1.7.8"
+
+    // https://github.com/mockk/mockk
+    const val MOCKK = "1.9.3"
 }
 
 object Libs {
@@ -89,7 +92,7 @@ object Libs {
 
     const val JACKSON_KOTLIN = "com.fasterxml.jackson.module:jackson-module-kotlin:${Versions.JACKSON}"
     const val JACKSON_YAML = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${Versions.JACKSON}"
-    const val JACKSON_XML ="com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${Versions.JACKSON}"
+    const val JACKSON_XML = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${Versions.JACKSON}"
 
     const val KOTLIN_COROUTINES_CORE = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.KOTLIN_COROUTINES}"
     const val KOTLIN_REFLECT = "org.jetbrains.kotlin:kotlin-reflect:${Versions.KOTLIN}"
@@ -105,7 +108,7 @@ object Libs {
     const val KOTLIN_LOGGING = "io.github.microutils:kotlin-logging:${Versions.KOTLIN_LOGGING}"
 
     //region Plugins
-    const val DETEKT_FORMATTING  ="io.gitlab.arturbosch.detekt:detekt-formatting:${Versions.DETEKT}"
+    const val DETEKT_FORMATTING = "io.gitlab.arturbosch.detekt:detekt-formatting:${Versions.DETEKT}"
     //endregion
 
     //region Test Dependencies
@@ -116,5 +119,6 @@ object Libs {
     const val PICOCLI = "info.picocli:picocli:${Versions.PICOCLI}"
     const val SYSTEM_RULES = "com.github.stefanbirkner:system-rules:${Versions.SYSTEM_RULES}"
     const val TRUTH = "com.google.truth:truth:${Versions.TRUTH}"
+    const val MOCKK = "io.mockk:mockk:${Versions.MOCKK}"
     //endregion
 }

--- a/test_runner/src/main/kotlin/ftl/config/BugsnagInitHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/config/BugsnagInitHelper.kt
@@ -1,0 +1,19 @@
+package ftl.config
+
+import com.bugsnag.Bugsnag
+import java.nio.file.Paths
+
+internal object BugsnagInitHelper {
+
+    private const val GSUTIL_FOLDER = ".gsutil"
+    private const val ANALYTICS_FILE = "analytics-uuid"
+    private const val DISABLED = "DISABLED"
+    private const val FLANK_API_KEY = "3d5f8ba4ee847d6bb51cb9c347eda74f"
+
+    internal fun initBugsnag(useMock: Boolean) =
+        Paths.get(System.getProperty("user.home"), "$GSUTIL_FOLDER/$ANALYTICS_FILE").toFile().run {
+            if (useMock) null
+            else if (exists() && readText().trim() == DISABLED) null
+            else Bugsnag(FLANK_API_KEY)
+        }
+}

--- a/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
+++ b/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
@@ -1,6 +1,5 @@
 package ftl.config
 
-import com.bugsnag.Bugsnag
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.googleapis.util.Utils
 import com.google.api.client.http.GoogleApiLogger
@@ -13,6 +12,7 @@ import com.google.auth.oauth2.ServiceAccountCredentials
 import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
+import ftl.config.BugsnagInitHelper.initBugsnag
 import ftl.gc.UserAuth
 import ftl.http.HttpTimeoutIncrease
 import ftl.util.fatalError
@@ -38,7 +38,6 @@ object FtlConstants {
     }
 
     const val localhost = "http://localhost:8080"
-
     const val defaultLocale = "en"
     const val defaultOrientation = "portrait"
     const val defaultIosModel = "iphone8"
@@ -52,12 +51,13 @@ object FtlConstants {
     const val applicationName = "Flank"
     const val GCS_PREFIX = "gs://"
     const val runTimeout = "-1"
+
     val JSON_FACTORY: JsonFactory by lazy { Utils.getDefaultJsonFactory() }
 
-    val bugsnag = Bugsnag(if (useMock) null else "3d5f8ba4ee847d6bb51cb9c347eda74f")
+    val bugsnag = initBugsnag(useMock)
 
     init {
-        bugsnag.setAppVersion(readRevision())
+        bugsnag?.setAppVersion(readRevision())
     }
 
     val httpTransport: NetHttpTransport by lazy {

--- a/test_runner/src/test/kotlin/ftl/config/BugsnagInitHelperTest.kt
+++ b/test_runner/src/test/kotlin/ftl/config/BugsnagInitHelperTest.kt
@@ -1,0 +1,70 @@
+package ftl.config
+
+import ftl.log.LogbackLogger
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.UUID
+
+private const val GSUTIL_FOLDER = ".gsutil"
+private const val ANALYTICS_FILE = "analytics-uuid"
+private const val DISABLED = "DISABLED\n"
+
+class BugsnagInitHelperTest {
+
+    private val helper = BugsnagInitHelper
+
+    @get:Rule
+    val folder = TemporaryFolder()
+
+    @Before
+    fun setUp() {
+        LogbackLogger.Bugsnag.isEnabled = false
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `should not create Bugsnag object if user has analytics disabled`() {
+        mockkStatic(System::class)
+        every { System.getProperty("user.home") } returns folder.root.absolutePath
+
+        val subfolder = folder.newFolder(GSUTIL_FOLDER)
+        File(subfolder, ANALYTICS_FILE).also { it.writeText(DISABLED) }
+
+        assertNull(helper.initBugsnag(useMock = false))
+    }
+
+    @Test
+    fun `should not create Bugsnag object if user provided analytics-uuid`() {
+        mockkStatic(System::class)
+        every { System.getProperty("user.home") } returns folder.root.absolutePath
+
+        val subfolder = folder.newFolder(GSUTIL_FOLDER)
+        File(subfolder, ANALYTICS_FILE).also { it.writeText(UUID.randomUUID().toString()) }
+
+        assertNotNull(helper.initBugsnag(useMock = false))
+    }
+
+    @Test
+    fun `should create Bugsnag object if mock server used`() {
+        mockkStatic(System::class)
+        every { System.getProperty("user.home") } returns folder.root.absolutePath
+
+        val subfolder = folder.newFolder(GSUTIL_FOLDER)
+        File(subfolder, ANALYTICS_FILE).also { it.writeText(UUID.randomUUID().toString()) }
+
+        assertNull(helper.initBugsnag(useMock = true))
+    }
+}


### PR DESCRIPTION
Fixes #581 

## Changes
* Introduce `BugsnagInitHelper` class to handle Bugsnag initialisation logic
* if `useMock` is equal true -- Bugsnag is not enabled
* if user had disabled `gcloud` analytics -- Bugsnag is not enabled
* in other cases -- Bugsnag enabled
* Add `updateFlank` gradle task to update local flank jar
* Add `mockk` library as POC (will replace `mockito` in the future)

## Checklist

- [x] Documented
- [x] Unit tested
- [x] release_notes.md updated
