### PR TITLE
Enhance permission denied exception logs

### DIFF
--- a/docs/permissions_denied_behavior.md
+++ b/docs/permissions_denied_behavior.md
@@ -28,6 +28,8 @@ Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 40
 
 ```
 
+You can reproduce it by set PROJECT_ID to project where your current firebase account doesn't have permission.
+
 ## 2. Project not found (404)
 
 When project not found on firebase Flank should return message like:
@@ -49,5 +51,7 @@ Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 40
 }
 
 ```
+
+You can reproduce it by set PROJECT_ID to not existing project.
 
 ## 3. On this two cases Flank throws FlankCommonException and exit with code: 1

--- a/docs/permissions_denied_behavior.md
+++ b/docs/permissions_denied_behavior.md
@@ -28,7 +28,7 @@ Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 40
 
 ```
 
-You can reproduce it by set PROJECT_ID to project where your current firebase account doesn't have permission.
+You can reproduce the error by setting PROJECT_ID to a project that the firebase account doesn't have permission to access.
 
 ## 2. Project not found (404)
 

--- a/docs/permissions_denied_behavior.md
+++ b/docs/permissions_denied_behavior.md
@@ -1,0 +1,53 @@
+# Flank permissions denied behavior
+
+Reported on: [Clean flank not authorized error messages #874](https://github.com/Flank/flank/issues/874)
+
+Changed on: [Enhance permission denied exception logs #875](https://github.com/Flank/flank/pull/875)
+
+## 1. User don't have permission to project (403)
+
+When user don't have permission to project Flank should returns message like:
+
+```json
+
+Flank encountered a 403 error when running on project $project_name. Please verify this credential is authorized for the project.
+Consider authentication a with Service Account https://github.com/Flank/flank#authenticate-with-a-service-account
+or with a Google account https://github.com/Flank/flank#authenticate-with-a-google-account
+
+Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
+{
+  "code" : 403,
+  "errors" : [ {
+    "domain" : "global",
+    "message" : "The caller does not have permission",
+    "reason" : "forbidden"
+  } ],
+  "message" : "The caller does not have permission",
+  "status" : "PERMISSION_DENIED"
+}
+
+```
+
+## 2. Project not found (404)
+
+When project not found on firebase Flank should return message like:
+
+```json
+
+Flank was unable to find project $project_name. Please verify the project id.
+
+Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
+{
+  "code" : 404,
+  "errors" : [ {
+    "domain" : "global",
+    "message" : "Project not found: $project_name",
+    "reason" : "notFound"
+  } ],
+  "message" : "Project not found: $project_name",
+  "status" : "NOT_FOUND"
+}
+
+```
+
+## 3. On this two cases Flank throws FlankCommonException and exit with code: 1

--- a/docs/permissions_denied_behavior.md
+++ b/docs/permissions_denied_behavior.md
@@ -52,6 +52,6 @@ Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 40
 
 ```
 
