### PR TITLE
Disable print error message when retry occurs

### DIFF
--- a/test_runner/src/main/kotlin/ftl/http/ExecuteWithRetry.kt
+++ b/test_runner/src/main/kotlin/ftl/http/ExecuteWithRetry.kt
@@ -8,12 +8,11 @@ import java.io.IOException
 fun <T> AbstractGoogleJsonClientRequest<T>.executeWithRetry(): T {
     var lastErr: IOException? = null
 
-    for (i in 1..10) {
+    repeat(10) {
         try {
             return this.execute()
         } catch (err: IOException) {
             lastErr = err
-            System.err.println("Request failed, retrying ${i}x $err")
         }
     }
 


### PR DESCRIPTION
When retry occurs error message is printed to user which can be misleading.
