### PR TITLE
#835 added printing all test environment information

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,7 @@
 - [#895](https://github.com/Flank/flank/pull/895) Added option to print iOS available devices to test against. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#894](https://github.com/Flank/flank/pull/894) Added option to print Android available versions to test against. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#897](https://github.com/Flank/flank/pull/897) Added option to print iOS available versions to test against. ([piotradamczyk5](https://github.com/piotradamczyk5))
+- [#901](https://github.com/Flank/flank/pull/901) Added option to print Android and iOS available test-environment. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - 
 - 
 -

--- a/test_runner/docs/ascii/flank.jar_-android.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android.adoc
@@ -38,6 +38,9 @@ flank.jar
 *versions*::
   Information about available software versions
 
+*test-environment*::
+  Print available devices and OS versions list to test against
+
 // end::picocli-generated-man-section-commands[]
 
 // end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android.adoc
@@ -38,6 +38,9 @@ flank.jar
 *versions*::
   Information about available software versions
 
+*test-environment*::
+  Print available devices and OS versions list to test against
+
 // end::picocli-generated-man-section-commands[]
 
 // end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios.adoc
@@ -38,6 +38,9 @@ flank.jar
 *versions*::
   Information about available software versions
 
+*test-environment*::
+  Print available devices and OS versions list to test against
+
 // end::picocli-generated-man-section-commands[]
 
 // end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-ios.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios.adoc
@@ -38,6 +38,9 @@ flank.jar
 *versions*::
   Information about available software versions
 
+*test-environment*::
+  Print available devices and OS versions list to test against
+
 // end::picocli-generated-man-section-commands[]
 
 // end::picocli-generated-full-manpage[]

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/AndroidCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/AndroidCommand.kt
@@ -2,6 +2,7 @@ package ftl.cli.firebase.test
 
 import ftl.cli.firebase.test.android.AndroidDoctorCommand
 import ftl.cli.firebase.test.android.AndroidRunCommand
+import ftl.cli.firebase.test.android.AndroidTestEnvironmentCommand
 import ftl.cli.firebase.test.android.models.AndroidModelsCommand
 import ftl.cli.firebase.test.android.versions.AndroidVersionsCommand
 import picocli.CommandLine
@@ -14,7 +15,8 @@ import picocli.CommandLine.Command
         AndroidRunCommand::class,
         AndroidDoctorCommand::class,
         AndroidModelsCommand::class,
-        AndroidVersionsCommand::class
+        AndroidVersionsCommand::class,
+        AndroidTestEnvironmentCommand::class
     ],
     usageHelpAutoWidth = true
 )

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/IosCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/IosCommand.kt
@@ -2,6 +2,7 @@ package ftl.cli.firebase.test
 
 import ftl.cli.firebase.test.ios.IosDoctorCommand
 import ftl.cli.firebase.test.ios.IosRunCommand
+import ftl.cli.firebase.test.ios.IosTestEnvironmentCommand
 import ftl.cli.firebase.test.ios.models.IosModelsCommand
 import ftl.cli.firebase.test.ios.versions.IosVersionsCommand
 import picocli.CommandLine
@@ -14,7 +15,8 @@ import picocli.CommandLine.Command
         IosRunCommand::class,
         IosDoctorCommand::class,
         IosModelsCommand::class,
-        IosVersionsCommand::class
+        IosVersionsCommand::class,
+        IosTestEnvironmentCommand::class
     ],
     usageHelpAutoWidth = true
 )

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
@@ -1,0 +1,32 @@
+package ftl.cli.firebase.test.android
+
+import ftl.android.AndroidCatalog.devicesCatalogAsTable
+import ftl.android.AndroidCatalog.supportedVersionsAsTable
+import ftl.args.AndroidArgs
+import ftl.config.FtlConstants
+import picocli.CommandLine
+import java.nio.file.Paths
+
+@CommandLine.Command(
+    name = "test-environment",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["Print available devices and OS versions list to test against"],
+    description = ["Print available Android devices and Android OS versions list to test against"],
+    usageHelpAutoWidth = true
+)
+class AndroidTestEnvironmentCommand : Runnable {
+    override fun run() {
+        println(devicesCatalogAsTable(AndroidArgs.load(Paths.get(configPath)).project))
+        println(supportedVersionsAsTable(AndroidArgs.load(Paths.get(configPath)).project))
+    }
+
+    @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = FtlConstants.defaultAndroidConfig
+
+    @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["Prints this help message"])
+    var usageHelpRequested: Boolean = false
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
@@ -1,0 +1,32 @@
+package ftl.cli.firebase.test.ios
+
+import ftl.args.IosArgs
+import ftl.config.FtlConstants
+import ftl.ios.IosCatalog.devicesCatalogAsTable
+import ftl.ios.IosCatalog.softwareVersionsAsTable
+import picocli.CommandLine
+import java.nio.file.Paths
+
+@CommandLine.Command(
+    name = "test-environment",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["Print available devices and OS versions list to test against"],
+    description = ["Print available iOS devices and iOS versions list to test against"],
+    usageHelpAutoWidth = true
+)
+class IosTestEnvironmentCommand : Runnable {
+    override fun run() {
+        println(devicesCatalogAsTable(IosArgs.load(Paths.get(configPath)).project))
+        println(softwareVersionsAsTable(IosArgs.load(Paths.get(configPath)).project))
+    }
+
+    @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = FtlConstants.defaultIosConfig
+
+    @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["Prints this help message"])
+    var usageHelpRequested: Boolean = false
+}

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommandTest.kt
@@ -1,0 +1,16 @@
+package ftl.cli.firebase.test.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import picocli.CommandLine
+
+class AndroidTestEnvironmentCommandTest {
+
+    @Test
+    fun androidTestEnvironmentCommandShouldParseConfig() {
+        val cmd = AndroidTestEnvironmentCommand()
+        CommandLine(cmd).parseArgs("--config=a")
+
+        assertThat(cmd.configPath).isEqualTo("a")
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommandTest.kt
@@ -1,0 +1,16 @@
+package ftl.cli.firebase.test.ios
+
+import com.google.common.truth.Truth
+import org.junit.Test
+import picocli.CommandLine
+
+class IosTestEnvironmentCommandTest {
+
+    @Test
+    fun iosTestEnvironmentCommandShouldParseConfig() {
+        val cmd = IosTestEnvironmentCommand()
+        CommandLine(cmd).parseArgs("--config=a")
+
+        Truth.assertThat(cmd.configPath).isEqualTo("a")
+    }
+}


### PR DESCRIPTION
Fixes #835 

## Test Plan
> How do we know the code works?

Use on of a new CLI option to test this PR:
- `flank firebase test android|ios test-environment` or `flank android|ios test-environment` - print Android|iOS available versions and devices to test against

More listing options of the test environment will be added in the next tasks

## Checklist

- [x] printing Android software versions and devices list together
- [x] printing iOS software versions and devices list together
- [x] Documented
- [x] Unit tested
- [x] release_notes.md updated
