### PR TITLE
Add dependency check plugin

### DIFF
--- a/test_runner/buildSrc/src/main/kotlin/Deps.kt
+++ b/test_runner/buildSrc/src/main/kotlin/Deps.kt
@@ -75,11 +75,14 @@ object Versions {
     // https://github.com/mockk/mockk
     const val MOCKK = "1.9.3"
 
-    //https://commons.apache.org/proper/commons-text/
+    // https://commons.apache.org/proper/commons-text/
     const val COMMON_TEXT = "1.8"
 
-    //https://github.com/fusesource/jansi/releases
+    // https://github.com/fusesource/jansi/releases
     const val JANSI = "1.18"
+
+    // https://github.com/ben-manes/gradle-versions-plugin/releases
+    const val BEN_MANES = "0.28.0"
 }
 
 object Libs {


### PR DESCRIPTION
Add simple dependency check plugin [gradle-versions-plugin](https://github.com/ben-manes/gradle-versions-plugin)
It adds `gradle dependencyUpdates` task which produces dependencies version report. With given configuration, only latest stable versions are proposed as update candidate

![Screenshot 2020-06-01 at 19 22 21](https://user-images.githubusercontent.com/32893017/83436138-a4056a00-a43d-11ea-8892-1902513c5588.png)
