### PR TITLE
Update ascii docs

### DIFF
--- a/test_runner/docs/ascii/flank.jar_-android-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-run.adoc
@@ -40,6 +40,7 @@ flank.jar
                        [*--project*=_<project>_] [*--results-bucket*=_<resultsBucket>_]
                        [*--results-dir*=_<resultsDir>_]
                        [*--results-history-name*=_<resultsHistoryName>_]
+                       [*--robo-script*=_<roboScript>_]
                        [*--run-timeout*=_<runTimeout>_] [*--shard-time*=_<shardTime>_]
                        [*--smart-flank-gcs-path*=_<smartFlankGcsPath>_]
                        [*--test*=_<test>_] [*--test-runner-class*=_<testRunnerClass>_]
@@ -55,7 +56,9 @@ flank.jar
                        _<String=String>_...]]...
                        [*--files-to-download*=_<filesToDownload>_[,
                        _<filesToDownload>_...]]... [*--other-files*=_<String=String>_
-                       [,_<String=String>_...]]... [*--test-targets*=_<testTargets>_[,
+                       [,_<String=String>_...]]...
+                       [*--robo-directives*=_<roboDirectives>_[,
+                       _<roboDirectives>_...]]... [*--test-targets*=_<testTargets>_[,
                        _<testTargets>_...]]...
                        [*--test-targets-always-run*=_<testTargetsAlwaysRun>_[,
                        _<testTargetsAlwaysRun>_...]]...
@@ -176,6 +179,26 @@ Configuration is read from flank.yml
 
 *--no-use-orchestrator*::
   Orchestrator is not used. See --use-orchestrator.
+
+*--robo-directives*=_<roboDirectives>_[,_<roboDirectives>_...]::
+  A comma-separated (<type>:<key>=<value>) map of robo_directives that you can use to customize the behavior of Robo test.
++
+The type specifies the action type of the directive, which may take on values click, text or ignore.
++
+If no type is provided, text will be used by default.
++
+Each key should be the Android resource name of a target UI element and each value should be the text input for that element.
++
+Values are only permitted for text type elements, so no value should be specified for click and ignore type elements.
+
+*--robo-script*=_<roboScript>_::
+  The path to a Robo Script JSON file.
++
+The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
++
+You can guide the Robo test to perform specific actions by recording a Robo Script in Android Studio and then specifying this argument.
++
+Learn more at https://firebase.google.com/docs/test-lab/robo-ux-test#scripting. 
 
 *--environment-variables*=_<String=String>_[,_<String=String>_...]::
   A comma-separated, key=value map of environment variables and their desired values. --environment-variables=coverage=true,coverageFile=/sdcard/coverage.ec The environment variables are mirrored as extra options to the am instrument -e KEY1 VALUE1 … command and passed to your test runner (typically AndroidJUnitRunner)

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-run.adoc
@@ -45,7 +45,8 @@ flank.jar
                                      [*--results-bucket*=_<resultsBucket>_]
                                      [*--results-dir*=_<resultsDir>_]
                                      [*--results-history-name*=_<resultsHistoryName_
-                  _                   >_] [*--run-timeout*=_<runTimeout>_]
+                  _                   >_] [*--robo-script*=_<roboScript>_]
+                                     [*--run-timeout*=_<runTimeout>_]
                                      [*--shard-time*=_<shardTime>_]
                                      [*--smart-flank-gcs-path*=_<smartFlankGcsPath>_
                                      ] [*--test*=_<test>_]
@@ -67,6 +68,8 @@ flank.jar
                                      _<filesToDownload>_...]]...
                                      [*--other-files*=_<String=String>_[,
                                      _<String=String>_...]]...
+                                     [*--robo-directives*=_<roboDirectives>_[,
+                                     _<roboDirectives>_...]]...
                                      [*--test-targets*=_<testTargets>_[,
                                      _<testTargets>_...]]...
                                      [*--test-targets-always-run*=_<testTargetsAlwa_
@@ -188,6 +191,26 @@ Configuration is read from flank.yml
 
 *--no-use-orchestrator*::
   Orchestrator is not used. See --use-orchestrator.
+
+*--robo-directives*=_<roboDirectives>_[,_<roboDirectives>_...]::
+  A comma-separated (<type>:<key>=<value>) map of robo_directives that you can use to customize the behavior of Robo test.
++
+The type specifies the action type of the directive, which may take on values click, text or ignore.
++
+If no type is provided, text will be used by default.
++
+Each key should be the Android resource name of a target UI element and each value should be the text input for that element.
++
+Values are only permitted for text type elements, so no value should be specified for click and ignore type elements.
+
+*--robo-script*=_<roboScript>_::
+  The path to a Robo Script JSON file.
++
+The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
++
+You can guide the Robo test to perform specific actions by recording a Robo Script in Android Studio and then specifying this argument.
++
+Learn more at https://firebase.google.com/docs/test-lab/robo-ux-test#scripting. 
 
 *--environment-variables*=_<String=String>_[,_<String=String>_...]::
   A comma-separated, key=value map of environment variables and their desired values. --environment-variables=coverage=true,coverageFile=/sdcard/coverage.ec The environment variables are mirrored as extra options to the am instrument -e KEY1 VALUE1 … command and passed to your test runner (typically AndroidJUnitRunner)


### PR DESCRIPTION
Quick fix which add missing `robo-script` and `robo-directives` in ascii docs
