### PR TITLE
Use legacy results for iOS by default

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,5 @@
 ## next (unreleased)
-- 
+- [#783](https://github.com/Flank/flank/pull/783) Use legacy results for iOS by default. ([pawelpasterz](https://github.com/pawelpasterz))
 
 ## v20.05.1
 

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -69,6 +69,8 @@ class IosArgs(
     override val networkProfile = cli?.networkProfile ?: gcloud.networkProfile
     override val ignoreFailedTests = cli?.ignoreFailedTests ?: flank.ignoreFailedTests
     override val keepFilePath = cli?.keepFilePath ?: flank.keepFilePath
+    // currently, FTL does not provide API based results for iOS
+    override val useLegacyJUnitResult = true
 
     private val iosFlank = iosFlankYml.flank
     val testTargets = cli?.testTargets ?: iosFlank.testTargets.filterNotNull()

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -171,6 +171,7 @@ flank:
             assert(flakyTestAttempts, 4)
             assert(disableSharding, true)
             assert(runTimeout, "15m")
+            assert(useLegacyJUnitResult, true)
         }
     }
 


### PR DESCRIPTION
Fixes #652

## Checklist

- [x] Unit tested
- [x] release_notes.md updated
