### PR TITLE
Allow runtime test discovery when sharding is disabled by not setting test-targets. This unblocks cucumber testing

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,7 +10,7 @@
 - [#812](https://github.com/Flank/flank/issues/812) Convert bitrise macOS workflow to github action. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#799](https://github.com/Flank/flank/pull/799) Refactor Shared object by splitting it into smaller functions. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#798](https://github.com/Flank/flank/pull/798) Remove failure nodes from tests that passed on retry so that Jenkins JUnit plugin marks them as successful. ([adamfilipow92](https://github.com/adamfilipow92))
-- [#822](https://github.com/Flank/flank/pull/822) Prevent set test targets is sharding is disabled and test-targets not set. ([adamfilipow92](https://github.com/adamfilipow92))
+- [#822](https://github.com/Flank/flank/pull/822) Allow runtime test discovery when sharding is disabled by not setting test-targets. This unblocks cucumber testing. ([adamfilipow92](https://github.com/adamfilipow92))
 
 ## v20.05.2
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,8 +10,7 @@
 - [#812](https://github.com/Flank/flank/issues/812) Convert bitrise macOS workflow to github action. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#799](https://github.com/Flank/flank/pull/799) Refactor Shared object by splitting it into smaller functions. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#798](https://github.com/Flank/flank/pull/798) Remove failure nodes from tests that passed on retry so that Jenkins JUnit plugin marks them as successful. ([adamfilipow92](https://github.com/adamfilipow92))
-- 
-- 
+- [#822](https://github.com/Flank/flank/pull/822) Prevent set test targets is sharding is disabled and test-targets not set. ([adamfilipow92](https://github.com/adamfilipow92))
 
 ## v20.05.2
 

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -61,7 +61,8 @@ internal suspend fun runAndroidTests(args: AndroidArgs): TestResult = coroutineS
         val androidTestConfig = args.createAndroidTestConfig(
             uploadedApks = uploadedApks,
             testShards = testShards,
-            runGcsPath = runGcsPath
+            runGcsPath = runGcsPath,
+            keepTestTargetsEmpty = args.disableSharding && args.testTargets.isEmpty()
         )
 
         testMatrices += executeAndroidTestMatrix(runCount = args.repeatTests) {

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
@@ -13,7 +13,8 @@ sealed class AndroidTestConfig {
         // sharding
         val disableSharding: Boolean,
         val testShards: ShardChunks,
-        val numUniformShards: Int?
+        val numUniformShards: Int?,
+        val keepTestTargetsEmpty: Boolean
     ) : AndroidTestConfig()
 
     data class Robo(

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestConfig.kt
@@ -12,14 +12,18 @@ internal fun AndroidArgs.createAndroidTestConfig(
 ): AndroidTestConfig = when {
     isInstrumentationTest -> createInstrumentationConfig(
         uploadedApks = uploadedApks,
-        testShards = when {
-            disableSharding && testTargets.isNullOrEmpty() -> emptyList()
-            else -> testShards ?: throw FlankFatalError("Arg testShards is required for instrumentation test.")
-        }
+        testShards = getTestShards(testShards)
     )
-    isRoboTest -> createRoboConfig(
+    isRoboTest
+    -> createRoboConfig(
         uploadedApks = uploadedApks,
         runGcsPath = runGcsPath ?: throw FlankFatalError("Arg runGcsPath is required for robo test.")
     )
     else -> throw FlankFatalError("Cannot create AndroidTestConfig, invalid AndroidArgs.")
 }
+
+private fun AndroidArgs.getTestShards(testShards: ShardChunks?): ShardChunks =
+    if (disableSharding && testTargets.isNullOrEmpty())
+        emptyList()
+    else
+        testShards ?: throw FlankFatalError("Arg testShards is required for instrumentation test.")

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestConfig.kt
@@ -12,7 +12,10 @@ internal fun AndroidArgs.createAndroidTestConfig(
 ): AndroidTestConfig = when {
     isInstrumentationTest -> createInstrumentationConfig(
         uploadedApks = uploadedApks,
-        testShards = testShards ?: throw FlankFatalError("Arg testShards is required for instrumentation test.")
+        testShards = when {
+            disableSharding && testTargets.isNullOrEmpty() -> emptyList()
+            else -> testShards ?: throw FlankFatalError("Arg testShards is required for instrumentation test.")
+        }
     )
     isRoboTest -> createRoboConfig(
         uploadedApks = uploadedApks,

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestConfig.kt
@@ -8,11 +8,13 @@ import ftl.util.FlankFatalError
 internal fun AndroidArgs.createAndroidTestConfig(
     uploadedApks: UploadedApks,
     testShards: ShardChunks? = null,
-    runGcsPath: String? = null
+    runGcsPath: String? = null,
+    keepTestTargetsEmpty: Boolean = false
 ): AndroidTestConfig = when {
     isInstrumentationTest -> createInstrumentationConfig(
         uploadedApks = uploadedApks,
-        testShards = getTestShards(testShards)
+        keepTestTargetsEmpty = keepTestTargetsEmpty,
+        testShards = testShards ?: throw FlankFatalError("Arg testShards is required for instrumentation test.")
     )
     isRoboTest
     -> createRoboConfig(
@@ -21,9 +23,3 @@ internal fun AndroidArgs.createAndroidTestConfig(
     )
     else -> throw FlankFatalError("Cannot create AndroidTestConfig, invalid AndroidArgs.")
 }
-
-private fun AndroidArgs.getTestShards(testShards: ShardChunks?): ShardChunks =
-    if (disableSharding && testTargets.isNullOrEmpty())
-        emptyList()
-    else
-        testShards ?: throw FlankFatalError("Arg testShards is required for instrumentation test.")

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateInstrumentationConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateInstrumentationConfig.kt
@@ -6,6 +6,7 @@ import ftl.args.yml.UploadedApks
 
 internal fun AndroidArgs.createInstrumentationConfig(
     uploadedApks: UploadedApks,
+    keepTestTargetsEmpty: Boolean,
     testShards: ShardChunks
 ) = AndroidTestConfig.Instrumentation(
     appApkGcsPath = uploadedApks.app,
@@ -14,5 +15,6 @@ internal fun AndroidArgs.createInstrumentationConfig(
     orchestratorOption = "USE_ORCHESTRATOR".takeIf { useOrchestrator },
     disableSharding = disableSharding,
     numUniformShards = numUniformShards,
-    testShards = testShards
+    testShards = testShards,
+    keepTestTargetsEmpty = keepTestTargetsEmpty
 )

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -11,7 +11,7 @@ fun main() {
     val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
         ?: "YOUR PROJECT ID"
     val quantity = "single"
-    val type = "errorFlaky"
+    val type = "success-disable-sharding"
 
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -1379,7 +1379,7 @@ AndroidArgs
           disable-sharding: true
         """.trimIndent()
         val args = AndroidArgs.load(yaml)
-        val androidTestConfig = args.createAndroidTestConfig(UploadedApks("", ""), listOf(listOf("test")))
+        val androidTestConfig = args.createAndroidTestConfig(UploadedApks("", ""), listOf(listOf("test")), null, true)
         val testSpecification = TestSpecification().setupAndroidTest(androidTestConfig)
         assertTrue(testSpecification.androidInstrumentationTest.testTargets.isEmpty())
     }

--- a/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-success-disable-sharding.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-success-disable-sharding.yml
@@ -1,0 +1,7 @@
+gcloud:
+  app: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
+  test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk
+  use-orchestrator: false
+
+flank:
+  disable-sharding: true

--- a/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
@@ -30,7 +30,8 @@ class GcAndroidTestMatrixTest {
                 orchestratorOption = null,
                 numUniformShards = null,
                 disableSharding = false,
-                testRunnerClass = ""
+                testRunnerClass = "",
+                keepTestTargetsEmpty = false
             ),
             runGcsPath = "",
             otherFiles = emptyMap(),
@@ -53,7 +54,8 @@ class GcAndroidTestMatrixTest {
                 orchestratorOption = null,
                 numUniformShards = null,
                 disableSharding = false,
-                testRunnerClass = ""
+                testRunnerClass = "",
+                keepTestTargetsEmpty = false
             ),
             runGcsPath = "",
             otherFiles = emptyMap(),
@@ -80,7 +82,8 @@ class GcAndroidTestMatrixTest {
                 orchestratorOption = null,
                 numUniformShards = null,
                 disableSharding = false,
-                testRunnerClass = ""
+                testRunnerClass = "",
+                keepTestTargetsEmpty = false
             ),
             runGcsPath = "",
             otherFiles = emptyMap(),

--- a/test_runner/src/test/kotlin/ftl/gc/android/CreateAndroidInstrumentationTestTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/android/CreateAndroidInstrumentationTestTest.kt
@@ -19,7 +19,8 @@ class UtilsKtTest {
             .setupTestTargets(
                 disableSharding = true,
                 testShards = testShards,
-                numUniformShards = null
+                numUniformShards = null,
+                keepTestTargetsEmpty = false
             )
             .testTargets
 
@@ -39,7 +40,8 @@ class UtilsKtTest {
             .setupTestTargets(
                 disableSharding = false,
                 testShards = testShards,
-                numUniformShards = 50
+                numUniformShards = 50,
+                keepTestTargetsEmpty = false
             )
 
         // then
@@ -57,7 +59,8 @@ class UtilsKtTest {
             .setupTestTargets(
                 disableSharding = false,
                 testShards = shardChunks,
-                numUniformShards = null
+                numUniformShards = null,
+                keepTestTargetsEmpty = false
             )
             .shardingOption
             .manualSharding


### PR DESCRIPTION
Fixes #815

## Checklist

- [X] Unit tested
- [X] release_notes.md updated
