### PR TITLE
#769 Convert bitrise macOS workflow into github actions

### DIFF
--- a/.github/workflows/macos_workflow.yml
+++ b/.github/workflows/macos_workflow.yml
@@ -1,0 +1,38 @@
+name: macOS-workflow
+
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Gradle check
+      uses: eskatos/gradle-command-action@v1
+      with:
+        # Path to the Gradle executable
+        gradle-executable: "./test_runner/gradlew"
+        # Gradle command line arguments, see gradle --help
+        arguments: "-p test_runner check"
+        
+    - name: Codecov
+      uses: codecov/codecov-action@v1.0.7
+      with:
+        # Repository upload token - get it from codecov.io. Required only for private repositories
+        token: ${{secrets.CODECOV_TOKEN}}

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,10 +2,12 @@
 
 - [#784](https://github.com/Flank/flank/pull/784) Add output-style option. ([jan-gogo](https://github.com/jan-gogo))
 - [#779](https://github.com/Flank/flank/pull/779) Print retries & display additional info. ([jan-gogo](https://github.com/jan-gogo))
-- [#793](https://github.com/Flank/flank/issues/793) Better error message on file not found. ([adamfilipow92](https://github.com/adamfilipow92))
-- [#808](https://github.com/Flank/flank/issues/808) Fixed dry run crashes. ([piotradamczyk5](https://github.com/piotradamczyk5))
-- [#807](https://github.com/Flank/flank/issues/807) Fix Bugsnag being initialized during tests. ([piotradamczyk5](https://github.com/piotradamczyk5))
+- [#793](https://github.com/Flank/flank/issues/793) Better error message on file not found. ([adamfilipow92](https://github.com/adamfilipow92)) 
+- [#808](https://github.com/Flank/flank/issues/808) Fixed dry run crashes. ([piotradamczyk5](https://github.com/piotradamczyk5)) 
+- [#807](https://github.com/Flank/flank/issues/807) Fix Bugsnag being initialized during tests. ([piotradamczyk5](https://github.com/piotradamczyk5)) 
 - [#805](https://github.com/Flank/flank/pull/805) Fix overlapping results. ([pawelpasterz](https://github.com/pawelpasterz))
+- [#811](https://github.com/Flank/flank/issues/811) Convert bitrise macOS workflow to github action. ([piotradamczyk5](https://github.com/piotradamczyk5)) 
+- 
 
 ## v20.05.2
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,12 +2,11 @@
 
 - [#784](https://github.com/Flank/flank/pull/784) Add output-style option. ([jan-gogo](https://github.com/jan-gogo))
 - [#779](https://github.com/Flank/flank/pull/779) Print retries & display additional info. ([jan-gogo](https://github.com/jan-gogo))
-- [#793](https://github.com/Flank/flank/issues/793) Better error message on file not found. ([adamfilipow92](https://github.com/adamfilipow92)) 
-- [#808](https://github.com/Flank/flank/issues/808) Fixed dry run crashes. ([piotradamczyk5](https://github.com/piotradamczyk5)) 
-- [#807](https://github.com/Flank/flank/issues/807) Fix Bugsnag being initialized during tests. ([piotradamczyk5](https://github.com/piotradamczyk5)) 
+- [#793](https://github.com/Flank/flank/issues/793) Better error message on file not found. ([adamfilipow92](https://github.com/adamfilipow92))
+- [#808](https://github.com/Flank/flank/issues/808) Fixed dry run crashes. ([piotradamczyk5](https://github.com/piotradamczyk5))
+- [#807](https://github.com/Flank/flank/issues/807) Fix Bugsnag being initialized during tests. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#805](https://github.com/Flank/flank/pull/805) Fix overlapping results. ([pawelpasterz](https://github.com/pawelpasterz))
-- [#811](https://github.com/Flank/flank/issues/811) Convert bitrise macOS workflow to github action. ([piotradamczyk5](https://github.com/piotradamczyk5)) 
-- 
+- [#812](https://github.com/Flank/flank/issues/812) Convert bitrise macOS workflow to github action. ([piotradamczyk5](https://github.com/piotradamczyk5))
 
 ## v20.05.2
 


### PR DESCRIPTION
Fixes #769 Convert [bitrise macOS workflow](https://app.bitrise.io/app/9767f3e19047d4db/workflow_editor#!/yml) to GitHub actions

This PR will cause that PR checks will be performed on GitHub Actions instead of Bitrise

## Checklist

- [x] release_notes.md updated