-You can reproduce it by set PROJECT_ID to not existing project.
+You can reproduce the error by setting PROJECT_ID to a project that doesn't exist.
 
 ## 3. On this two cases Flank throws FlankCommonException and exit with code: 1

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,13 +6,8 @@
 - [#865](https://github.com/Flank/flank/pull/865) Flank needs to respect the timeout value as that's a cap for billing purposes. ([adamfilipow92](https://github.com/adamfilipow92), [pawelpasterz](https://github.com/pawelpasterz))
 - [#866](https://github.com/Flank/flank/pull/866) Fix printing all matrix links. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#862](https://github.com/Flank/flank/pull/862) Added printing outcome details. ([piotradamczyk5](https://github.com/piotradamczyk5), [jan-gogo](https://github.com/jan-gogo))
-<<<<<<< HEAD
-- [#876](https://github.com/Flank/flank/pull/876) Added --directories-to-pull validation and avoid making request with empty toolStepResult. ([piotradamczyk5](https://github.com/piotradamczyk5)
+- [#876](https://github.com/Flank/flank/pull/876) Added --directories-to-pull validation and avoid making request with empty toolStepResult. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#875](https://github.com/Flank/flank/pull/875) Enhance permission denied exception logs. ([adamfilipow92](https://github.com/adamfilipow92), [pawelpasterz](https://github.com/pawelpasterz))
--
-=======
-- [#875](https://github.com/Flank/flank/pull/875) Enhance permission denied exception logs. ([adamfilipow92](https://github.com/adamfilipow92), [pawelpasterz](https://github.com/pawelpasterz))
->>>>>>> Update release notes
 -
 
 ## v20.06.2

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,9 +6,13 @@
 - [#865](https://github.com/Flank/flank/pull/865) Flank needs to respect the timeout value as that's a cap for billing purposes. ([adamfilipow92](https://github.com/adamfilipow92), [pawelpasterz](https://github.com/pawelpasterz))
 - [#866](https://github.com/Flank/flank/pull/866) Fix printing all matrix links. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#862](https://github.com/Flank/flank/pull/862) Added printing outcome details. ([piotradamczyk5](https://github.com/piotradamczyk5), [jan-gogo](https://github.com/jan-gogo))
+<<<<<<< HEAD
 - [#876](https://github.com/Flank/flank/pull/876) Added --directories-to-pull validation and avoid making request with empty toolStepResult. ([piotradamczyk5](https://github.com/piotradamczyk5)
 - [#875](https://github.com/Flank/flank/pull/875) Enhance permission denied exception logs. ([adamfilipow92](https://github.com/adamfilipow92), [pawelpasterz](https://github.com/pawelpasterz))
 -
+=======
+- [#875](https://github.com/Flank/flank/pull/875) Enhance permission denied exception logs. ([adamfilipow92](https://github.com/adamfilipow92), [pawelpasterz](https://github.com/pawelpasterz))
+>>>>>>> Update release notes
 -
 
 ## v20.06.2

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,8 @@
 - [#865](https://github.com/Flank/flank/pull/865) Flank needs to respect the timeout value as that's a cap for billing purposes. ([adamfilipow92](https://github.com/adamfilipow92), [pawelpasterz](https://github.com/pawelpasterz))
 - [#866](https://github.com/Flank/flank/pull/866) Fix printing all matrix links. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#862](https://github.com/Flank/flank/pull/862) Added printing outcome details. ([piotradamczyk5](https://github.com/piotradamczyk5), [jan-gogo](https://github.com/jan-gogo))
-- [#876](https://github.com/Flank/flank/pull/876) Added --directories-to-pull validation and avoid making request with empty toolStepResult. ([piotradamczyk5](https://github.com/piotradamczyk5))
+- [#876](https://github.com/Flank/flank/pull/876) Added --directories-to-pull validation and avoid making request with empty toolStepResult. ([piotradamczyk5](https://github.com/piotradamczyk5)
+- [#875](https://github.com/Flank/flank/pull/875) Enhance permission denied exception logs. ([adamfilipow92](https://github.com/adamfilipow92), [pawelpasterz](https://github.com/pawelpasterz))
 -
 -
 
@@ -21,7 +22,7 @@
 
 - [#831](https://github.com/Flank/flank/pull/831) Refactor config entities and arguments. ([jan-gogo](https://github.com/jan-gogo))
 - [#817](https://github.com/Flank/flank/pull/817) Add AndroidTestContext as base data for dump shards & test execution. ([jan-gogo](https://github.com/jan-gogo))
-- [#801](https://github.com/Flank/flank/pull/801) Omit missing app apk if additional-app-test-apks specified. ([jan-gogo](https://github.com/jan-gogo)) 
+- [#801](https://github.com/Flank/flank/pull/801) Omit missing app apk if additional-app-test-apks specified. ([jan-gogo](https://github.com/jan-gogo))
 - [#784](https://github.com/Flank/flank/pull/784) Add output-style option. ([jan-gogo](https://github.com/jan-gogo))
 - [#779](https://github.com/Flank/flank/pull/779) Print retries & display additional info. ([jan-gogo](https://github.com/jan-gogo))
 - [#793](https://github.com/Flank/flank/issues/793) Better error message on file not found. ([adamfilipow92](https://github.com/adamfilipow92))

--- a/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
@@ -120,11 +120,11 @@ object GcToolResults {
 
     fun getDefaultBucket(projectId: String): String? = try {
         service.Projects().initializeSettings(projectId).executeWithRetry().defaultBucket
-    } catch (ex: FTLProjectError) {
+    } catch (ftlProjectError: FTLProjectError) {
         // flank need to rewrap exception with additional info about project
-        when (ex) {
-            is PermissionDenied -> throw FlankCommonException(permissionDeniedErrorMessage(projectId, ex.message))
-            is ProjectNotFound -> throw FlankCommonException(projectNotFoundErrorMessage(projectId, ex.message))
+        when (ftlProjectError) {
+            is PermissionDenied -> throw FlankCommonException(permissionDeniedErrorMessage(projectId, ftlProjectError.message))
+            is ProjectNotFound -> throw FlankCommonException(projectNotFoundErrorMessage(projectId, ftlProjectError.message))
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
@@ -121,7 +121,7 @@ object GcToolResults {
     fun getDefaultBucket(projectId: String): String? = try {
         service.Projects().initializeSettings(projectId).executeWithRetry().defaultBucket
     } catch (ftlProjectError: FTLProjectError) {
-        // flank need to rewrap exception with additional info about project
+        // flank needs to rewrap the exception with additional info about project
         when (ftlProjectError) {
             is PermissionDenied -> throw FlankCommonException(permissionDeniedErrorMessage(projectId, ftlProjectError.message))
             is ProjectNotFound -> throw FlankCommonException(projectNotFoundErrorMessage(projectId, ftlProjectError.message))
@@ -131,14 +131,14 @@ object GcToolResults {
 
 private val permissionDeniedErrorMessage = { projectId: String, message: String? ->
     """Flank encountered a 403 error when running on project $projectId. Please verify this credential is authorized for the project.
-Consider authentication with Service Account https://github.com/Flank/flank#authenticate-with-a-service-account
-or with Google account https://github.com/Flank/flank#authenticate-with-a-google-account
+Consider authentication with a Service Account https://github.com/Flank/flank#authenticate-with-a-service-account
+or with a Google account https://github.com/Flank/flank#authenticate-with-a-google-account
 
 $message""".trimIndent()
 }
 
 private val projectNotFoundErrorMessage = { projectId: String, message: String? ->
-    """Flank was unable to find project $projectId. Please verify project id.
+    """Flank was unable to find project $projectId. Please verify the project id.
 
 $message""".trimIndent()
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
@@ -130,7 +130,7 @@ object GcToolResults {
 }
 
 private val permissionDeniedErrorMessage = { projectId: String, message: String? ->
-    """Flank encountered a 403 error when running on project $projectId. Please verify this credential is authorized for the project.
+    """Flank encountered a 403 error when running on project $projectId. Please verify this credential is authorized for the project and has the required permissions.
 Consider authentication with a Service Account https://github.com/Flank/flank#authenticate-with-a-service-account
 or with a Google account https://github.com/Flank/flank#authenticate-with-a-google-account
 

--- a/test_runner/src/main/kotlin/ftl/http/ExecuteWithRetry.kt
+++ b/test_runner/src/main/kotlin/ftl/http/ExecuteWithRetry.kt
@@ -2,7 +2,6 @@ package ftl.http
 
 import com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest
 import com.google.api.client.http.HttpResponseException
-import com.google.api.client.http.HttpStatusCodes
 import ftl.config.FtlConstants
 import ftl.util.PermissionDenied
 import ftl.util.ProjectNotFound
@@ -10,7 +9,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.IOException
 import kotlin.math.exp
-import kotlin.math.roundToLong
+import kotlin.math.roundToInt
 
 // Only use on calls that don't change state.
 // Fetching status is safe to retry on timeout. Creating a matrix is not.
@@ -18,44 +17,27 @@ fun <T> AbstractGoogleJsonClientRequest<T>.executeWithRetry(): T = withRetry { t
 
 private inline fun <T> withRetry(crossinline block: () -> T): T = runBlocking {
     var lastError: IOException? = null
-    repeat(MAX_TRIES) { repeatCounter ->
-        val executionResult = tryExecuteBlock(block)
-        if (executionResult.isSuccess()) return@runBlocking executionResult.success()
+    repeat(4) {
+        try {
+            return@runBlocking block()
+        } catch (err: IOException) {
+            // We want to send every occurrence of Google API error for statistic purposes
+            // https://github.com/Flank/flank/issues/701
+            FtlConstants.bugsnag?.notify(FlankGoogleApiError(err))
 
-        val error = executionResult.error()
-        // We want to send every occurrence of Google API error for statistic purposes
-        // https://github.com/Flank/flank/issues/701
-        FtlConstants.bugsnag?.notify(FlankGoogleApiError(error))
-        lastError = error
-        if (handleFtlError(error)) return@repeat
-        delay(calculateDelayTime(repeatCounter))
+            lastError = err
+            if (err is HttpResponseException) {
+                // we want to handle some FTL errors with special care
+                when (err.statusCode) {
+                    429 -> return@repeat
+                    403 -> throw PermissionDenied(err)
+                    404 -> throw ProjectNotFound(err)
+                }
+            }
+            delay(exp(it - 1.0).roundToInt().toLong())
+        }
     }
     throw IOException("Request failed", lastError)
 }
-private const val MAX_TRIES = 4
-
-private inline fun <T> tryExecuteBlock(block: () -> T): ExecutionBlockResult<T> = try {
-    ExecutionBlockResult(block(), null)
-} catch (ioError: IOException) {
-    ExecutionBlockResult(null, ioError)
-}
-
-private data class ExecutionBlockResult<T>(private val success: T?, private val error: IOException?) {
-    fun isSuccess() = success != null
-    fun success() = success!!
-    fun error() = error!!
-}
-
-private fun handleFtlError(error: IOException) = (error as? HttpResponseException)?.let {
-    // we want to handle some FTL errors with special care
-    when (it.statusCode) {
-        HttpStatusCodes.STATUS_CODE_FORBIDDEN -> throw PermissionDenied(it)
-        HttpStatusCodes.STATUS_CODE_NOT_FOUND -> throw ProjectNotFound(it)
-        429 -> true
-        else -> false
-    }
-} ?: false
-
-private fun calculateDelayTime(repeatCounter: Int) = exp(repeatCounter - 1.0).roundToLong()
 
 private class FlankGoogleApiError(exception: Throwable) : Error(exception)

--- a/test_runner/src/main/kotlin/ftl/http/ExecuteWithRetry.kt
+++ b/test_runner/src/main/kotlin/ftl/http/ExecuteWithRetry.kt
@@ -18,7 +18,7 @@ fun <T> AbstractGoogleJsonClientRequest<T>.executeWithRetry(): T = withRetry { t
 
 private inline fun <T> withRetry(crossinline block: () -> T): T = runBlocking {
     var lastError: IOException? = null
-    repeat(maxTries) { repeatCounter ->
+    repeat(MAX_TRIES) { repeatCounter ->
         val executionResult = tryExecuteBlock(block)
         if (executionResult.isSuccess()) return@runBlocking executionResult.success()
 
@@ -32,7 +32,7 @@ private inline fun <T> withRetry(crossinline block: () -> T): T = runBlocking {
     }
     throw IOException("Request failed", lastError)
 }
-private const val maxTries = 4
+private const val MAX_TRIES = 4
 
 private inline fun <T> tryExecuteBlock(block: () -> T): ExecutionBlockResult<T> = try {
     ExecutionBlockResult(block(), null)

--- a/test_runner/src/main/kotlin/ftl/http/ExecuteWithRetry.kt
+++ b/test_runner/src/main/kotlin/ftl/http/ExecuteWithRetry.kt
@@ -2,6 +2,7 @@ package ftl.http
 
 import com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest
 import com.google.api.client.http.HttpResponseException
+import com.google.api.client.http.HttpStatusCodes
 import ftl.config.FtlConstants
 import ftl.util.PermissionDenied
 import ftl.util.ProjectNotFound
@@ -9,37 +10,52 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.IOException
 import kotlin.math.exp
-import kotlin.math.roundToInt
+import kotlin.math.roundToLong
 
 // Only use on calls that don't change state.
 // Fetching status is safe to retry on timeout. Creating a matrix is not.
 fun <T> AbstractGoogleJsonClientRequest<T>.executeWithRetry(): T = withRetry { this.execute() }
 
 private inline fun <T> withRetry(crossinline block: () -> T): T = runBlocking {
-    var lastErr: IOException? = null
+    var lastError: IOException? = null
+    repeat(maxTries) { repeatCounter ->
+        val executionResult = tryExecuteBlock(block)
+        if (executionResult.isSuccess()) return@runBlocking executionResult.success()
 
-    repeat(4) {
-        try {
-            return@runBlocking block()
-        } catch (err: IOException) {
-            // We want to send every occurrence of Google API error for statistic purposes
-            // https://github.com/Flank/flank/issues/701
-            FtlConstants.bugsnag?.notify(FlankGoogleApiError(err))
-
-            lastErr = err
-            if (err is HttpResponseException) {
-                // we want to handle some FTL errors with special care
-                when (err.statusCode) {
-                    429 -> return@repeat
-                    403 -> throw PermissionDenied(err)
-                    404 -> throw ProjectNotFound(err)
-                }
-            }
-            delay(exp(it - 1.0).roundToInt().toLong())
-        }
+        val error = executionResult.error()
+        // We want to send every occurrence of Google API error for statistic purposes
+        // https://github.com/Flank/flank/issues/701
+        FtlConstants.bugsnag?.notify(FlankGoogleApiError(error))
+        lastError = error
+        if (handleFtlError(error)) return@repeat
+        delay(calculateDelayTime(repeatCounter))
     }
-
-    throw IOException("Request failed", lastErr)
+    throw IOException("Request failed", lastError)
 }
+private const val maxTries = 4
+
+private inline fun <T> tryExecuteBlock(block: () -> T): ExecutionBlockResult<T> = try {
+    ExecutionBlockResult(block(), null)
+} catch (ioError: IOException) {
+    ExecutionBlockResult(null, ioError)
+}
+
+private data class ExecutionBlockResult<T>(private val success: T?, private val error: IOException?) {
+    fun isSuccess() = success != null
+    fun success() = success!!
+    fun error() = error!!
+}
+
+private fun handleFtlError(error: IOException) = (error as? HttpResponseException)?.let {
+    // we want to handle some FTL errors with special care
+    when (it.statusCode) {
+        HttpStatusCodes.STATUS_CODE_FORBIDDEN -> throw PermissionDenied(it)
+        HttpStatusCodes.STATUS_CODE_NOT_FOUND -> throw ProjectNotFound(it)
+        429 -> true
+        else -> false
+    }
+} ?: false
+
+private fun calculateDelayTime(repeatCounter: Int) = exp(repeatCounter - 1.0).roundToLong()
 
 private class FlankGoogleApiError(exception: Throwable) : Error(exception)

--- a/test_runner/src/main/kotlin/ftl/util/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankException.kt
@@ -60,3 +60,11 @@ class FlankFatalError(message: String) : FlankException(message)
  * @param message [String] message to be printed to [System.err]
  */
 class FlankCommonException(message: String) : FlankException(message)
+
+/**
+ * Custom exception to handle only permission denied errors.
+ * Should be caught and rewrap to FlankCommonException with project id info attached.
+ *
+ * @param message [String] message to be printed
+ */
+class ProjectPermissionDeniedError(message: String) : FlankException(message)

--- a/test_runner/src/main/kotlin/ftl/util/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankException.kt
@@ -1,6 +1,7 @@
 package ftl.util
 
 import ftl.json.SavedMatrix
+import java.io.IOException
 
 /**
  * Base class for all custom flank's exceptions
@@ -62,9 +63,11 @@ class FlankFatalError(message: String) : FlankException(message)
 class FlankCommonException(message: String) : FlankException(message)
 
 /**
- * Custom exception to handle only permission denied errors.
+ * Base class for project related exceptions.
  * Should be caught and rewrap to FlankCommonException with project id info attached.
  *
- * @param message [String] message to be printed
+ * @param exc [IOException]
  */
-class ProjectPermissionDeniedError(message: String) : FlankException(message)
+sealed class FTLProjectError(exc: IOException) : FlankException("Caused by: $exc")
+class PermissionDenied(exc: IOException) : FTLProjectError(exc)
+class ProjectNotFound(exc: IOException) : FTLProjectError(exc)

--- a/test_runner/src/test/kotlin/ftl/gc/GcToolResultsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcToolResultsTest.kt
@@ -1,18 +1,30 @@
 package ftl.gc
 
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.client.http.HttpResponseException
 import com.google.api.services.testing.model.ToolResultsHistory
 import com.google.common.truth.Truth.assertThat
 import ftl.args.AndroidArgs
+import ftl.config.FtlConstants
 import ftl.test.util.FlankTestRunner
+import ftl.test.util.TestHelper.getThrowable
+import ftl.util.FlankCommonException
+import ftl.util.PermissionDenied
+import ftl.util.ProjectNotFound
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.IOException
 
 @RunWith(FlankTestRunner::class)
 class GcToolResultsTest {
+
+    private val projectId = "123"
 
     @After
     fun tearDown() = unmockkAll()
@@ -20,10 +32,10 @@ class GcToolResultsTest {
     @Test
     fun `createToolResultsHistory null succeeds`() {
         val args = mockk<AndroidArgs>()
-        every { args.project } returns "123"
+        every { args.project } returns projectId
         every { args.resultsHistoryName } returns null
 
-        val expected = ToolResultsHistory().setProjectId("123")
+        val expected = ToolResultsHistory().setProjectId(projectId)
 
         assertThat(GcToolResults.createToolResultsHistory(args)).isEqualTo(expected)
     }
@@ -31,13 +43,115 @@ class GcToolResultsTest {
     @Test
     fun `createToolResultsHistory succeeds`() {
         val args = mockk<AndroidArgs>()
-        every { args.project } returns "123"
+        every { args.project } returns projectId
         every { args.resultsHistoryName } returns "custom history"
 
         val expected = ToolResultsHistory()
-            .setProjectId("123")
+            .setProjectId(projectId)
             .setHistoryId("mockId")
 
         assertThat(GcToolResults.createToolResultsHistory(args)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `getDefaultBucket on 403 error should throw exception with specific message`() {
+        val expected = """
+            Flank encountered a 403 error when running on project $projectId. Please verify this credential is authorized for the project.
+            Consider authentication with Service Account https://github.com/Flank/flank#authenticate-with-a-service-account
+            or with Google account https://github.com/Flank/flank#authenticate-with-a-google-account
+            
+            Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
+            {
+              "code" : 403,
+              "errors" : [ {
+                "domain" : "global",
+                "message" : "The caller does not have permission",
+                "reason" : "forbidden"
+              } ],
+              "message" : "The caller does not have permission",
+              "status" : "PERMISSION_DENIED"
+            }
+        """.trimIndent()
+        mockkObject(GcToolResults) {
+            every { GcToolResults.service.applicationName } returns projectId
+
+            val exceptionBuilder = mockk<HttpResponseException.Builder>()
+            every { exceptionBuilder.message } returns """
+            403 Forbidden
+            {
+              "code" : 403,
+              "errors" : [ {
+                "domain" : "global",
+                "message" : "The caller does not have permission",
+                "reason" : "forbidden"
+              } ],
+              "message" : "The caller does not have permission",
+              "status" : "PERMISSION_DENIED"
+            }
+            """.trimIndent()
+            val mockJSonException = GoogleJsonResponseException(exceptionBuilder, null)
+            every { GcToolResults.service.Projects().initializeSettings(projectId) } throws PermissionDenied(mockJSonException)
+            val exception = getThrowable { GcToolResults.getDefaultBucket(projectId) }
+            assertEquals(expected, exception.message)
+        }
+    }
+
+    @Test(expected = FlankCommonException::class)
+    fun `getDefaultBucket on PermissionDenied error should throw FlankCommonException`() {
+        mockkObject(GcToolResults) {
+            every { GcToolResults.service.applicationName } returns projectId
+            every { GcToolResults.service.Projects().initializeSettings(projectId) } throws PermissionDenied(IOException())
+            GcToolResults.getDefaultBucket(projectId)
+        }
+    }
+
+    @Test(expected = FlankCommonException::class)
+    fun `getDefaultBucket on ProjectNotFound error should throw FlankCommonException`() {
+        mockkObject(GcToolResults) {
+            every { GcToolResults.service.applicationName } returns projectId
+            every { GcToolResults.service.Projects().initializeSettings(projectId) } throws ProjectNotFound(IOException())
+            GcToolResults.getDefaultBucket(projectId)
+        }
+    }
+
+    @Test
+    fun `getDefaultBucket on 404 error should throw exception with specific message`() {
+        val expected = """
+            Flank was unable to find project $projectId. Please verify project id.
+            
+            Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
+            {
+              "code" : 404,
+              "errors" : [ {
+                "domain" : "global",
+                "message" : "Project not found: $projectId",
+                "reason" : "notFound"
+              } ],
+              "message" : "Project not found: $projectId",
+              "status" : "NOT_FOUND"
+            }
+        """.trimIndent()
+        mockkObject(GcToolResults) {
+            every { GcToolResults.service.applicationName } returns FtlConstants.applicationName
+
+            val exceptionBuilder = mockk<HttpResponseException.Builder>()
+            every { exceptionBuilder.message } returns """
+            404 Not Found
+            {
+              "code" : 404,
+              "errors" : [ {
+                "domain" : "global",
+                "message" : "Project not found: $projectId",
+                "reason" : "notFound"
+              } ],
+              "message" : "Project not found: $projectId",
+              "status" : "NOT_FOUND"
+            }
+            """.trimIndent()
+            val mockJSonException = GoogleJsonResponseException(exceptionBuilder, null)
+            every { GcToolResults.service.Projects().initializeSettings(projectId) } throws ProjectNotFound(mockJSonException)
+            val exception = getThrowable { GcToolResults.getDefaultBucket(projectId) }
+            assertEquals(expected, exception.message)
+        }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/gc/GcToolResultsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcToolResultsTest.kt
@@ -56,7 +56,7 @@ class GcToolResultsTest {
     @Test
     fun `getDefaultBucket on 403 error should throw exception with specific message`() {
         val expected = """
-            Flank encountered a 403 error when running on project $projectId. Please verify this credential is authorized for the project.
+            Flank encountered a 403 error when running on project $projectId. Please verify this credential is authorized for the project and has the required permissions.
             Consider authentication with a Service Account https://github.com/Flank/flank#authenticate-with-a-service-account
             or with a Google account https://github.com/Flank/flank#authenticate-with-a-google-account
             

--- a/test_runner/src/test/kotlin/ftl/gc/GcToolResultsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcToolResultsTest.kt
@@ -57,8 +57,8 @@ class GcToolResultsTest {
     fun `getDefaultBucket on 403 error should throw exception with specific message`() {
         val expected = """
             Flank encountered a 403 error when running on project $projectId. Please verify this credential is authorized for the project.
-            Consider authentication with Service Account https://github.com/Flank/flank#authenticate-with-a-service-account
-            or with Google account https://github.com/Flank/flank#authenticate-with-a-google-account
+            Consider authentication with a Service Account https://github.com/Flank/flank#authenticate-with-a-service-account
+            or with a Google account https://github.com/Flank/flank#authenticate-with-a-google-account
             
             Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
             {
@@ -117,7 +117,7 @@ class GcToolResultsTest {
     @Test
     fun `getDefaultBucket on 404 error should throw exception with specific message`() {
         val expected = """
-            Flank was unable to find project $projectId. Please verify project id.
+            Flank was unable to find project $projectId. Please verify the project id.
             
             Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
             {


### PR DESCRIPTION
Fixes #874

## Test Plan
> How do we know the code works?

### 1. User don't have permission to project (403)

When user don't have permission to project Flank should returns message like:

```

Flank encountered a 403 error when running on project $project_name. Please verify this credential is authorized for the project.
Consider authentication with a Service Account https://github.com/Flank/flank#authenticate-with-a-service-account
or with a Google account https://github.com/Flank/flank#authenticate-with-a-google-account

Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
{
  "code" : 403,
  "errors" : [ {
    "domain" : "global",
    "message" : "The caller does not have permission",
    "reason" : "forbidden"
  } ],
  "message" : "The caller does not have permission",
  "status" : "PERMISSION_DENIED"
}

```

### 2. Project not found (404)

When project not found on firebase Flank should return message like:

```

Flank was unable to find project $project_name. Please verify the project id.

Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
{
  "code" : 404,
  "errors" : [ {
    "domain" : "global",
    "message" : "Project not found: $project_name",
    "reason" : "notFound"
  } ],
  "message" : "Project not found: $project_name",
  "status" : "NOT_FOUND"
}

```

### 3. On this two cases Flank throws FlankCommonException and exit with code: 1

## Checklist

- [X] Documented
- [X] Unit tested
- [X] release_notes.md updated
