### PR TITLE
886 Print network profiles

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,7 @@
 - [#897](https://github.com/Flank/flank/pull/897) Added option to print iOS available versions to test against. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#901](https://github.com/Flank/flank/pull/901) Added option to print Android and iOS available test-environment. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#904](https://github.com/Flank/flank/pull/904) Added option to print provided software. ([piotradamczyk5](https://github.com/piotradamczyk5))
-- 
+- [#906](https://github.com/Flank/flank/pull/906) Added option to print network profiles. ([adamfilipow92](https://github.com/adamfilipow92))
 - 
 -
 

--- a/test_runner/docs/ascii/flank.jar_-android-models-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-models-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-android-models-list - Print current list of devices available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ android models list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of Android devices available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-android-models.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-models.adoc
@@ -1,0 +1,34 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-android-models - Information about available models
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ android models* [COMMAND]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Information about available models. For example prints list of available models to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-commands[]
+== Commands
+
+*list*::
+  Print current list of devices available to test against
+
+// end::picocli-generated-man-section-commands[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-android-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-run.adoc
@@ -121,6 +121,9 @@ Configuration is read from flank.yml
 *--shard-time*=_<shardTime>_::
   The max amount of seconds each shard should run.
 
+*--project*=_<project>_::
+  The Google Cloud Platform project name to use for this invocation. If omitted, then the project from the service account credential is used
+
 *--num-test-runs*=_<repeatTests>_::
   The amount of times to run the test executions.
 
@@ -138,9 +141,6 @@ Configuration is read from flank.yml
 
 *--files-to-download*=_<filesToDownload>_[,_<filesToDownload>_...]::
   A list of paths that will be downloaded from the resulting bucket to the local results folder after the test is complete. These must be absolute paths (for example, --files-to-download /images/tempDir1,/data/local/tmp/tempDir2). Path names are restricted to the characters a-zA-Z0-9_-./+.
-
-*--project*=_<project>_::
-  The Google Cloud Platform project name to use for this invocation. If omitted, then the project from the service account credential is used
 
 *--local-result-dir*=_<localResultsDir>_::
   Saves test result to this local folder. Deleted before each run.

--- a/test_runner/docs/ascii/flank.jar_-android-test-environment.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-test-environment.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-android-test-environment - Print available devices and OS versions list to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ android test-environment* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print available Android devices and Android OS versions list to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-android-test-environment.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-test-environment.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--android-test-environment - Print available devices and OS versions list to test against
+-android-test-environment - Print available devices, OS versions, provided software list and network configuration to test against
 
 // end::picocli-generated-man-section-name[]
 
@@ -19,7 +19,7 @@ flank.jar
 // tag::picocli-generated-man-section-description[]
 == Description
 
-Print available Android devices and Android OS versions list to test against
+Print available Android devices, Android OS versions list, provided software and network configuration to test against
 
 // end::picocli-generated-man-section-description[]
 

--- a/test_runner/docs/ascii/flank.jar_-android-versions-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-versions-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-android-versions-list - List of OS versions available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ android versions list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of Android OS versions available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-android-versions.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-versions.adoc
@@ -1,0 +1,34 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-android-versions - Information about available software versions
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ android versions* [COMMAND]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Information about available software versions. For example prints list of available software versions
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-commands[]
+== Commands
+
+*list*::
+  List of OS versions available to test against
+
+// end::picocli-generated-man-section-commands[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-models-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-models-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-android-models-list - Print current list of devices available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test android models list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of Android devices available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-models.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-models.adoc
@@ -1,0 +1,34 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-android-models - Information about available models
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test android models* [COMMAND]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Information about available models. For example prints list of available models to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-commands[]
+== Commands
+
+*list*::
+  Print current list of devices available to test against
+
+// end::picocli-generated-man-section-commands[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-run.adoc
@@ -133,6 +133,9 @@ Configuration is read from flank.yml
 *--shard-time*=_<shardTime>_::
   The max amount of seconds each shard should run.
 
+*--project*=_<project>_::
+  The Google Cloud Platform project name to use for this invocation. If omitted, then the project from the service account credential is used
+
 *--num-test-runs*=_<repeatTests>_::
   The amount of times to run the test executions.
 
@@ -150,9 +153,6 @@ Configuration is read from flank.yml
 
 *--files-to-download*=_<filesToDownload>_[,_<filesToDownload>_...]::
   A list of paths that will be downloaded from the resulting bucket to the local results folder after the test is complete. These must be absolute paths (for example, --files-to-download /images/tempDir1,/data/local/tmp/tempDir2). Path names are restricted to the characters a-zA-Z0-9_-./+.
-
-*--project*=_<project>_::
-  The Google Cloud Platform project name to use for this invocation. If omitted, then the project from the service account credential is used
 
 *--local-result-dir*=_<localResultsDir>_::
   Saves test result to this local folder. Deleted before each run.

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-test-environment.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-test-environment.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-android-test-environment - Print available devices and OS versions list to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test android test-environment* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print available Android devices and Android OS versions list to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-test-environment.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-test-environment.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--firebase-test-android-test-environment - Print available devices and OS versions list to test against
+-firebase-test-android-test-environment - Print available devices, OS versions, provided software list and network configuration to test against
 
 // end::picocli-generated-man-section-name[]
 
@@ -19,7 +19,7 @@ flank.jar
 // tag::picocli-generated-man-section-description[]
 == Description
 
-Print available Android devices and Android OS versions list to test against
+Print available Android devices, Android OS versions list, provided software and network configuration to test against
 
 // end::picocli-generated-man-section-description[]
 

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-versions-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-versions-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-android-versions-list - List of OS versions available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test android versions list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of Android OS versions available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-versions.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-versions.adoc
@@ -1,0 +1,34 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-android-versions - Information about available software versions
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test android versions* [COMMAND]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Information about available software versions. For example prints list of available software versions
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-commands[]
+== Commands
+
+*list*::
+  List of OS versions available to test against
+
+// end::picocli-generated-man-section-commands[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android.adoc
@@ -39,7 +39,7 @@ flank.jar
   Information about available software versions
 
 *test-environment*::
-  Print available devices and OS versions list to test against
+  Print available devices, OS versions, provided software list and network configuration to test against
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-models-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-models-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-ios-models-list - Print current list of devices available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test ios models list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of iOS devices available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-models.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-models.adoc
@@ -1,0 +1,34 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-ios-models - Information about available models
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test ios models* [COMMAND]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Information about available models. For example prints list of available models to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-commands[]
+== Commands
+
+*list*::
+  Print current list of devices available to test against
+
+// end::picocli-generated-man-section-commands[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-run.adoc
@@ -154,14 +154,14 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
+*--xcode-version*=_<xcodeVersion>_::
+  The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
+
 *--test*=_<test>_::
   The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
 
 *--xctestrun-file*=_<xctestrunFile>_::
   The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
-
-*--xcode-version*=_<xcodeVersion>_::
-  The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
 
 *--test-targets*=_<testTargets>_[,_<testTargets>_...]::
   A list of one or more test method names to run (default: run all test targets).

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-run.adoc
@@ -112,6 +112,9 @@ Configuration is read from flank.yml
 *--shard-time*=_<shardTime>_::
   The max amount of seconds each shard should run.
 
+*--project*=_<project>_::
+  The Google Cloud Platform project name to use for this invocation. If omitted, then the project from the service account credential is used
+
 *--num-test-runs*=_<repeatTests>_::
   The amount of times to run the test executions.
 
@@ -129,9 +132,6 @@ Configuration is read from flank.yml
 
 *--files-to-download*=_<filesToDownload>_[,_<filesToDownload>_...]::
   A list of paths that will be downloaded from the resulting bucket to the local results folder after the test is complete. These must be absolute paths (for example, --files-to-download /images/tempDir1,/data/local/tmp/tempDir2). Path names are restricted to the characters a-zA-Z0-9_-./+.
-
-*--project*=_<project>_::
-  The Google Cloud Platform project name to use for this invocation. If omitted, then the project from the service account credential is used
 
 *--local-result-dir*=_<localResultsDir>_::
   Saves test result to this local folder. Deleted before each run.
@@ -154,14 +154,14 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
+*--xctestrun-file*=_<xctestrunFile>_::
+  The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
+
 *--xcode-version*=_<xcodeVersion>_::
   The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
 
 *--test*=_<test>_::
   The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
-
-*--xctestrun-file*=_<xctestrunFile>_::
-  The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
 
 *--test-targets*=_<testTargets>_[,_<testTargets>_...]::
   A list of one or more test method names to run (default: run all test targets).

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-test-environment.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-test-environment.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-ios-test-environment - Print available devices and OS versions list to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test ios test-environment* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print available iOS devices and iOS versions list to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-test-environment.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-test-environment.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--firebase-test-ios-test-environment - Print available devices and OS versions list to test against
+-firebase-test-ios-test-environment - Print available devices, OS versions, provided software list and network configuration to test against
 
 // end::picocli-generated-man-section-name[]
 
@@ -19,7 +19,7 @@ flank.jar
 // tag::picocli-generated-man-section-description[]
 == Description
 
-Print available iOS devices and iOS versions list to test against
+Print available iOS devices, iOS OS versions list, provided software and network configuration to test against
 
 // end::picocli-generated-man-section-description[]
 

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-versions-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-versions-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-ios-versions-list - List of OS versions available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test ios versions list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of iOS versions available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-versions.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-versions.adoc
@@ -1,0 +1,34 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-ios-versions - Information about available software versions
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test ios versions* [COMMAND]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Information about available software versions. For example prints list of available software versions
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-commands[]
+== Commands
+
+*list*::
+  List of OS versions available to test against
+
+// end::picocli-generated-man-section-commands[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios.adoc
@@ -39,7 +39,7 @@ flank.jar
   Information about available software versions
 
 *test-environment*::
-  Print available devices and OS versions list to test against
+  Print available devices, OS versions, provided software list and network configuration to test against
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-provided-software-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-provided-software-list.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--firebase-test - 
+-firebase-test-provided-software-list - The software environment provided by TestExecutionService.
 
 // end::picocli-generated-man-section-name[]
 
@@ -12,7 +12,7 @@ flank.jar
 == Synopsis
 
 *flank.jar
- firebase test* [COMMAND]
+ firebase test provided-software list*
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -22,22 +22,5 @@ flank.jar
 
 
 // end::picocli-generated-man-section-description[]
-
-// tag::picocli-generated-man-section-commands[]
-== Commands
-
-*android*::
-  
-
-*ios*::
-  
-
-*network-profiles*::
-  
-
-*provided-software*::
-  
-
-// end::picocli-generated-man-section-commands[]
 
 // end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-provided-software.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-provided-software.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
- - 
+-firebase-test-provided-software - 
 
 // end::picocli-generated-man-section-name[]
 
@@ -12,7 +12,7 @@ flank.jar
 == Synopsis
 
 *flank.jar
-* [*-v*] [*--debug*] [COMMAND]
+ firebase test provided-software* [COMMAND]
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -23,40 +23,11 @@ flank.jar
 
 // end::picocli-generated-man-section-description[]
 
-// tag::picocli-generated-man-section-options[]
-== Options
-
-*--debug*::
-  Enables debug logging
-
-*-v*, *--version*::
-  Prints the version
-
-// end::picocli-generated-man-section-options[]
-
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*firebase*::
-  
-
-*ios*::
-  
-
-*android*::
-  
-
-*refresh*::
-  Downloads results for the last Firebase Test Lab run
-
-*cancel*::
-  Cancels the last Firebase Test Lab run
-
-*auth*::
-  Manage oauth2 credentials for Google Cloud
-
-*provided-software*::
-  
+*list*::
+  The software environment provided by TestExecutionService.
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-ios-models-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-models-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-ios-models-list - Print current list of devices available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ ios models list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of iOS devices available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-ios-models.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-models.adoc
@@ -1,0 +1,34 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-ios-models - Information about available models
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ ios models* [COMMAND]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Information about available models. For example prints list of available models to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-commands[]
+== Commands
+
+*list*::
+  Print current list of devices available to test against
+
+// end::picocli-generated-man-section-commands[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-ios-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-run.adoc
@@ -146,14 +146,14 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
+*--xcode-version*=_<xcodeVersion>_::
+  The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
+
 *--test*=_<test>_::
   The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
 
 *--xctestrun-file*=_<xctestrunFile>_::
   The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
-
-*--xcode-version*=_<xcodeVersion>_::
-  The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
 
 *--test-targets*=_<testTargets>_[,_<testTargets>_...]::
   A list of one or more test method names to run (default: run all test targets).

--- a/test_runner/docs/ascii/flank.jar_-ios-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-run.adoc
@@ -104,6 +104,9 @@ Configuration is read from flank.yml
 *--shard-time*=_<shardTime>_::
   The max amount of seconds each shard should run.
 
+*--project*=_<project>_::
+  The Google Cloud Platform project name to use for this invocation. If omitted, then the project from the service account credential is used
+
 *--num-test-runs*=_<repeatTests>_::
   The amount of times to run the test executions.
 
@@ -121,9 +124,6 @@ Configuration is read from flank.yml
 
 *--files-to-download*=_<filesToDownload>_[,_<filesToDownload>_...]::
   A list of paths that will be downloaded from the resulting bucket to the local results folder after the test is complete. These must be absolute paths (for example, --files-to-download /images/tempDir1,/data/local/tmp/tempDir2). Path names are restricted to the characters a-zA-Z0-9_-./+.
-
-*--project*=_<project>_::
-  The Google Cloud Platform project name to use for this invocation. If omitted, then the project from the service account credential is used
 
 *--local-result-dir*=_<localResultsDir>_::
   Saves test result to this local folder. Deleted before each run.
@@ -146,14 +146,14 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
+*--xctestrun-file*=_<xctestrunFile>_::
+  The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
+
 *--xcode-version*=_<xcodeVersion>_::
   The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
 
 *--test*=_<test>_::
   The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
-
-*--xctestrun-file*=_<xctestrunFile>_::
-  The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
 
 *--test-targets*=_<testTargets>_[,_<testTargets>_...]::
   A list of one or more test method names to run (default: run all test targets).

--- a/test_runner/docs/ascii/flank.jar_-ios-test-environment.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-test-environment.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--ios-test-environment - Print available devices and OS versions list to test against
+-ios-test-environment - Print available devices, OS versions, provided software list and network configuration to test against
 
 // end::picocli-generated-man-section-name[]
 
@@ -19,7 +19,7 @@ flank.jar
 // tag::picocli-generated-man-section-description[]
 == Description
 
-Print available iOS devices and iOS versions list to test against
+Print available iOS devices, iOS OS versions list, provided software and network configuration to test against
 
 // end::picocli-generated-man-section-description[]
 

--- a/test_runner/docs/ascii/flank.jar_-ios-test-environment.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-test-environment.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-ios-test-environment - Print available devices and OS versions list to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ ios test-environment* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print available iOS devices and iOS versions list to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-ios-versions-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-versions-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-ios-versions-list - List of OS versions available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ ios versions list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of iOS versions available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-ios-versions.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-versions.adoc
@@ -1,0 +1,34 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-ios-versions - Information about available software versions
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ ios versions* [COMMAND]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Information about available software versions. For example prints list of available software versions
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-commands[]
+== Commands
+
+*list*::
+  List of OS versions available to test against
+
+// end::picocli-generated-man-section-commands[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-ios.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios.adoc
@@ -39,7 +39,7 @@ flank.jar
   Information about available software versions
 
 *test-environment*::
-  Print available devices and OS versions list to test against
+  Print available devices, OS versions, provided software list and network configuration to test against
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-network-profiles-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-network-profiles-list.adoc
@@ -1,0 +1,26 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-network-profiles-list - List all network profiles available for testing 
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ network-profiles list*
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+
+
+// end::picocli-generated-man-section-description[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-network-profiles.adoc
+++ b/test_runner/docs/ascii/flank.jar_-network-profiles.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--android - 
+-network-profiles - 
 
 // end::picocli-generated-man-section-name[]
 
@@ -12,7 +12,7 @@ flank.jar
 == Synopsis
 
 *flank.jar
- android* [COMMAND]
+ network-profiles* [COMMAND]
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -26,20 +26,8 @@ flank.jar
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*run*::
-  Run tests on Firebase Test Lab
-
-*doctor*::
-  Verifies flank firebase is setup correctly
-
-*models*::
-  Information about available models
-
-*versions*::
-  Information about available software versions
-
-*test-environment*::
-  Print available devices, OS versions, provided software list and network configuration to test against
+*list*::
+  List all network profiles available for testing 
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-provided-software-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-provided-software-list.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--firebase-test - 
+-provided-software-list - The software environment provided by TestExecutionService.
 
 // end::picocli-generated-man-section-name[]
 
@@ -12,7 +12,7 @@ flank.jar
 == Synopsis
 
 *flank.jar
- firebase test* [COMMAND]
+ provided-software list*
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -22,22 +22,5 @@ flank.jar
 
 
 // end::picocli-generated-man-section-description[]
-
-// tag::picocli-generated-man-section-commands[]
-== Commands
-
-*android*::
-  
-
-*ios*::
-  
-
-*network-profiles*::
-  
-
-*provided-software*::
-  
-
-// end::picocli-generated-man-section-commands[]
 
 // end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-provided-software.adoc
+++ b/test_runner/docs/ascii/flank.jar_-provided-software.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
- - 
+-provided-software - 
 
 // end::picocli-generated-man-section-name[]
 
@@ -12,7 +12,7 @@ flank.jar
 == Synopsis
 
 *flank.jar
-* [*-v*] [*--debug*] [COMMAND]
+ provided-software* [COMMAND]
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -23,40 +23,11 @@ flank.jar
 
 // end::picocli-generated-man-section-description[]
 
-// tag::picocli-generated-man-section-options[]
-== Options
-
-*--debug*::
-  Enables debug logging
-
-*-v*, *--version*::
-  Prints the version
-
-// end::picocli-generated-man-section-options[]
-
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*firebase*::
-  
-
-*ios*::
-  
-
-*android*::
-  
-
-*refresh*::
-  Downloads results for the last Firebase Test Lab run
-
-*cancel*::
-  Cancels the last Firebase Test Lab run
-
-*auth*::
-  Manage oauth2 credentials for Google Cloud
-
-*provided-software*::
-  
+*list*::
+  The software environment provided by TestExecutionService.
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_.adoc
+++ b/test_runner/docs/ascii/flank.jar_.adoc
@@ -58,6 +58,9 @@ flank.jar
 *provided-software*::
   
 
+*network-profiles*::
+  
+
 // end::picocli-generated-man-section-commands[]
 
 // end::picocli-generated-full-manpage[]

--- a/test_runner/src/main/kotlin/ftl/Main.kt
+++ b/test_runner/src/main/kotlin/ftl/Main.kt
@@ -6,6 +6,7 @@ import ftl.cli.firebase.CancelCommand
 import ftl.cli.firebase.RefreshCommand
 import ftl.cli.firebase.test.AndroidCommand
 import ftl.cli.firebase.test.IosCommand
+import ftl.cli.firebase.test.NetworkProfilesCommand
 import ftl.cli.firebase.test.ProvidedSoftwareCommand
 import ftl.log.setDebugLogging
 import ftl.util.readRevision
@@ -23,7 +24,8 @@ import picocli.CommandLine
         RefreshCommand::class,
         CancelCommand::class,
         AuthCommand::class,
-        ProvidedSoftwareCommand::class
+        ProvidedSoftwareCommand::class,
+        NetworkProfilesCommand::class
     ]
 )
 class Main : Runnable {

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
@@ -26,7 +26,7 @@ class AndroidTestEnvironmentCommand : Runnable {
         println(devicesCatalogAsTable(AndroidArgs.load(Paths.get(configPath)).project))
         println(supportedVersionsAsTable(AndroidArgs.load(Paths.get(configPath)).project))
         println(providedSoftwareAsTable())
-        GcTesting.networkConfiguration().asPrintableTable().forEach { println(it) }
+        println(GcTesting.networkConfiguration().asPrintableTable())
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
@@ -5,6 +5,8 @@ import ftl.android.AndroidCatalog.supportedVersionsAsTable
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
 import ftl.environment.providedSoftwareAsTable
+import ftl.environment.asPrintableTable
+import ftl.gc.GcTesting
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -24,6 +26,7 @@ class AndroidTestEnvironmentCommand : Runnable {
         println(devicesCatalogAsTable(AndroidArgs.load(Paths.get(configPath)).project))
         println(supportedVersionsAsTable(AndroidArgs.load(Paths.get(configPath)).project))
         println(providedSoftwareAsTable())
+        GcTesting.networkConfiguration().asPrintableTable().forEach { println(it) }
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
@@ -5,8 +5,7 @@ import ftl.android.AndroidCatalog.supportedVersionsAsTable
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
 import ftl.environment.providedSoftwareAsTable
-import ftl.environment.asPrintableTable
-import ftl.gc.GcTesting
+import ftl.environment.networkConfigurationAsTable
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -17,8 +16,8 @@ import java.nio.file.Paths
     descriptionHeading = "%n@|bold,underline Description:|@%n%n",
     parameterListHeading = "%n@|bold,underline Parameters:|@%n",
     optionListHeading = "%n@|bold,underline Options:|@%n",
-    header = ["Print available devices and OS versions list to test against"],
-    description = ["Print available Android devices and Android OS versions list to test against"],
+    header = ["Print available devices, OS versions, provided software list and network configuration to test against"],
+    description = ["Print available Android devices, Android OS versions list, provided software and network configuration to test against"],
     usageHelpAutoWidth = true
 )
 class AndroidTestEnvironmentCommand : Runnable {
@@ -26,7 +25,7 @@ class AndroidTestEnvironmentCommand : Runnable {
         println(devicesCatalogAsTable(AndroidArgs.load(Paths.get(configPath)).project))
         println(supportedVersionsAsTable(AndroidArgs.load(Paths.get(configPath)).project))
         println(providedSoftwareAsTable())
-        println(GcTesting.networkConfiguration().asPrintableTable())
+        println(networkConfigurationAsTable())
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
@@ -26,7 +26,7 @@ class IosTestEnvironmentCommand : Runnable {
         println(devicesCatalogAsTable(IosArgs.load(Paths.get(configPath)).project))
         println(softwareVersionsAsTable(IosArgs.load(Paths.get(configPath)).project))
         println(providedSoftwareAsTable())
-        GcTesting.networkConfiguration().asPrintableTable().forEach { println(it) }
+        println(GcTesting.networkConfiguration().asPrintableTable())
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
@@ -3,8 +3,7 @@ package ftl.cli.firebase.test.ios
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.environment.providedSoftwareAsTable
-import ftl.environment.asPrintableTable
-import ftl.gc.GcTesting
+import ftl.environment.networkConfigurationAsTable
 import ftl.ios.IosCatalog.devicesCatalogAsTable
 import ftl.ios.IosCatalog.softwareVersionsAsTable
 import picocli.CommandLine
@@ -17,8 +16,8 @@ import java.nio.file.Paths
     descriptionHeading = "%n@|bold,underline Description:|@%n%n",
     parameterListHeading = "%n@|bold,underline Parameters:|@%n",
     optionListHeading = "%n@|bold,underline Options:|@%n",
-    header = ["Print available devices and OS versions list to test against"],
-    description = ["Print available iOS devices and iOS versions list to test against"],
+    header = ["Print available devices, OS versions, provided software list and network configuration to test against"],
+    description = ["Print available iOS devices, iOS OS versions list, provided software and network configuration to test against"],
     usageHelpAutoWidth = true
 )
 class IosTestEnvironmentCommand : Runnable {
@@ -26,7 +25,7 @@ class IosTestEnvironmentCommand : Runnable {
         println(devicesCatalogAsTable(IosArgs.load(Paths.get(configPath)).project))
         println(softwareVersionsAsTable(IosArgs.load(Paths.get(configPath)).project))
         println(providedSoftwareAsTable())
-        println(GcTesting.networkConfiguration().asPrintableTable())
+        println(networkConfigurationAsTable())
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
@@ -3,6 +3,8 @@ package ftl.cli.firebase.test.ios
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.environment.providedSoftwareAsTable
+import ftl.environment.asPrintableTable
+import ftl.gc.GcTesting
 import ftl.ios.IosCatalog.devicesCatalogAsTable
 import ftl.ios.IosCatalog.softwareVersionsAsTable
 import picocli.CommandLine
@@ -24,6 +26,7 @@ class IosTestEnvironmentCommand : Runnable {
         println(devicesCatalogAsTable(IosArgs.load(Paths.get(configPath)).project))
         println(softwareVersionsAsTable(IosArgs.load(Paths.get(configPath)).project))
         println(providedSoftwareAsTable())
+        GcTesting.networkConfiguration().asPrintableTable().forEach { println(it) }
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
@@ -1,5 +1,6 @@
 package ftl.cli.firebase.test.networkprofiles
 
+import ftl.environment.asPrintableTable
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 import ftl.run.common.prettyPrint
@@ -19,13 +20,6 @@ import picocli.CommandLine
 class NetworkProfilesListCommand : Runnable {
     override fun run() {
         println("fetching available network profiles...")
-        val configurations = GcTesting.get.testEnvironmentCatalog()
-            .get("NETWORK_CONFIGURATION")
-            .executeWithRetry()
-            ?.networkConfigurationCatalog
-            ?.configurations
-            ?: emptyList()
-        println()
-        println(prettyPrint.toJson(configurations))
+        GcTesting.networkConfiguration().asPrintableTable().forEach { println(it) }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
@@ -1,7 +1,6 @@
 package ftl.cli.firebase.test.networkprofiles
 
-import ftl.environment.asPrintableTable
-import ftl.gc.GcTesting
+import ftl.environment.networkConfigurationAsTable
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -18,6 +17,6 @@ import picocli.CommandLine
 class NetworkProfilesListCommand : Runnable {
     override fun run() {
         println("fetching available network profiles...")
-        println(GcTesting.networkConfiguration().asPrintableTable())
+        println(networkConfigurationAsTable())
     }
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
@@ -20,6 +20,6 @@ import picocli.CommandLine
 class NetworkProfilesListCommand : Runnable {
     override fun run() {
         println("fetching available network profiles...")
-        GcTesting.networkConfiguration().asPrintableTable().forEach { println(it) }
+        println(GcTesting.networkConfiguration().asPrintableTable())
     }
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
@@ -2,8 +2,6 @@ package ftl.cli.firebase.test.networkprofiles
 
 import ftl.environment.asPrintableTable
 import ftl.gc.GcTesting
-import ftl.http.executeWithRetry
-import ftl.run.common.prettyPrint
 import picocli.CommandLine
 
 @CommandLine.Command(

--- a/test_runner/src/main/kotlin/ftl/environment/ListNetworkConfiguration.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ListNetworkConfiguration.kt
@@ -3,10 +3,10 @@ package ftl.environment
 import com.google.api.services.testing.model.NetworkConfiguration
 import ftl.util.buildTable
 
-fun List<NetworkConfiguration>.asPrintableTable() = createProfileDetails().createNetworkProfileTable()
+fun List<NetworkConfiguration>.asPrintableTable() = createConfigurationDetails().createConfigurationsTable()
 
-private fun List<NetworkConfiguration>.createProfileDetails() = fold(mutableMapOf<String, MutableList<String>>()) { table, networkConfiguration ->
-    table.apply {
+private fun List<NetworkConfiguration>.createConfigurationDetails() = fold(mutableMapOf<String, MutableList<String>>()) { networkInfo, networkConfiguration ->
+    networkInfo.apply {
         getOrCreateList(PROFILE_ID).add(" ")
         getOrCreateList(PROFILE_ID).add(networkConfiguration.id)
 
@@ -32,7 +32,7 @@ private fun List<NetworkConfiguration>.createProfileDetails() = fold(mutableMapO
 }
 
 
-private fun TestEnvironmentInfo.createNetworkProfileTable() = buildTable(
+private fun TestEnvironmentInfo.createConfigurationsTable() = buildTable(
     createTableColumnFor(PROFILE_ID),
     createTableColumnFor(RULE),
     createTableColumnFor(DELAY),

--- a/test_runner/src/main/kotlin/ftl/environment/ListNetworkConfiguration.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ListNetworkConfiguration.kt
@@ -1,6 +1,7 @@
 package ftl.environment
 
 import com.google.api.services.testing.model.NetworkConfiguration
+import ftl.util.TableStyle
 import ftl.util.buildTable
 
 fun List<NetworkConfiguration>.asPrintableTable() = createConfigurationDetails().createConfigurationsTable()
@@ -37,7 +38,8 @@ private fun TestEnvironmentInfo.createConfigurationsTable() = buildTable(
     createTableColumnFor(LOSS_RATION),
     createTableColumnFor(DUPLICATION_RATION),
     createTableColumnFor(BANDWIDTH),
-    createTableColumnFor(BURST)
+    createTableColumnFor(BURST),
+    tableStyle = TableStyle.ROW_SEPARATOR
 )
 
 private const val PROFILE_ID = "PROFILE_ID"

--- a/test_runner/src/main/kotlin/ftl/environment/ListNetworkConfiguration.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ListNetworkConfiguration.kt
@@ -10,7 +10,6 @@ private fun List<NetworkConfiguration>.createConfigurationDetails() = fold(mutab
         getOrCreateList(PROFILE_ID).add(" ")
         getOrCreateList(PROFILE_ID).add(networkConfiguration.id)
 
-
         getOrCreateList(RULE).add(RULE_UP)
         getOrCreateList(RULE).add(RULE_DOWN)
 
@@ -31,7 +30,6 @@ private fun List<NetworkConfiguration>.createConfigurationDetails() = fold(mutab
     }
 }
 
-
 private fun TestEnvironmentInfo.createConfigurationsTable() = buildTable(
     createTableColumnFor(PROFILE_ID),
     createTableColumnFor(RULE),
@@ -42,9 +40,7 @@ private fun TestEnvironmentInfo.createConfigurationsTable() = buildTable(
     createTableColumnFor(BURST)
 )
 
-
 private const val PROFILE_ID = "PROFILE_ID"
-
 private const val RULE = "RULE"
 private const val RULE_UP = "up"
 private const val RULE_DOWN = "down"

--- a/test_runner/src/main/kotlin/ftl/environment/ListNetworkProfiles.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ListNetworkProfiles.kt
@@ -2,47 +2,38 @@ package ftl.environment
 
 import com.google.api.services.testing.model.NetworkConfiguration
 import ftl.util.buildTable
-import ftl.util.buildTableWithPad
 
-fun List<NetworkConfiguration>.asPrintableTable() = createProfileData().createNetworkProfileTables()
+fun List<NetworkConfiguration>.asPrintableTable() = createProfileDetails().createNetworkProfileTable()
 
-private fun List<NetworkConfiguration>.createProfileData() = createProfileHeaders().zip(createProfileDetails()) { header, details -> listOf(header, details) }.flatten()
+private fun List<NetworkConfiguration>.createProfileDetails() = fold(mutableMapOf<String, MutableList<String>>()) { table, networkConfiguration ->
+    table.apply {
+        getOrCreateList(PROFILE_ID).add(" ")
+        getOrCreateList(PROFILE_ID).add(networkConfiguration.id)
 
-private fun List<NetworkConfiguration>.createProfileHeaders() = map { it.createProfileHeader() }
 
-private fun NetworkConfiguration.createProfileHeader() = mutableMapOf<String, MutableList<String>>().apply {
-    getOrCreateList(PROFILE_ID).add(id)
+        getOrCreateList(RULE).add(RULE_UP)
+        getOrCreateList(RULE).add(RULE_DOWN)
+
+        getOrCreateList(DELAY).add(networkConfiguration.upRule.delay.orEmpty())
+        getOrCreateList(DELAY).add(networkConfiguration.downRule.delay.orEmpty())
+
+        getOrCreateList(LOSS_RATION).add(networkConfiguration.upRule.packetLossRatio?.toString().orEmpty())
+        getOrCreateList(LOSS_RATION).add(networkConfiguration.downRule.packetLossRatio?.toString().orEmpty())
+
+        getOrCreateList(DUPLICATION_RATION).add(networkConfiguration.upRule.packetDuplicationRatio?.toString().orEmpty())
+        getOrCreateList(DUPLICATION_RATION).add(networkConfiguration.downRule.packetDuplicationRatio?.toString().orEmpty())
+
+        getOrCreateList(BANDWIDTH).add(networkConfiguration.upRule.bandwidth?.toString().orEmpty())
+        getOrCreateList(BANDWIDTH).add(networkConfiguration.downRule.bandwidth?.toString().orEmpty())
+
+        getOrCreateList(BURST).add(networkConfiguration.upRule.burst?.toString().orEmpty())
+        getOrCreateList(BURST).add(networkConfiguration.downRule.burst?.toString().orEmpty())
+    }
 }
 
-private fun List<NetworkConfiguration>.createProfileDetails() = this.map { it.createProfileDetails() }
 
-private fun NetworkConfiguration.createProfileDetails() = mutableMapOf<String, MutableList<String>>().apply {
-    getOrCreateList(RULE).add(RULE_UP)
-    getOrCreateList(RULE).add(RULE_DOWN)
-
-    getOrCreateList(DELAY).add(upRule.delay.orEmpty())
-    getOrCreateList(DELAY).add(downRule.delay.orEmpty())
-
-    getOrCreateList(LOSS_RATION).add(upRule.packetLossRatio?.toString().orEmpty())
-    getOrCreateList(LOSS_RATION).add(downRule.packetLossRatio?.toString().orEmpty())
-
-    getOrCreateList(DUPLICATION_RATION).add(upRule.packetDuplicationRatio?.toString().orEmpty())
-    getOrCreateList(DUPLICATION_RATION).add(downRule.packetDuplicationRatio?.toString().orEmpty())
-
-    getOrCreateList(BANDWIDTH).add(upRule.bandwidth?.toString().orEmpty())
-    getOrCreateList(BANDWIDTH).add(downRule.bandwidth?.toString().orEmpty())
-
-    getOrCreateList(BURST).add(upRule.burst?.toString().orEmpty())
-    getOrCreateList(BURST).add(downRule.burst?.toString().orEmpty())
-}
-
-private fun List<TestEnvironmentInfo>.createNetworkProfileTables() = map { it.createNetworkProfileTable() }
-private fun TestEnvironmentInfo.createNetworkProfileTable() =
-    if (this.containsKey(PROFILE_ID)) buildTable(createTableColumnFor(PROFILE_ID))
-    else buildDetailsTable()
-
-private fun TestEnvironmentInfo.buildDetailsTable(): String = buildTableWithPad(
-    TABLE_PAD,
+private fun TestEnvironmentInfo.createNetworkProfileTable() = buildTable(
+    createTableColumnFor(PROFILE_ID),
     createTableColumnFor(RULE),
     createTableColumnFor(DELAY),
     createTableColumnFor(LOSS_RATION),
@@ -51,7 +42,6 @@ private fun TestEnvironmentInfo.buildDetailsTable(): String = buildTableWithPad(
     createTableColumnFor(BURST)
 )
 
-private const val TABLE_PAD = 3
 
 private const val PROFILE_ID = "PROFILE_ID"
 
@@ -59,7 +49,7 @@ private const val RULE = "RULE"
 private const val RULE_UP = "up"
 private const val RULE_DOWN = "down"
 private const val DELAY = "DELAY"
-private const val LOSS_RATION = "LOSS_RATION"
-private const val DUPLICATION_RATION = "DUPLICATION_RATION"
+private const val LOSS_RATION = "LOSS_RATIO"
+private const val DUPLICATION_RATION = "DUPLICATION_RATIO"
 private const val BANDWIDTH = "BANDWIDTH"
 private const val BURST = "BURST"

--- a/test_runner/src/main/kotlin/ftl/environment/ListNetworkProfiles.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ListNetworkProfiles.kt
@@ -1,0 +1,65 @@
+package ftl.environment
+
+import com.google.api.services.testing.model.NetworkConfiguration
+import ftl.util.buildTable
+import ftl.util.buildTableWithPad
+
+fun List<NetworkConfiguration>.asPrintableTable() = createProfileData().createNetworkProfileTables()
+
+private fun List<NetworkConfiguration>.createProfileData() = createProfileHeaders().zip(createProfileDetails()) { header, details -> listOf(header, details) }.flatten()
+
+private fun List<NetworkConfiguration>.createProfileHeaders() = map { it.createProfileHeader() }
+
+private fun NetworkConfiguration.createProfileHeader() = mutableMapOf<String, MutableList<String>>().apply {
+    getOrCreateList(PROFILE_ID).add(id)
+}
+
+private fun List<NetworkConfiguration>.createProfileDetails() = this.map { it.createProfileDetails() }
+
+private fun NetworkConfiguration.createProfileDetails() = mutableMapOf<String, MutableList<String>>().apply {
+    getOrCreateList(RULE).add(RULE_UP)
+    getOrCreateList(RULE).add(RULE_DOWN)
+
+    getOrCreateList(DELAY).add(upRule.delay.orEmpty())
+    getOrCreateList(DELAY).add(downRule.delay.orEmpty())
+
+    getOrCreateList(LOSS_RATION).add(upRule.packetLossRatio?.toString().orEmpty())
+    getOrCreateList(LOSS_RATION).add(downRule.packetLossRatio?.toString().orEmpty())
+
+    getOrCreateList(DUPLICATION_RATION).add(upRule.packetDuplicationRatio?.toString().orEmpty())
+    getOrCreateList(DUPLICATION_RATION).add(downRule.packetDuplicationRatio?.toString().orEmpty())
+
+    getOrCreateList(BANDWIDTH).add(upRule.bandwidth?.toString().orEmpty())
+    getOrCreateList(BANDWIDTH).add(downRule.bandwidth?.toString().orEmpty())
+
+    getOrCreateList(BURST).add(upRule.burst?.toString().orEmpty())
+    getOrCreateList(BURST).add(downRule.burst?.toString().orEmpty())
+}
+
+private fun List<TestEnvironmentInfo>.createNetworkProfileTables() = map { it.createNetworkProfileTable() }
+private fun TestEnvironmentInfo.createNetworkProfileTable() =
+    if (this.containsKey(PROFILE_ID)) buildTable(createTableColumnFor(PROFILE_ID))
+    else buildDetailsTable()
+
+private fun TestEnvironmentInfo.buildDetailsTable(): String = buildTableWithPad(
+    TABLE_PAD,
+    createTableColumnFor(RULE),
+    createTableColumnFor(DELAY),
+    createTableColumnFor(LOSS_RATION),
+    createTableColumnFor(DUPLICATION_RATION),
+    createTableColumnFor(BANDWIDTH),
+    createTableColumnFor(BURST)
+)
+
+private const val TABLE_PAD = 3
+
+private const val PROFILE_ID = "PROFILE_ID"
+
+private const val RULE = "RULE"
+private const val RULE_UP = "up"
+private const val RULE_DOWN = "down"
+private const val DELAY = "DELAY"
+private const val LOSS_RATION = "LOSS_RATION"
+private const val DUPLICATION_RATION = "DUPLICATION_RATION"
+private const val BANDWIDTH = "BANDWIDTH"
+private const val BURST = "BURST"

--- a/test_runner/src/main/kotlin/ftl/environment/NetworkConfigurationCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/NetworkConfigurationCatalog.kt
@@ -1,0 +1,13 @@
+package ftl.environment
+
+import ftl.gc.GcTesting
+import ftl.http.executeWithRetry
+
+fun networkConfigurationAsTable() = networkConfiguration().asPrintableTable()
+
+private fun networkConfiguration() = GcTesting.get.testEnvironmentCatalog()
+    .get("NETWORK_CONFIGURATION")
+    .executeWithRetry()
+    ?.networkConfigurationCatalog
+    ?.configurations
+    .orEmpty()

--- a/test_runner/src/main/kotlin/ftl/gc/GcTesting.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcTesting.kt
@@ -6,10 +6,8 @@ import ftl.config.FtlConstants.JSON_FACTORY
 import ftl.config.FtlConstants.applicationName
 import ftl.config.FtlConstants.httpCredential
 import ftl.config.FtlConstants.httpTransport
-import ftl.http.executeWithRetry
 
 object GcTesting {
-
     val get: Testing by lazy {
         val builder = Testing.Builder(httpTransport, JSON_FACTORY, httpCredential)
             .setApplicationName(applicationName)
@@ -18,11 +16,4 @@ object GcTesting {
 
         builder.build()
     }
-
-    fun networkConfiguration() = get.testEnvironmentCatalog()
-        .get("NETWORK_CONFIGURATION")
-        .executeWithRetry()
-        ?.networkConfigurationCatalog
-        ?.configurations
-        .orEmpty()
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcTesting.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcTesting.kt
@@ -6,6 +6,7 @@ import ftl.config.FtlConstants.JSON_FACTORY
 import ftl.config.FtlConstants.applicationName
 import ftl.config.FtlConstants.httpCredential
 import ftl.config.FtlConstants.httpTransport
+import ftl.http.executeWithRetry
 
 object GcTesting {
 
@@ -17,4 +18,11 @@ object GcTesting {
 
         builder.build()
     }
+
+    fun networkConfiguration() = get.testEnvironmentCatalog()
+        .get("NETWORK_CONFIGURATION")
+        .executeWithRetry()
+        ?.networkConfigurationCatalog
+        ?.configurations
+        .orEmpty()
 }

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -29,6 +29,7 @@ object IosCatalog {
         projectId: String
     ) = iosDeviceCatalog(projectId).models.find { it.id == modelId }?.supportedVersionIds?.contains(versionId) ?: false
 
+
     // Device catalogMap is different depending on the project id
     private fun iosDeviceCatalog(
         projectId: String

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -29,7 +29,6 @@ object IosCatalog {
         projectId: String
     ) = iosDeviceCatalog(projectId).models.find { it.id == modelId }?.supportedVersionIds?.contains(versionId) ?: false
 
-
     // Device catalogMap is different depending on the project id
     private fun iosDeviceCatalog(
         projectId: String

--- a/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
+++ b/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
@@ -2,6 +2,11 @@ package ftl.util
 
 import com.google.common.annotations.VisibleForTesting
 
+enum class TableStyle {
+    DEFAULT,
+    ROW_SEPARATOR
+}
+
 data class TableColumn(
     val header: String,
     val data: List<String>,
@@ -49,13 +54,13 @@ const val END_TABLE_MIDDLE_CHAR = '┴'
 @VisibleForTesting
 const val END_TABLE_END_CHAR = '┘'
 
-fun buildTable(vararg tableColumns: TableColumn): String {
+fun buildTable(vararg tableColumns: TableColumn, tableStyle: TableStyle = TableStyle.DEFAULT): String {
     val rowSizes = tableColumns.map { it.columnSize }
     val builder = StringBuilder().apply {
         startTable(rowSizes)
         tableColumns.map { DataWithSize(it.header, it.columnSize) }.apply { appendDataRow(this) }
         rowSeparator(rowSizes)
-        appendData(tableColumns, rowSizes)
+        appendData(tableColumns, rowSizes, tableStyle)
         endTable(rowSizes)
     }
     return builder.toString()
@@ -81,7 +86,7 @@ private fun StringBuilder.rowSeparator(rowSizes: List<Int>) {
     appendln()
 }
 
-private fun StringBuilder.appendData(tableColumns: Array<out TableColumn>, rowSizes: List<Int>) {
+private fun StringBuilder.appendData(tableColumns: Array<out TableColumn>, rowSizes: List<Int>, tableStyle: TableStyle) {
     val rowCount = (tableColumns.maxBy { it.data.size } ?: tableColumns.first()).data.size
     (0 until rowCount)
         .map { rowNumber ->
@@ -95,7 +100,8 @@ private fun StringBuilder.appendData(tableColumns: Array<out TableColumn>, rowSi
         }
         .forEachIndexed { index, list ->
             appendDataRow(list)
-            if (index < rowCount - 1 && list.first().data.isNotBlank()) rowSeparator(rowSizes)
+            if (tableStyle == TableStyle.ROW_SEPARATOR && index < rowCount - 1 && list.first().data.isNotBlank())
+                rowSeparator(rowSizes)
         }
 }
 

--- a/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
+++ b/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
@@ -55,7 +55,7 @@ fun buildTable(vararg tableColumns: TableColumn): String {
         startTable(rowSizes)
         tableColumns.map { DataWithSize(it.header, it.columnSize) }.apply { appendDataRow(this) }
         rowSeparator(rowSizes)
-        appendData(tableColumns,rowSizes)
+        appendData(tableColumns, rowSizes)
         endTable(rowSizes)
     }
     return builder.toString()
@@ -95,7 +95,7 @@ private fun StringBuilder.appendData(tableColumns: Array<out TableColumn>, rowSi
         }
         .forEachIndexed { index, list ->
             appendDataRow(list)
-            if (index < rowCount -1 && list.first().data.isNotBlank()) rowSeparator(rowSizes)
+            if (index < rowCount - 1 && list.first().data.isNotBlank()) rowSeparator(rowSizes)
         }
 }
 

--- a/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
+++ b/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
@@ -15,19 +15,45 @@ private data class DataWithSize(
 )
 
 private const val DEFAULT_COLUMN_PADDING = 2
-@VisibleForTesting const val TABLE_HORIZONTAL_LINE = '─'
-@VisibleForTesting const val TABLE_VERTICAL_LINE = '│'
-@VisibleForTesting const val START_TABLE_START_CHAR = '┌'
-@VisibleForTesting const val START_TABLE_MIDDLE_CHAR = '┬'
-@VisibleForTesting const val START_TABLE_END_CHAR = '┐'
-@VisibleForTesting const val MIDDLE_TABLE_START_CHAR = '├'
-@VisibleForTesting const val MIDDLE_TABLE_MIDDLE_CHAR = '┼'
-@VisibleForTesting const val MIDDLE_TABLE_END_CHAR = '┤'
-@VisibleForTesting const val END_TABLE_START_CHAR = '└'
-@VisibleForTesting const val END_TABLE_MIDDLE_CHAR = '┴'
-@VisibleForTesting const val END_TABLE_END_CHAR = '┘'
 
-fun buildTable(vararg tableColumns: TableColumn): String {
+@VisibleForTesting
+const val TABLE_HORIZONTAL_LINE = '─'
+
+@VisibleForTesting
+const val TABLE_VERTICAL_LINE = '│'
+
+@VisibleForTesting
+const val START_TABLE_START_CHAR = '┌'
+
+@VisibleForTesting
+const val START_TABLE_MIDDLE_CHAR = '┬'
+
+@VisibleForTesting
+const val START_TABLE_END_CHAR = '┐'
+
+@VisibleForTesting
+const val MIDDLE_TABLE_START_CHAR = '├'
+
+@VisibleForTesting
+const val MIDDLE_TABLE_MIDDLE_CHAR = '┼'
+
+@VisibleForTesting
+const val MIDDLE_TABLE_END_CHAR = '┤'
+
+@VisibleForTesting
+const val END_TABLE_START_CHAR = '└'
+
+@VisibleForTesting
+const val END_TABLE_MIDDLE_CHAR = '┴'
+
+@VisibleForTesting
+const val END_TABLE_END_CHAR = '┘'
+
+@VisibleForTesting
+const val PAD_CHAR = ' '
+fun buildTable(vararg tableColumns: TableColumn): String = buildTableWithPad(0, *tableColumns)
+
+fun buildTableWithPad(padStart: Int, vararg tableColumns: TableColumn): String {
     val rowSizes = tableColumns.map { it.columnSize }
     val builder = StringBuilder().apply {
         startTable(rowSizes)
@@ -35,8 +61,7 @@ fun buildTable(vararg tableColumns: TableColumn): String {
         rowSeparator(rowSizes)
         appendData(tableColumns)
         endTable(rowSizes)
-    }
-
+    }.appendPadToEveryRow(padStart)
     return builder.toString()
 }
 
@@ -110,3 +135,9 @@ private fun String.center(columnSize: Int): String? {
 }
 
 inline fun TableColumn.applyColorsUsing(mapper: (String) -> SystemOutColor) = copy(dataColor = data.map(mapper))
+
+private fun StringBuilder.appendPadToEveryRow(pad: Int) : StringBuilder = StringBuilder().also { builder ->
+    this.lines().forEach { line ->
+        builder.appendln(line.padStart(pad + line.length, PAD_CHAR))
+    }
+}

--- a/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
+++ b/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
@@ -55,7 +55,7 @@ fun buildTable(vararg tableColumns: TableColumn): String {
         startTable(rowSizes)
         tableColumns.map { DataWithSize(it.header, it.columnSize) }.apply { appendDataRow(this) }
         rowSeparator(rowSizes)
-        appendData(tableColumns)
+        appendData(tableColumns,rowSizes)
         endTable(rowSizes)
     }
     return builder.toString()
@@ -81,9 +81,8 @@ private fun StringBuilder.rowSeparator(rowSizes: List<Int>) {
     appendln()
 }
 
-private fun StringBuilder.appendData(tableColumns: Array<out TableColumn>) {
+private fun StringBuilder.appendData(tableColumns: Array<out TableColumn>, rowSizes: List<Int>) {
     val rowCount = (tableColumns.maxBy { it.data.size } ?: tableColumns.first()).data.size
-    val rowSizes = tableColumns.map { it.columnSize }
     (0 until rowCount)
         .map { rowNumber ->
             tableColumns.map {
@@ -96,7 +95,7 @@ private fun StringBuilder.appendData(tableColumns: Array<out TableColumn>) {
         }
         .forEachIndexed { index, list ->
             appendDataRow(list)
-            if (index < rowCount -1 && index % 2 != 0) rowSeparator(rowSizes)
+            if (index < rowCount -1 && list.first().data.isNotBlank()) rowSeparator(rowSizes)
         }
 }
 

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -17,14 +17,14 @@ fun main() {
     withGlobalExceptionHandling {
         CommandLine(Main()).execute(
 //            "--debug",
-            "firebase","test", "android",
-            "test-environment"
+            "firebase", "test", "android",
+            "test-environment",
 //            "--dry",
 //            "--dump-shards",
 //            "--output-style=single",
-//            "--full-junit-result",
-//            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
-//            "--project=$projectId"
+            "--full-junit-result",
+            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
+            "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"
         )
     }

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -18,14 +18,14 @@ fun main() {
     withGlobalExceptionHandling {
         CommandLine(Main()).execute(
 //            "--debug",
-            "firebase", "test",
-            "android", "run",
+            "firebase","test", "android",
+            "test-environment"
 //            "--dry",
 //            "--dump-shards",
-            "--output-style=single",
-            "--full-junit-result",
-            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
-            "--project=$projectId"
+//            "--output-style=single",
+//            "--full-junit-result",
+//            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
+//            "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"
         )
     }

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -18,13 +18,13 @@ fun main() {
         CommandLine(Main()).execute(
 //            "--debug",
             "firebase", "test", "android",
-            "test-environment",
+            "test-environment"
 //            "--dry",
 //            "--dump-shards",
 //            "--output-style=single",
-            "--full-junit-result",
-            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
-            "--project=$projectId"
+//            "--full-junit-result",
+//            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
+//            "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"
         )
     }

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -18,13 +18,13 @@ fun main() {
         CommandLine(Main()).execute(
 //            "--debug",
             "firebase", "test", "android",
-            "test-environment"
+            "test-environment",
 //            "--dry",
 //            "--dump-shards",
 //            "--output-style=single",
-//            "--full-junit-result",
-//            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
-//            "--project=$projectId"
+            "--full-junit-result",
+            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
+            "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"
         )
     }

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -12,7 +12,6 @@ fun main() {
         ?: "YOUR PROJECT ID"
     val quantity = "multiple"
     val type = "success"
-
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151
     withGlobalExceptionHandling {

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommandTest.kt
@@ -1,8 +1,5 @@
 package ftl.cli.firebase.test.networkprofiles
 
-import com.google.api.services.testing.model.NetworkConfiguration
-import com.google.api.services.testing.model.TrafficRule
-import ftl.environment.asPrintableTable
 import ftl.environment.networkConfigurationAsTable
 import ftl.gc.GcTesting
 import io.mockk.every

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommandTest.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.networkprofiles
 import com.google.api.services.testing.model.NetworkConfiguration
 import com.google.api.services.testing.model.TrafficRule
 import ftl.environment.asPrintableTable
+import ftl.environment.networkConfigurationAsTable
 import ftl.gc.GcTesting
 import io.mockk.every
 import io.mockk.mockkObject
@@ -33,17 +34,11 @@ class NetworkProfilesListCommandTest {
     @Test
     fun run() {
         mockkObject(GcTesting) {
-            val configurationsMock = listOf(NetworkConfiguration().apply {
-                id = "test"
-                upRule = TrafficRule()
-                downRule = TrafficRule()
-            })
             every {
-                GcTesting.networkConfiguration()
-            } returns configurationsMock
-            every { configurationsMock.asPrintableTable() } returns ""
+                networkConfigurationAsTable()
+            } returns ""
             CommandLine(NetworkProfilesListCommand()).execute()
-            verify { configurationsMock.asPrintableTable() }
+            verify { networkConfigurationAsTable() }
         }
     }
 }


### PR DESCRIPTION
Fixes #886 

## Test Plan
> How do we know the code works?

Command 

```

flank firebase test network-profiles list

```
and

```

flank network-profiles list

```

Should print table

```

┌────────────┬──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
│ PROFILE_ID │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.040s │   0.001    │                   │  16000.0  │       │
│    LTE     │ down │ 0.040s │   0.001    │                   │  16000.0  │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.060s │   0.0015   │                   │  4000.0   │       │
│  LTE-poor  │ down │ 0.060s │   0.0015   │                   │  4000.0   │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.060s │   0.001    │                   │  2000.0   │       │
│    HSPA    │ down │ 0.060s │   0.001    │                   │  4000.0   │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.100s │   0.0015   │                   │   500.0   │       │
│ HSPA-poor  │ down │ 0.100s │   0.0015   │                   │  1000.0   │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.060s │    0.02    │                   │  2000.0   │       │
│    UMTS    │ down │ 0.060s │    0.02    │                   │  2000.0   │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.090s │    0.04    │                   │   384.0   │       │
│ UMTS-poor  │ down │ 0.090s │    0.04    │                   │   384.0   │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.150s │    0.04    │                   │   384.0   │       │
│    EDGE    │ down │ 0.150s │    0.04    │                   │   384.0   │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.200s │    0.08    │                   │   96.0    │       │
│ EDGE-poor  │ down │ 0.200s │    0.08    │                   │   96.0    │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.300s │    0.08    │                   │   172.0   │       │
│    GPRS    │ down │ 0.300s │    0.08    │                   │   172.0   │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.500s │    0.1     │                   │   48.0    │       │
│ GPRS-poor  │ down │ 0.500s │    0.1     │                   │   48.0    │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.500s │    0.08    │                   │    9.6    │       │
│    GSM     │ down │ 0.500s │    0.08    │                   │    9.6    │       │
├────────────┼──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
│            │  up  │ 0.600s │    0.1     │                   │    2.4    │       │
│  GSM-poor  │ down │ 0.600s │    0.1     │                   │    2.4    │       │
└────────────┴──────┴────────┴────────────┴───────────────────┴───────────┴───────┘

```

also

```

flank firebase test android|ios test-environment 

```
should print this table at the end of the output. 

## WDYT

I added row separator to all tables to keep one style. In my opinion, it looks fine but on the other hand, the table with row separator takes more space. Tell me please what you think. Maybe we shouldn't add row separators to all tables.

## Checklist

- [X] Unit tested
- [X] release_notes.md updated
- [X] Printing network profiles on `flank firebase test network-profiles list`
- [X] Printing network profiles on `flank firebase test android|ios test-environment `
