### PR TITLE
Use "localhost" as default for hostname to fix backward compatibility…

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,5 @@
 ## next (unreleased)
+- [#763](https://github.com/Flank/flank/pull/763) Use "localhost" as default for hostname to fix backward compatibility. ([jan-gogo](https://github.com/jan-gogo))
 - [#757](https://github.com/Flank/flank/pull/757) Print version and revision before each command. ([jan-gogo](https://github.com/jan-gogo))
 - [#759](https://github.com/Flank/flank/pull/759) Add shard name for uploaded xctestrun files. ([pawelpasterz](https://github.com/pawelpasterz))
 - [#755](https://github.com/Flank/flank/pull/755) Remove ascii doc generated section header. ([jan-gogo](https://github.com/jan-gogo))

--- a/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestSuite.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestSuite.kt
@@ -32,7 +32,7 @@ data class JUnitTestSuite(
     val timestamp: String?, // String. Android only
 
     @JacksonXmlProperty(isAttribute = true)
-    val hostname: String? = null, // String.
+    val hostname: String? = "localhost", // String.
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JacksonXmlProperty(isAttribute = true)


### PR DESCRIPTION
Fixes #749 

## Checklist

- [x] release_notes.md updated
