### PR TITLE
Update  gradle wrapper to 6.5 and github actions to cache@v2

### DIFF
--- a/.github/workflows/macos_workflow.yml
+++ b/.github/workflows/macos_workflow.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}

--- a/.github/workflows/macos_workflow.yml
+++ b/.github/workflows/macos_workflow.yml
@@ -15,7 +15,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
     - uses: actions/cache@v2
       with:
         path: ~/.gradle/caches

--- a/.github/workflows/macos_workflow.yml
+++ b/.github/workflows/macos_workflow.yml
@@ -19,9 +19,9 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        key: ${{ runner.os }}-2-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
-          ${{ runner.os }}-gradle-
+          ${{ runner.os }}-2-gradle-
 
     - name: Gradle check
       uses: eskatos/gradle-command-action@v1

--- a/test_runner/gradle/wrapper/gradle-wrapper.properties
+++ b/test_runner/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
There is some problem with the current macOS workflow builds, so in order to fix this gradlew wrapper and cache should be updated

## Test Plan
> How do we know the code works?

Update  gradle wrapper to 6.5 and github actions to cache@v2



