### PR TITLE
Removed duplicate run-timeout option from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,6 @@ flank:
   ## Default: false
   # keep-file-path: false
 
-  ## The max time this test run can execute before it is cancelled (default: unlimited).
-  # run-timeout: 60m
-
   ## Terminate with exit code 0 when there are failed tests.
   ## Useful for Fladle and other gradle plugins that don't expect the process to have a non-zero exit code.
   ## The JUnit XML is used to determine failure. (default: false)


### PR DESCRIPTION
run-timeout mentioned 2 times in README with configuration example
