### PR TITLE
Add detailed api reporting

### DIFF
--- a/test_runner/bash/update_flank.sh
+++ b/test_runner/bash/update_flank.sh
@@ -6,4 +6,4 @@ FLANK="$DIR/.."
 
 "$FLANK/gradlew" -p "$FLANK" clean assemble shadowJar
 
-cp "$FLANK"/build/libs/flank-*.jar "$DIR/flank.jar"
+cp "$FLANK"/build/libs/flank.jar "$DIR/flank.jar"


### PR DESCRIPTION
Fixes #701

Flank will send notifications to Bugsnag when Google API error occurrs. Data can be fetch within api request [API docs](https://bugsnagapiv2.docs.apiary.io/). However authorized account (added to project/organization) is required