### PR TITLE
#850 fix printing all matrix links

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,7 @@
 - [#868](https://github.com/Flank/flank/pull/868) Restored weblinks to all test results, not just failures. ([rainnapper](https://github.com/rainnapper))
 - [#828](https://github.com/Flank/flank/pull/828) Store test results in gcloud bucket. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#865](https://github.com/Flank/flank/pull/865) Flank needs to respect the timeout value as that's a cap for billing purposes. ([adamfilipow92](https://github.com/adamfilipow92), [pawelpasterz](https://github.com/pawelpasterz))
+- [#866](https://github.com/Flank/flank/pull/866) Fix printing all matrix links. ([piotradamczyk5](https://github.com/piotradamczyk5))
 -
 -
 -

--- a/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
@@ -1,6 +1,5 @@
 package ftl.reports
 
-import com.google.api.services.testing.model.TestMatrix
 import ftl.args.IArgs
 import ftl.config.FtlConstants.indent
 import ftl.gc.GcStorage

--- a/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
@@ -58,13 +58,14 @@ object MatrixResultsReport : IReport {
         }
     }
 
-    private fun Collection<SavedMatrix>.printMatricesLinks(writer: StringWriter) {
-        filter { it.failed() }
-            .takeIf { it.isNotEmpty() }
-            ?.also { writer.println("More details are available at:") }
-            ?.map { it.webLinkWithoutExecutionDetails }
-            ?.forEach { writer.println(it) }
-    }
+private fun Collection<SavedMatrix>.printMatricesLinks(writer: StringWriter) = this
+        .filter { it.failed() }
+        .takeIf { it.isNotEmpty() }
+        ?.run {
+            writer.println("More details are available at:")
+            forEach { writer.println(it.webLinkWithoutExecutionDetails) }
+            writer.println()
+        }
 
     override fun run(matrices: MatrixMap, result: JUnitTestResult?, printToStdout: Boolean, args: IArgs) {
         val output = generate(matrices)

--- a/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
@@ -59,8 +59,14 @@ object MatrixResultsReport : IReport {
     }
 
     private fun Collection<SavedMatrix>.printMatricesLinks(writer: StringWriter) {
-        writer.println("More details are available at:")
-        map { it.webLinkWithoutExecutionDetails }.forEach { writer.println(it) }
+        filter { it.failed() }
+            .takeIf { it.isNotEmpty() }
+            ?.let { failedMatrices ->
+                writer.println("More details are available at:")
+                failedMatrices
+                    .map { it.webLinkWithoutExecutionDetails }
+                    .forEach { writer.println(it) }
+            }
     }
 
     override fun run(matrices: MatrixMap, result: JUnitTestResult?, printToStdout: Boolean, args: IArgs) {

--- a/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
@@ -61,12 +61,9 @@ object MatrixResultsReport : IReport {
     private fun Collection<SavedMatrix>.printMatricesLinks(writer: StringWriter) {
         filter { it.failed() }
             .takeIf { it.isNotEmpty() }
-            ?.let { failedMatrices ->
-                writer.println("More details are available at:")
-                failedMatrices
-                    .map { it.webLinkWithoutExecutionDetails }
-                    .forEach { writer.println(it) }
-            }
+            ?.also { writer.println("More details are available at:") }
+            ?.map { it.webLinkWithoutExecutionDetails }
+            ?.forEach { writer.println(it) }
     }
 
     override fun run(matrices: MatrixMap, result: JUnitTestResult?, printToStdout: Boolean, args: IArgs) {

--- a/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
@@ -1,9 +1,11 @@
 package ftl.reports
 
+import com.google.api.services.testing.model.TestMatrix
 import ftl.args.IArgs
 import ftl.config.FtlConstants.indent
 import ftl.gc.GcStorage
 import ftl.json.MatrixMap
+import ftl.json.SavedMatrix
 import ftl.reports.util.IReport
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.util.asPrintableTable
@@ -48,12 +50,18 @@ object MatrixResultsReport : IReport {
             }
 
             if (matrices.map.isNotEmpty()) {
-                writer.println("More details are available at [${matrices.map.values.first().webLinkWithoutExecutionDetails}]")
-                writer.println(matrices.map.values.toList().asPrintableTable())
+                val savedMatrices = matrices.map.values
+                writer.println(savedMatrices.toList().asPrintableTable())
+                savedMatrices.printMatricesLinks(writer)
             }
 
             return writer.toString()
         }
+    }
+
+    private fun Collection<SavedMatrix>.printMatricesLinks(writer: StringWriter) {
+        writer.println("More details are available at:")
+        map { it.webLinkWithoutExecutionDetails }.forEach { writer.println(it) }
     }
 
     override fun run(matrices: MatrixMap, result: JUnitTestResult?, printToStdout: Boolean, args: IArgs) {


### PR DESCRIPTION
Fixes #850 

## Test Plan
> How do we know the code works?

All matrices failed links are printed in summary below the summary table.
Do not print any data if there are not present failed links.

## Checklist

- [x] Unit tested
- [x] release_notes.md updated
