### PR TITLE
Print only skipped/failed tests

### DIFF
--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -161,7 +161,7 @@ repositories {
 // Avoids having to read the HTML report
 tasks.withType<Test> {
     testLogging {
-        events("passed", "skipped", "failed")
+        events("skipped", "failed")
         exceptionFormat = TestExceptionFormat.FULL
     }
 }


### PR DESCRIPTION
Only failed/skipped tests are printed to std out during gradle task run
