### PR TITLE
Fix logging level for both root and Bugsnag not being initialized

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,7 @@
 ## next (unreleased)
+- [#687](https://github.com/Flank/flank/pull/687) Debug message printed after every command. ([pawelpasterz](https://github.com/pawelpasterz))
 - [#666](https://github.com/Flank/flank/pull/666) Use API instead of XML for result parsing for android. ([jan-gogo](https://github.com/jan-gogo))
-- [#678](https://github.com/Flank/flank/pull/678) Skip Bugsnag initialization if user disabled gcloud analytics. ([pawelpasterz](https://github.com/pawelpasterz)) 
+- [#678](https://github.com/Flank/flank/pull/678) Skip Bugsnag initialization if user disabled gcloud analytics. ([pawelpasterz](https://github.com/pawelpasterz))
 - [#672](https://github.com/Flank/flank/pull/672) Flank timeout feature. ([pawelpasterz](https://github.com/pawelpasterz))
 - [#657](https://github.com/Flank/flank/pull/657) Fix execution hangs. ([pawelpasterz](https://github.com/pawelpasterz))
 - [#654](https://github.com/Flank/flank/pull/654) Fix test filters when using both notPackage and notClass. ([jan-gogo](https://github.com/jan-gogo))

--- a/test_runner/src/main/kotlin/ftl/Main.kt
+++ b/test_runner/src/main/kotlin/ftl/Main.kt
@@ -39,7 +39,8 @@ class Main : Runnable {
 
     @CommandLine.Option(
         names = ["--debug"],
-        description = ["Enables debug logging"]
+        description = ["Enables debug logging"],
+        defaultValue = "false"
     )
     fun debug(enabled: Boolean) = setDebugLogging(enabled)
 

--- a/test_runner/src/main/kotlin/ftl/log/LogbackLogger.kt
+++ b/test_runner/src/main/kotlin/ftl/log/LogbackLogger.kt
@@ -2,6 +2,7 @@ package ftl.log
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
+import com.bugsnag.Bugsnag
 import org.slf4j.LoggerFactory.getLogger
 import kotlin.properties.Delegates
 
@@ -9,12 +10,12 @@ sealed class LogbackLogger(private val logger: Logger) : FlankLogger {
 
     constructor(logger: Any) : this(logger as Logger)
 
-    override var isEnabled: Boolean by Delegates.observable(false) { _, _, enable ->
+    final override var isEnabled: Boolean by Delegates.observable(false) { _, _, enable ->
         logger.level = if (enable)
             Level.ALL else
             Level.OFF
     }
 
     object Root : LogbackLogger(getLogger(Logger.ROOT_LOGGER_NAME))
-    object Bugsnag : LogbackLogger(getLogger(Bugsnag::class.java))
+    object FlankBugsnag : LogbackLogger(getLogger(Bugsnag::class.java))
 }

--- a/test_runner/src/main/kotlin/ftl/log/Loggers.kt
+++ b/test_runner/src/main/kotlin/ftl/log/Loggers.kt
@@ -4,7 +4,7 @@ import com.google.api.client.http.GoogleApiLogger
 
 private val LOGGERS = listOf(
     LogbackLogger.Root,
-    LogbackLogger.Bugsnag,
+    LogbackLogger.FlankBugsnag,
     GoogleApiLogger
 )
 

--- a/test_runner/src/test/kotlin/ftl/config/FlankBugsnagInitHelperTest.kt
+++ b/test_runner/src/test/kotlin/ftl/config/FlankBugsnagInitHelperTest.kt
@@ -18,7 +18,7 @@ private const val GSUTIL_FOLDER = ".gsutil"
 private const val ANALYTICS_FILE = "analytics-uuid"
 private const val DISABLED = "DISABLED\n"
 
-class BugsnagInitHelperTest {
+class FlankBugsnagInitHelperTest {
 
     private val helper = BugsnagInitHelper
 
@@ -27,7 +27,7 @@ class BugsnagInitHelperTest {
 
     @Before
     fun setUp() {
-        LogbackLogger.Bugsnag.isEnabled = false
+        LogbackLogger.FlankBugsnag.isEnabled = false
     }
 
     @After


### PR DESCRIPTION
Fixes #682 

Due to lazy initialization of Kotlin's objects logging level was not set (default was used).

## Checklist
- [x] release_notes.md updated
