### PR TITLE
#816 Omit `environment-variables` for robo test executions instead of throwing exception.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -17,6 +17,8 @@
 - [#825](https://github.com/Flank/flank/pull/825) Automatically convert -1 in maximum-test-shards to the maximum shard amount. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#833](https://github.com/Flank/flank/pull/833) More error messages improvements. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - 
+- [#826](https://github.com/Flank/flank/pull/826) Fast fail when using `environment-variables` in a robo test. ([adamfilipow92](https://github.com/adamfilipow92))
+-
 -
 
 ## v20.05.2

--- a/release_notes.md
+++ b/release_notes.md
@@ -17,7 +17,7 @@
 - [#825](https://github.com/Flank/flank/pull/825) Automatically convert -1 in maximum-test-shards to the maximum shard amount. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#833](https://github.com/Flank/flank/pull/833) More error messages improvements. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - 
-- [#826](https://github.com/Flank/flank/pull/826) Fast fail when using `environment-variables` in a robo test. ([adamfilipow92](https://github.com/adamfilipow92))
+- [#826](https://github.com/Flank/flank/pull/826) Omit `environment-variables` for robo test executions instead of throwing exception. ([adamfilipow92](https://github.com/adamfilipow92))
 -
 -
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,7 +16,6 @@
 - [#819](https://github.com/Flank/flank/pull/819) Display matrix results in a table format. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#825](https://github.com/Flank/flank/pull/825) Automatically convert -1 in maximum-test-shards to the maximum shard amount. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#833](https://github.com/Flank/flank/pull/833) More error messages improvements. ([piotradamczyk5](https://github.com/piotradamczyk5))
-- 
 - [#826](https://github.com/Flank/flank/pull/826) Omit `environment-variables` for robo test executions instead of throwing exception. ([adamfilipow92](https://github.com/adamfilipow92))
 -
 -

--- a/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
@@ -3,6 +3,7 @@ package ftl.gc
 import com.google.api.services.testing.Testing
 import com.google.api.services.testing.model.Account
 import com.google.api.services.testing.model.AndroidDeviceList
+import com.google.api.services.testing.model.AndroidInstrumentationTest
 import com.google.api.services.testing.model.ClientInfo
 import com.google.api.services.testing.model.EnvironmentMatrix
 import com.google.api.services.testing.model.EnvironmentVariable
@@ -62,7 +63,7 @@ object GcAndroidTestMatrix {
             .setAdditionalApks(additionalApkGcsPaths.mapGcsPathsToApks())
             .setFilesToPush(otherFiles.mapToDeviceFiles())
 
-        if (args.environmentVariables.isNotEmpty()) {
+        if (args.environmentVariables.isNotEmpty() && androidTestConfig is AndroidTestConfig.Instrumentation) {
             testSetup.environmentVariables =
                 args.environmentVariables.map { it.toEnvironmentVariable() }
         }

--- a/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
@@ -5,7 +5,7 @@ import com.google.api.services.testing.model.Account
 import com.google.api.services.testing.model.AndroidDeviceList
 import com.google.api.services.testing.model.ClientInfo
 import com.google.api.services.testing.model.EnvironmentMatrix
-import com.google.api.services.testing.model.EnvironmentVariable
+import ftl.gc.android.setEnvironmentVariables
 import com.google.api.services.testing.model.GoogleAuto
 import com.google.api.services.testing.model.GoogleCloudStorage
 import com.google.api.services.testing.model.ResultStorage
@@ -13,7 +13,6 @@ import com.google.api.services.testing.model.TestMatrix
 import com.google.api.services.testing.model.TestSetup
 import com.google.api.services.testing.model.TestSpecification
 import com.google.api.services.testing.model.ToolResultsHistory
-import com.google.common.annotations.VisibleForTesting
 import ftl.args.AndroidArgs
 import ftl.gc.android.mapGcsPathsToApks
 import ftl.gc.android.mapToDeviceFiles
@@ -23,20 +22,6 @@ import ftl.util.join
 import ftl.util.timeoutToSeconds
 
 object GcAndroidTestMatrix {
-
-    private fun Map.Entry<String, String>.toEnvironmentVariable() = EnvironmentVariable().apply {
-        key = this@toEnvironmentVariable.key
-        value = this@toEnvironmentVariable.value
-    }
-
-    @VisibleForTesting
-    internal fun TestSetup.setEnvironmentVariables(args: AndroidArgs, testConfig: AndroidTestConfig) = this.apply {
-        environmentVariables = if (args.environmentVariables.isNotEmpty() && testConfig is AndroidTestConfig.Instrumentation) {
-            args.environmentVariables.map { it.toEnvironmentVariable() }
-        } else {
-            emptyList()
-        }
-    }
 
     @Suppress("LongParameterList")
     fun build(

--- a/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
@@ -3,7 +3,6 @@ package ftl.gc
 import com.google.api.services.testing.Testing
 import com.google.api.services.testing.model.Account
 import com.google.api.services.testing.model.AndroidDeviceList
-import com.google.api.services.testing.model.AndroidInstrumentationTest
 import com.google.api.services.testing.model.ClientInfo
 import com.google.api.services.testing.model.EnvironmentMatrix
 import com.google.api.services.testing.model.EnvironmentVariable
@@ -14,6 +13,7 @@ import com.google.api.services.testing.model.TestMatrix
 import com.google.api.services.testing.model.TestSetup
 import com.google.api.services.testing.model.TestSpecification
 import com.google.api.services.testing.model.ToolResultsHistory
+import com.google.common.annotations.VisibleForTesting
 import ftl.args.AndroidArgs
 import ftl.gc.android.mapGcsPathsToApks
 import ftl.gc.android.mapToDeviceFiles
@@ -27,6 +27,15 @@ object GcAndroidTestMatrix {
     private fun Map.Entry<String, String>.toEnvironmentVariable() = EnvironmentVariable().apply {
         key = this@toEnvironmentVariable.key
         value = this@toEnvironmentVariable.value
+    }
+
+    @VisibleForTesting
+    internal fun TestSetup.setEnvironmentVariables(args: AndroidArgs, testConfig: AndroidTestConfig) = this.apply {
+        environmentVariables = if (args.environmentVariables.isNotEmpty() && testConfig is AndroidTestConfig.Instrumentation) {
+            args.environmentVariables.map { it.toEnvironmentVariable() }
+        } else {
+            emptyList()
+        }
     }
 
     @Suppress("LongParameterList")
@@ -62,11 +71,7 @@ object GcAndroidTestMatrix {
             .setDirectoriesToPull(args.directoriesToPull)
             .setAdditionalApks(additionalApkGcsPaths.mapGcsPathsToApks())
             .setFilesToPush(otherFiles.mapToDeviceFiles())
-
-        if (args.environmentVariables.isNotEmpty() && androidTestConfig is AndroidTestConfig.Instrumentation) {
-            testSetup.environmentVariables =
-                args.environmentVariables.map { it.toEnvironmentVariable() }
-        }
+            .setEnvironmentVariables(args, androidTestConfig)
 
         val testTimeoutSeconds = timeoutToSeconds(args.testTimeout)
 

--- a/test_runner/src/main/kotlin/ftl/gc/android/SetupEnvironmentVariables.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/android/SetupEnvironmentVariables.kt
@@ -14,7 +14,6 @@ internal fun TestSetup.setEnvironmentVariables(args: AndroidArgs, testConfig: An
     }
 }
 
-
 private fun Map.Entry<String, String>.toEnvironmentVariable() = EnvironmentVariable().apply {
     key = this@toEnvironmentVariable.key
     value = this@toEnvironmentVariable.value

--- a/test_runner/src/main/kotlin/ftl/gc/android/SetupEnvironmentVariables.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/android/SetupEnvironmentVariables.kt
@@ -1,0 +1,21 @@
+package ftl.gc.android
+
+import com.google.api.services.testing.model.EnvironmentVariable
+import com.google.api.services.testing.model.TestSetup
+import com.google.common.annotations.VisibleForTesting
+import ftl.args.AndroidArgs
+import ftl.run.platform.android.AndroidTestConfig
+
+@VisibleForTesting
+internal fun TestSetup.setEnvironmentVariables(args: AndroidArgs, testConfig: AndroidTestConfig) = this.apply {
+    environmentVariables = when (testConfig) {
+        is AndroidTestConfig.Instrumentation -> args.environmentVariables.map { it.toEnvironmentVariable() }
+        is AndroidTestConfig.Robo -> emptyList()
+    }
+}
+
+
+private fun Map.Entry<String, String>.toEnvironmentVariable() = EnvironmentVariable().apply {
+    key = this@toEnvironmentVariable.key
+    value = this@toEnvironmentVariable.value
+}

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -11,7 +11,7 @@ fun main() {
     val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
         ?: "YOUR PROJECT ID"
     val quantity = "single"
-    val type = "success-disable-sharding"
+    val type = "robo"
 
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -10,8 +10,8 @@ fun main() {
     // run "gradle check" to generate required fixtures
     val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
         ?: "YOUR PROJECT ID"
-    val quantity = "single"
-    val type = "robo"
+    val quantity = "multiple"
+    val type = "mixed"
 
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -454,6 +454,7 @@ AndroidArgs
         gcloud:
           app: $appApk
           test: $testErrorApk
+
         flank:
           max-test-shards: -1
       """
@@ -668,7 +669,7 @@ AndroidArgs
 
     @Test
     fun `cli numUniformShards`() {
-        val expected = 50
+        val expected = AVAILABLE_SHARD_COUNT_RANGE.last
         val cli = AndroidRunCommand()
         CommandLine(cli).parseArgs("--num-uniform-shards=$expected")
 
@@ -689,9 +690,9 @@ AndroidArgs
         gcloud:
           app: $appApk
           test: $testApk
-          num-uniform-shards: 50
+          num-uniform-shards: ${AVAILABLE_SHARD_COUNT_RANGE.last}
         flank:
-          max-test-shards: 50
+          max-test-shards: ${AVAILABLE_SHARD_COUNT_RANGE.last}
       """
         AndroidArgs.load(yaml)
     }
@@ -1344,7 +1345,7 @@ AndroidArgs
             "  num-flaky-test-attempts: 3",
             """
             flank:
-              max-test-shards: 50
+              max-test-shards: ${AVAILABLE_SHARD_COUNT_RANGE.last}
             """.trimIndent(),
             """
             flank:

--- a/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-multiple-mixed.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-multiple-mixed.yml
@@ -2,7 +2,10 @@ gcloud:
   app: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
   robo-script: ./src/test/kotlin/ftl/fixtures/test_app_cases/MainActivity_robo_script.json
   num-flaky-test-attempts: 2
-
+  environment-variables:
+    coverage: true
+    coverageFilePath: /sdcard/
+    clearPackageData: true
 flank:
   disable-sharding: false
   max-test-shards: 2

--- a/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-robo.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-robo.yml
@@ -5,3 +5,7 @@ gcloud:
     "click:button3": ""
     "ignore:button1": ""
     "ignore:button2": ""
+  environment-variables:
+    coverage: true
+    coverageFilePath: /sdcard/
+    clearPackageData: true

--- a/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-robo.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-robo.yml
@@ -1,10 +1,6 @@
 gcloud:
   app: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
-#  robo-script: ./src/test/kotlin/ftl/fixtures/test_app_cases/MainActivity_robo_script.json
-  robo-directives:
-    "click:button3": ""
-    "ignore:button1": ""
-    "ignore:button2": ""
+  robo-script: ./src/test/kotlin/ftl/fixtures/test_app_cases/MainActivity_robo_script.json
   environment-variables:
     coverage: true
     coverageFilePath: /sdcard/

--- a/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
@@ -3,7 +3,7 @@ package ftl.gc
 import com.google.api.services.testing.model.AndroidDeviceList
 import com.google.api.services.testing.model.TestSetup
 import ftl.args.AndroidArgs
-import ftl.gc.GcAndroidTestMatrix.setEnvironmentVariables
+import ftl.gc.android.setEnvironmentVariables
 import ftl.gc.GcToolResults.createToolResultsHistory
 import ftl.run.platform.android.AndroidTestConfig
 import ftl.test.util.FlankTestRunner

--- a/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
@@ -1,7 +1,9 @@
 package ftl.gc
 
 import com.google.api.services.testing.model.AndroidDeviceList
+import com.google.api.services.testing.model.TestSetup
 import ftl.args.AndroidArgs
+import ftl.gc.GcAndroidTestMatrix.setEnvironmentVariables
 import ftl.gc.GcToolResults.createToolResultsHistory
 import ftl.run.platform.android.AndroidTestConfig
 import ftl.test.util.FlankTestRunner
@@ -9,11 +11,15 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.junit.After
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.StringReader
 
 @RunWith(FlankTestRunner::class)
 class GcAndroidTestMatrixTest {
+    private val appApk = "../test_app/apks/app-debug.apk"
+    private val testApk = "../test_app/apks/app-debug-androidTest.apk"
 
     @After
     fun tearDown() = unmockkAll()
@@ -92,5 +98,64 @@ class GcAndroidTestMatrixTest {
             toolResultsHistory = createToolResultsHistory(androidArgs),
             additionalApkGcsPaths = emptyList()
         )
+    }
+
+    @Test
+    fun `should not set env variables on robo test`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          robo-directives:
+            "click:button3": ""
+            "ignore:button1": ""
+            "ignore:button2": ""
+          environment-variables:
+            coverage: true
+            coverageFilePath: /sdcard/
+            clearPackageData: true
+        """.trimIndent()
+        val androidArgs = AndroidArgs.load(StringReader(yaml), null)
+
+        val testSetup = TestSetup().setEnvironmentVariables(
+            androidArgs, AndroidTestConfig.Robo(
+                appApkGcsPath = "",
+                flankRoboDirectives = emptyList(),
+                roboScriptGcsPath = ""
+            )
+        )
+        assertTrue(testSetup.environmentVariables.isEmpty())
+    }
+
+    @Test
+    fun `should set env variables on instrumental test`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          robo-directives:
+            "click:button3": ""
+            "ignore:button1": ""
+            "ignore:button2": ""
+          environment-variables:
+            coverage: true
+            coverageFilePath: /sdcard/
+            clearPackageData: true
+        """.trimIndent()
+        val androidArgs = AndroidArgs.load(StringReader(yaml), null)
+
+        val testSetup = TestSetup().setEnvironmentVariables(
+            androidArgs, AndroidTestConfig.Instrumentation(
+                appApkGcsPath = "",
+                testApkGcsPath = "",
+                testShards = emptyList(),
+                orchestratorOption = null,
+                numUniformShards = null,
+                disableSharding = false,
+                testRunnerClass = "",
+                keepTestTargetsEmpty = false
+            )
+        )
+        assertTrue(testSetup.environmentVariables.isNotEmpty())
     }
 }


### PR DESCRIPTION
Fixes #816

## Checklist

- [X] Unit tested
- [X] release_notes.md updated
