### PR TITLE
Handle duplicated apks names

### DIFF
--- a/test_runner/src/main/kotlin/ftl/gc/GcApkFileNameGenerator.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcApkFileNameGenerator.kt
@@ -1,0 +1,6 @@
+package ftl.gc
+
+import com.google.common.annotations.VisibleForTesting
+
+@VisibleForTesting
+internal fun generateApkFileName(actualFileName: String, counter: Int? = null) = actualFileName.run { counter?.let { replace(".apk", "_$counter.apk") } ?: this }

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -5,6 +5,7 @@ import com.google.cloud.storage.BlobInfo
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.StorageOptions
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
+import com.google.common.annotations.VisibleForTesting
 import ftl.args.IArgs
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
@@ -22,7 +23,7 @@ import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 
 object GcStorage {
-
+    @VisibleForTesting
     private val uploadCache: ConcurrentHashMap<String, String> = ConcurrentHashMap()
     private val downloadCache: ConcurrentHashMap<String, String> = ConcurrentHashMap()
 
@@ -113,7 +114,7 @@ object GcStorage {
 
     private fun upload(file: String, fileBytes: ByteArray, rootGcsBucket: String, runGcsPath: String, counter: Int? = null): String {
         val filePath = Paths.get(file)
-        val fileName = filePath.fileName.toString().run { counter?.let { replace(".apk", "_$counter.apk") } ?: this }
+        val fileName = generateApkFileName(filePath.fileName.toString(), counter)
         val absolutePath = filePath.toAbsolutePath().toString()
         return uploadCache[absolutePath] ?: uploadCache.computeIfAbsent(absolutePath) {
             val gcsFilePath = GCS_PREFIX + join(rootGcsBucket, runGcsPath, fileName)

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -47,14 +47,15 @@ object GcStorage {
         }
     }
 
-    fun upload(file: String, rootGcsBucket: String, runGcsPath: String): String {
+    fun upload(file: String, rootGcsBucket: String, runGcsPath: String, counter: Int? = null): String {
         if (file.startsWith(GCS_PREFIX)) return file
 
         return upload(
             file = file,
             fileBytes = Files.readAllBytes(Paths.get(file)),
             rootGcsBucket = rootGcsBucket,
-            runGcsPath = runGcsPath
+            runGcsPath = runGcsPath,
+            counter = counter
         )
     }
 
@@ -110,9 +111,11 @@ object GcStorage {
         return null
     }
 
-    private fun upload(file: String, fileBytes: ByteArray, rootGcsBucket: String, runGcsPath: String): String {
-        val fileName = Paths.get(file).fileName.toString()
-        return uploadCache[fileName] ?: uploadCache.computeIfAbsent(fileName) {
+    private fun upload(file: String, fileBytes: ByteArray, rootGcsBucket: String, runGcsPath: String, counter: Int? = null): String {
+        val filePath = Paths.get(file)
+        val fileName = filePath.fileName.toString().run { counter?.let { replace(".apk", "_$counter.apk") } ?: this }
+        val absolutePath = filePath.toAbsolutePath().toString()
+        return uploadCache[absolutePath] ?: uploadCache.computeIfAbsent(absolutePath) {
             val gcsFilePath = GCS_PREFIX + join(rootGcsBucket, runGcsPath, fileName)
 
             // 404 Not Found error when rootGcsBucket does not exist

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -5,7 +5,6 @@ import com.google.cloud.storage.BlobInfo
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.StorageOptions
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
-import com.google.common.annotations.VisibleForTesting
 import ftl.args.IArgs
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
@@ -23,7 +22,7 @@ import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
 
 object GcStorage {
-    @VisibleForTesting
+
     private val uploadCache: ConcurrentHashMap<String, String> = ConcurrentHashMap()
     private val downloadCache: ConcurrentHashMap<String, String> = ConcurrentHashMap()
 

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -11,8 +11,11 @@ import ftl.run.model.AndroidTestContext
 import ftl.run.model.InstrumentationTestContext
 import ftl.run.model.RoboTestContext
 import ftl.run.model.TestResult
-import ftl.run.platform.android.*
+import ftl.run.platform.android.testApkCounter
+import ftl.run.platform.android.upload
 import ftl.run.platform.android.createAndroidTestConfig
+import ftl.run.platform.android.createAndroidTestContexts
+import ftl.run.platform.android.uploadAdditionalApks
 import ftl.run.platform.android.uploadOtherFiles
 import ftl.run.platform.common.afterRunTests
 import ftl.run.platform.common.beforeRunMessage
@@ -82,5 +85,5 @@ private val AndroidTestContext.index
         is InstrumentationTestContext -> getAppendedNumber(test.gcs) ?: testApkCounter.getAndIncrement()
         is RoboTestContext -> "robo_${roboCounter.getAndIncrement()}"
     }
-private inline fun getAppendedNumber(gcsPath: String) = regex.find(gcsPath)?.let { it.groups[1]?.value }
+private fun getAppendedNumber(gcsPath: String) = regex.find(gcsPath)?.let { it.groups[1]?.value }
 private val roboCounter = AtomicInteger(0)

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -78,12 +78,12 @@ private suspend fun executeAndroidTestMatrix(
     }
 }
 
-private val regex = ".*_(\\d)\\.apk".toRegex()
+private val apkFileRegex = ".*_(\\d)\\.apk".toRegex()
 
 private val AndroidTestContext.index
     get() = when (this) {
         is InstrumentationTestContext -> getAppendedNumber(test.gcs) ?: testApkCounter.getAndIncrement()
         is RoboTestContext -> "robo_${roboCounter.getAndIncrement()}"
     }
-private fun getAppendedNumber(gcsPath: String) = regex.find(gcsPath)?.let { it.groups[1]?.value }
+private fun getAppendedNumber(gcsPath: String) = apkFileRegex.find(gcsPath)?.let { it.groups[1]?.value }
 private val roboCounter = AtomicInteger(0)

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/UploadApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/UploadApks.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Upload an APK pair if the path given is local
@@ -27,7 +28,7 @@ private fun AndroidTestContext.upload(rootGcsBucket: String, runGcsPath: String)
 
 private fun InstrumentationTestContext.upload(rootGcsBucket: String, runGcsPath: String) = copy(
     app = app.uploadIfNeeded(rootGcsBucket, runGcsPath),
-    test = test.uploadIfNeeded(rootGcsBucket, runGcsPath)
+    test = test.uploadIfNeeded(rootGcsBucket, runGcsPath, testApkCounter.getAndIncrement())
 )
 
 private fun RoboTestContext.upload(rootGcsBucket: String, runGcsPath: String) = copy(
@@ -40,3 +41,5 @@ suspend fun AndroidArgs.uploadAdditionalApks(runGcsPath: String) = coroutineScop
         async { it.asFileReference().uploadIfNeeded(resultsBucket, runGcsPath).gcs }
     }.awaitAll()
 }
+
+private val testApkCounter = AtomicInteger(0)

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/UploadApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/UploadApks.kt
@@ -42,4 +42,4 @@ suspend fun AndroidArgs.uploadAdditionalApks(runGcsPath: String) = coroutineScop
     }.awaitAll()
 }
 
-private val testApkCounter = AtomicInteger(0)
+val testApkCounter = AtomicInteger(0)

--- a/test_runner/src/main/kotlin/ftl/util/FileReference.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FileReference.kt
@@ -26,6 +26,6 @@ fun FileReference.downloadIfNeeded() =
     if (local.isNotBlank()) this
     else copy(local = GcStorage.download(gcs))
 
-fun FileReference.uploadIfNeeded(rootGcsBucket: String, runGcsPath: String) =
+fun FileReference.uploadIfNeeded(rootGcsBucket: String, runGcsPath: String, counter: Int? = null) =
     if (gcs.isNotBlank()) this
-    else copy(gcs = GcStorage.upload(local, rootGcsBucket, runGcsPath))
+    else copy(gcs = GcStorage.upload(local, rootGcsBucket, runGcsPath, counter))

--- a/test_runner/src/test/kotlin/ftl/gc/GcApkFileNameGeneratorTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcApkFileNameGeneratorTest.kt
@@ -1,0 +1,22 @@
+package ftl.gc
+
+import org.junit.Assert
+import org.junit.Test
+
+class GcApkFileNameGeneratorTest {
+    private val apkName = "app-debug.apk"
+
+    @Test
+    fun `apk name should't changed if counter is not set`() {
+        val actual = generateApkFileName(apkName)
+        Assert.assertEquals(apkName, actual)
+    }
+
+    @Test
+    fun `apk name should contains file name with counter value`() {
+        val counterValue = 1
+        val actual = generateApkFileName(apkName, counterValue)
+        val expected = "app-debug_$counterValue.apk"
+        Assert.assertEquals(expected, actual)
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/run/DumpShardsKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/DumpShardsKtTest.kt
@@ -22,7 +22,9 @@ class DumpShardsKtTest {
     "test": "$path/src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk",
     "shards": {
       "shard-0": [
-        "class com.example.test_app.InstrumentedTest#test"
+        "class com.example.test_app.InstrumentedTest#test",
+        "class com.example.test_app.InstrumentedTest#ignoredTest",
+        "class com.example.test_app.InstrumentedTest#ignoredTest2"
       ]
     }
   },
@@ -34,7 +36,11 @@ class DumpShardsKtTest {
         "class com.example.test_app.InstrumentedTest#test1",
         "class com.example.test_app.InstrumentedTest#test2",
         "class com.example.test_app.ParameterizedTest",
-        "class com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed"
+        "class com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed",
+        "class com.example.test_app.InstrumentedTest#ignoredTest1",
+        "class com.example.test_app.InstrumentedTest#ignoredTest2",
+        "class com.example.test_app.bar.BarInstrumentedTest#ignoredTestBar",
+        "class com.example.test_app.foo.FooInstrumentedTest#ignoredTestFoo"
       ],
       "shard-1": [
         "class com.example.test_app.InstrumentedTest#test0",

--- a/test_runner/src/test/kotlin/ftl/run/platform/RunAndroidTestsKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/RunAndroidTestsKtTest.kt
@@ -19,8 +19,8 @@ class RunAndroidTestsKtTest {
         val expected = should<MatrixMap> {
             map.size == 3
         } to listOf<List<String>>(
-            should { size == 1 },
-            should { size == 4 },
+            should { size == 3 },
+            should { size == 8 },
             should { size == 5 }
         )
 

--- a/test_runner/src/test/kotlin/ftl/run/platform/android/CreateAndroidTestContextKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/android/CreateAndroidTestContextKtTest.kt
@@ -24,14 +24,14 @@ class CreateAndroidTestContextKtTest {
                 app = should { local.endsWith("app-debug.apk") },
                 test = should { local.endsWith("app-single-success-debug-androidTest.apk") },
                 shards = listOf(
-                    should { size == 1 }
+                    should { size == 3 }
                 )
             ),
             InstrumentationTestContext(
                 app = should { local.endsWith("app-debug.apk") },
                 test = should { local.endsWith("app-multiple-flaky-debug-androidTest.apk") },
                 shards = listOf(
-                    should { size == 4 && contains("class com.example.test_app.ParameterizedTest") },
+                    should { size == 8 && contains("class com.example.test_app.ParameterizedTest") },
                     should { size == 5 }
                 )
             )


### PR DESCRIPTION
Potential fix for #818 

## Test Plan
> How do we know the code works?

All tests are correctly launched when additional test apks have the same name. Appended numbers to test apks names correspond with `matrix_[number]`.
Robo test matrix directory has new name: `matrix_robo_[number]`.
Instrumentation and robo matrices have separated  counters.
![Screenshot 2020-06-17 at 10 10 04](https://user-images.githubusercontent.com/32893017/84872899-bf4db780-b082-11ea-8507-30a52477e6d7.png)


_flank.yml_
```
gcloud:
  app: ~/duplicated_names/app-debug.apk
  test: ~/duplicated_names/dir1/app-multiple-success-debug-androidTest.apk
  use-orchestrator: false
flank:
  disable-sharding: false
  max-test-shards: 3
  additional-app-test-apks:
    - test: ~/duplicated_names/dir2/app-multiple-success-debug-androidTest.apk
    - test: ~/duplicated_names/dir3/app-multiple-success-debug-androidTest.apk
    - test: ~/duplicated_names/dir4/app-multiple-success-debug-androidTest.apk
```
###  ++++ Before fix ++++
Bucket (note only one test apk):
[gcs bucket](https://console.cloud.google.com/storage/browser/test-lab-v9cn46bb990nx-kz69ymd4nm9aq/2020-06-17_06-32-03.457000_Ibff)
![Screenshot 2020-06-17 at 08 55 26](https://user-images.githubusercontent.com/32893017/84865335-54977e80-b078-11ea-808d-c4108e1ac6e9.png)

Matrices:
[matrix-3czoyl2reb5zb](https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/7425787307181874986) -- SUCCESS
[matrix-1syf6utonh6av](https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/8692790499129874612) -- FAILED
[matrix-1ih4gd2jimkhi](https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/6343125104001163339) -- FAILED
[matrix-mgl0d9m5f0oia](https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/5807119982707091928) -- FAILED
![Screenshot 2020-06-17 at 08 38 18](https://user-images.githubusercontent.com/32893017/84863945-23b64a00-b076-11ea-9d1c-8cff82e85959.png)
![Screenshot 2020-06-17 at 08 38 08](https://user-images.githubusercontent.com/32893017/84863961-2b75ee80-b076-11ea-9560-e3e5f0695a07.png)


### ++++ After fix ++++
Bucket (multiple test apk with suffix `_[number].apk`):
[gcs bucket](https://console.cloud.google.com/storage/browser/test-lab-v9cn46bb990nx-kz69ymd4nm9aq/2020-06-17_06-45-47.954000_nUOO)
![Screenshot 2020-06-17 at 08 54 03](https://user-images.githubusercontent.com/32893017/84865300-42b5db80-b078-11ea-9777-643a997699b9.png)
Matrices:
[matrix-67npvezinaqva](https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/8460887780193410808) -- SUCCESS
[matrix-20mfp8bhyycmh](https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/8129974352956006345) -- SUCCESS
[matrix-3vfuw3av7vxld](https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/6046117458746675257) -- SUCCESS
[matrix-11a8n4gbhe2i0](https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/6421410258116218811) -- SUCCESS
_JUnitResults.xml_
[JUnitReport.zip](https://github.com/Flank/flank/files/4790841/JUnitReport.zip)

## Checklist

- [x] Documented
- [ ] Unit tested
- [ ] release_notes.md updated
