### PR TITLE
905 - Print devices screen orientations

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,7 +8,7 @@
 - [#904](https://github.com/Flank/flank/pull/904) Added option to print provided software. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#906](https://github.com/Flank/flank/pull/906) Added option to print network profiles. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#908](https://github.com/Flank/flank/pull/908) Added option to print iOS available locales to test against.  ([piotradamczyk5](https://github.com/piotradamczyk5))
-- 
+- [#906](https://github.com/Flank/flank/pull/909) Added option to print iOS and Android screen orientations. ([adamfilipow92](https://github.com/adamfilipow92))
 -
 
 ## v20.07.0

--- a/test_runner/docs/ascii/flank.jar_-android-orientations-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-orientations-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-android-orientations-list - List of device orientations available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ android orientations list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of Android orientations available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-android-orientations.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-orientations.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--firebase-test-android - 
+-android-orientations - Information about available orientation versions
 
 // end::picocli-generated-man-section-name[]
 
@@ -12,37 +12,22 @@ flank.jar
 == Synopsis
 
 *flank.jar
- firebase test android* [COMMAND]
+ android orientations* [COMMAND]
 
 // end::picocli-generated-man-section-synopsis[]
 
 // tag::picocli-generated-man-section-description[]
 == Description
 
-
+Information about available orientation versions. For example prints list of available orientation versions
 
 // end::picocli-generated-man-section-description[]
 
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*run*::
-  Run tests on Firebase Test Lab
-
-*doctor*::
-  Verifies flank firebase is setup correctly
-
-*models*::
-  Information about available models
-
-*versions*::
-  Information about available software versions
-
-*test-environment*::
-  Print available devices, OS versions, provided software list and network configuration to test against
-
-*orientations*::
-  Information about available orientation versions
+*list*::
+  List of device orientations available to test against
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-android-orientations.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-orientations.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--android-orientations - Information about available orientation versions
+-android-orientations - Information about available orientations
 
 // end::picocli-generated-man-section-name[]
 
@@ -19,7 +19,7 @@ flank.jar
 // tag::picocli-generated-man-section-description[]
 == Description
 
-Information about available orientation versions. For example prints list of available orientation versions
+Prints list of available orientations
 
 // end::picocli-generated-man-section-description[]
 

--- a/test_runner/docs/ascii/flank.jar_-android.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android.adoc
@@ -41,6 +41,9 @@ flank.jar
 *test-environment*::
   Print available devices, OS versions, provided software list and network configuration to test against
 
+*orientations*::
+  Information about available orientation versions
+
 // end::picocli-generated-man-section-commands[]
 
 // end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-android.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android.adoc
@@ -42,7 +42,7 @@ flank.jar
   Print available devices, OS versions, provided software list and network configuration to test against
 
 *orientations*::
-  Information about available orientation versions
+  Information about available orientations
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-orientations-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-orientations-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-android-orientations-list - List of device orientations available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test android orientations list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of Android orientations available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-orientations.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-orientations.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--firebase-test-android-orientations - Information about available orientation versions
+-firebase-test-android-orientations - Information about available orientations
 
 // end::picocli-generated-man-section-name[]
 
@@ -19,7 +19,7 @@ flank.jar
 // tag::picocli-generated-man-section-description[]
 == Description
 
-Information about available orientation versions. For example prints list of available orientation versions
+Prints list of available orientations
 
 // end::picocli-generated-man-section-description[]
 

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-orientations.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-orientations.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--firebase-test-android - 
+-firebase-test-android-orientations - Information about available orientation versions
 
 // end::picocli-generated-man-section-name[]
 
@@ -12,37 +12,22 @@ flank.jar
 == Synopsis
 
 *flank.jar
- firebase test android* [COMMAND]
+ firebase test android orientations* [COMMAND]
 
 // end::picocli-generated-man-section-synopsis[]
 
 // tag::picocli-generated-man-section-description[]
 == Description
 
-
+Information about available orientation versions. For example prints list of available orientation versions
 
 // end::picocli-generated-man-section-description[]
 
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*run*::
-  Run tests on Firebase Test Lab
-
-*doctor*::
-  Verifies flank firebase is setup correctly
-
-*models*::
-  Information about available models
-
-*versions*::
-  Information about available software versions
-
-*test-environment*::
-  Print available devices, OS versions, provided software list and network configuration to test against
-
-*orientations*::
-  Information about available orientation versions
+*list*::
+  List of device orientations available to test against
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android.adoc
@@ -42,7 +42,7 @@ flank.jar
   Print available devices, OS versions, provided software list and network configuration to test against
 
 *orientations*::
-  Information about available orientation versions
+  Information about available orientations
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-locales-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-locales-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-ios-locales-list - Print current list of locales available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test ios locales list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of iOS locales available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-locales.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-locales.adoc
@@ -1,0 +1,34 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-ios-locales - Information about available locales on device
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test ios locales* [COMMAND]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Information about available locales on device. For example prints list of available locales to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-commands[]
+== Commands
+
+*list*::
+  Print current list of locales available to test against
+
+// end::picocli-generated-man-section-commands[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-orientations-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-orientations-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-firebase-test-ios-orientations-list - List of device orientations available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ firebase test ios orientations list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of iOS orientations available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-orientations.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-orientations.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--firebase-test-android - 
+-firebase-test-ios-orientations - Information about available orientation versions
 
 // end::picocli-generated-man-section-name[]
 
@@ -12,37 +12,22 @@ flank.jar
 == Synopsis
 
 *flank.jar
- firebase test android* [COMMAND]
+ firebase test ios orientations* [COMMAND]
 
 // end::picocli-generated-man-section-synopsis[]
 
 // tag::picocli-generated-man-section-description[]
 == Description
 
-
+Information about available orientation versions. For example prints list of available orientation versions
 
 // end::picocli-generated-man-section-description[]
 
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*run*::
-  Run tests on Firebase Test Lab
-
-*doctor*::
-  Verifies flank firebase is setup correctly
-
-*models*::
-  Information about available models
-
-*versions*::
-  Information about available software versions
-
-*test-environment*::
-  Print available devices, OS versions, provided software list and network configuration to test against
-
-*orientations*::
-  Information about available orientation versions
+*list*::
+  List of device orientations available to test against
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-orientations.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-orientations.adoc
@@ -19,7 +19,7 @@ flank.jar
 // tag::picocli-generated-man-section-description[]
 == Description
 
-Information about available orientation versions. For example prints list of available orientation versions
+Prints list of available orientations
 
 // end::picocli-generated-man-section-description[]
 

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-run.adoc
@@ -154,14 +154,14 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
-*--test*=_<test>_::
-  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
-
 *--xctestrun-file*=_<xctestrunFile>_::
   The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
 
 *--xcode-version*=_<xcodeVersion>_::
   The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
+
+*--test*=_<test>_::
+  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
 
 *--test-targets*=_<testTargets>_[,_<testTargets>_...]::
   A list of one or more test method names to run (default: run all test targets).

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-run.adoc
@@ -154,14 +154,14 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
+*--test*=_<test>_::
+  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
+
 *--xctestrun-file*=_<xctestrunFile>_::
   The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
 
 *--xcode-version*=_<xcodeVersion>_::
   The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
-
-*--test*=_<test>_::
-  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
 
 *--test-targets*=_<testTargets>_[,_<testTargets>_...]::
   A list of one or more test method names to run (default: run all test targets).

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios.adoc
@@ -44,6 +44,9 @@ flank.jar
 *test-environment*::
   Print available devices, OS versions, locales, provided software list and network configuration to test against
 
+*orientations*::
+  Information about available orientation versions
+
 // end::picocli-generated-man-section-commands[]
 
 // end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-ios-locales-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-locales-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-ios-locales-list - Print current list of locales available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ ios locales list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of iOS locales available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-ios-locales.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-locales.adoc
@@ -1,0 +1,34 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-ios-locales - Information about available locales on device
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ ios locales* [COMMAND]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Information about available locales on device. For example prints list of available locales to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-commands[]
+== Commands
+
+*list*::
+  Print current list of locales available to test against
+
+// end::picocli-generated-man-section-commands[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-ios-orientations-list.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-orientations-list.adoc
@@ -1,0 +1,37 @@
+// tag::picocli-generated-full-manpage[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+flank.jar
+-ios-orientations-list - List of device orientations available to test against
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*flank.jar
+ ios orientations list* [*-h*] [*-c*=_<configPath>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Print current list of iOS orientations available to test against
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-c*, *--config*=_<configPath>_::
+  YAML config file path
+
+*-h*, *--help*::
+  Prints this help message
+
+// end::picocli-generated-man-section-options[]
+
+// end::picocli-generated-full-manpage[]

--- a/test_runner/docs/ascii/flank.jar_-ios-orientations.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-orientations.adoc
@@ -4,7 +4,7 @@
 == Name
 
 flank.jar
--firebase-test-android - 
+-ios-orientations - Information about available orientation versions
 
 // end::picocli-generated-man-section-name[]
 
@@ -12,37 +12,22 @@ flank.jar
 == Synopsis
 
 *flank.jar
- firebase test android* [COMMAND]
+ ios orientations* [COMMAND]
 
 // end::picocli-generated-man-section-synopsis[]
 
 // tag::picocli-generated-man-section-description[]
 == Description
 
-
+Information about available orientation versions. For example prints list of available orientation versions
 
 // end::picocli-generated-man-section-description[]
 
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*run*::
-  Run tests on Firebase Test Lab
-
-*doctor*::
-  Verifies flank firebase is setup correctly
-
-*models*::
-  Information about available models
-
-*versions*::
-  Information about available software versions
-
-*test-environment*::
-  Print available devices, OS versions, provided software list and network configuration to test against
-
-*orientations*::
-  Information about available orientation versions
+*list*::
+  List of device orientations available to test against
 
 // end::picocli-generated-man-section-commands[]
 

--- a/test_runner/docs/ascii/flank.jar_-ios-orientations.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-orientations.adoc
@@ -19,7 +19,7 @@ flank.jar
 // tag::picocli-generated-man-section-description[]
 == Description
 
-Information about available orientation versions. For example prints list of available orientation versions
+Prints list of available orientations
 
 // end::picocli-generated-man-section-description[]
 

--- a/test_runner/docs/ascii/flank.jar_-ios-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-run.adoc
@@ -146,14 +146,14 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
-*--test*=_<test>_::
-  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
-
 *--xctestrun-file*=_<xctestrunFile>_::
   The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
 
 *--xcode-version*=_<xcodeVersion>_::
   The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
+
+*--test*=_<test>_::
+  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
 
 *--test-targets*=_<testTargets>_[,_<testTargets>_...]::
   A list of one or more test method names to run (default: run all test targets).

--- a/test_runner/docs/ascii/flank.jar_-ios-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-run.adoc
@@ -146,14 +146,14 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
+*--test*=_<test>_::
+  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
+
 *--xctestrun-file*=_<xctestrunFile>_::
   The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
 
 *--xcode-version*=_<xcodeVersion>_::
   The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
-
-*--test*=_<test>_::
-  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
 
 *--test-targets*=_<testTargets>_[,_<testTargets>_...]::
   A list of one or more test method names to run (default: run all test targets).

--- a/test_runner/docs/ascii/flank.jar_-ios.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios.adoc
@@ -44,6 +44,9 @@ flank.jar
 *test-environment*::
   Print available devices, OS versions, locales, provided software list and network configuration to test against
 
+*orientations*::
+  Information about available orientation versions
+
 // end::picocli-generated-man-section-commands[]
 
 // end::picocli-generated-full-manpage[]

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -3,6 +3,7 @@ package ftl.android
 import com.google.api.services.testing.model.AndroidDevice
 import com.google.api.services.testing.model.AndroidDeviceCatalog
 import ftl.environment.android.asPrintableTable
+import ftl.environment.common.asPrintableTable
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -2,7 +2,7 @@ package ftl.android
 
 import com.google.api.services.testing.model.AndroidDevice
 import com.google.api.services.testing.model.AndroidDeviceCatalog
-import ftl.environment.asPrintableTable
+import ftl.environment.android.asPrintableTable
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
@@ -26,6 +26,8 @@ object AndroidCatalog {
     fun devicesCatalogAsTable(projectId: String) = deviceCatalog(projectId).models.asPrintableTable()
 
     fun supportedVersionsAsTable(projectId: String) = deviceCatalog(projectId).versions.asPrintableTable()
+
+    fun supportedOrientationsAsTable(projectId: String) = deviceCatalog(projectId).runtimeConfiguration.orientations.asPrintableTable()
 
     fun androidModelIds(projectId: String) =
         modelMap.getOrPut(projectId) { deviceCatalog(projectId).models.map { it.id } }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/AndroidCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/AndroidCommand.kt
@@ -4,6 +4,7 @@ import ftl.cli.firebase.test.android.AndroidDoctorCommand
 import ftl.cli.firebase.test.android.AndroidRunCommand
 import ftl.cli.firebase.test.android.AndroidTestEnvironmentCommand
 import ftl.cli.firebase.test.android.models.AndroidModelsCommand
+import ftl.cli.firebase.test.android.orientations.AndroidOrientationsCommand
 import ftl.cli.firebase.test.android.versions.AndroidVersionsCommand
 import picocli.CommandLine
 import picocli.CommandLine.Command
@@ -16,7 +17,8 @@ import picocli.CommandLine.Command
         AndroidDoctorCommand::class,
         AndroidModelsCommand::class,
         AndroidVersionsCommand::class,
-        AndroidTestEnvironmentCommand::class
+        AndroidTestEnvironmentCommand::class,
+        AndroidOrientationsCommand::class
     ],
     usageHelpAutoWidth = true
 )

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/IosCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/IosCommand.kt
@@ -18,7 +18,7 @@ import picocli.CommandLine.Command
         IosDoctorCommand::class,
         IosModelsCommand::class,
         IosVersionsCommand::class,
-        IosLocalesCommand::class,,
+        IosLocalesCommand::class,
         IosTestEnvironmentCommand::class,
         IosOrientationsCommand::class
     ],

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/IosCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/IosCommand.kt
@@ -5,6 +5,7 @@ import ftl.cli.firebase.test.ios.IosRunCommand
 import ftl.cli.firebase.test.ios.IosTestEnvironmentCommand
 import ftl.cli.firebase.test.ios.configuration.IosLocalesCommand
 import ftl.cli.firebase.test.ios.models.IosModelsCommand
+import ftl.cli.firebase.test.ios.orientations.IosOrientationsCommand
 import ftl.cli.firebase.test.ios.versions.IosVersionsCommand
 import picocli.CommandLine
 import picocli.CommandLine.Command
@@ -17,8 +18,9 @@ import picocli.CommandLine.Command
         IosDoctorCommand::class,
         IosModelsCommand::class,
         IosVersionsCommand::class,
-        IosLocalesCommand::class,
-        IosTestEnvironmentCommand::class
+        IosLocalesCommand::class,,
+        IosTestEnvironmentCommand::class,
+        IosOrientationsCommand::class
     ],
     usageHelpAutoWidth = true
 )

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
@@ -1,6 +1,7 @@
 package ftl.cli.firebase.test.android
 
 import ftl.android.AndroidCatalog.devicesCatalogAsTable
+import ftl.android.AndroidCatalog.supportedOrientationsAsTable
 import ftl.android.AndroidCatalog.supportedVersionsAsTable
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
@@ -22,10 +23,12 @@ import java.nio.file.Paths
 )
 class AndroidTestEnvironmentCommand : Runnable {
     override fun run() {
-        println(devicesCatalogAsTable(AndroidArgs.load(Paths.get(configPath)).project))
-        println(supportedVersionsAsTable(AndroidArgs.load(Paths.get(configPath)).project))
+        val projectId = AndroidArgs.load(Paths.get(configPath)).project
+        println(devicesCatalogAsTable(projectId))
+        println(supportedVersionsAsTable(projectId))
         println(providedSoftwareAsTable())
         println(networkConfigurationAsTable())
+        println(supportedOrientationsAsTable(projectId))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsCommand.kt
@@ -1,0 +1,21 @@
+package ftl.cli.firebase.test.android.orientations
+
+import picocli.CommandLine
+
+@CommandLine.Command(
+    name = "orientations",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["Information about available orientation versions"],
+    description = ["Information about available orientation versions. For example prints list of available orientation versions"],
+    subcommands = [AndroidOrientationsListCommand::class],
+    usageHelpAutoWidth = true
+)
+class AndroidOrientationsCommand : Runnable {
+    override fun run() {
+        CommandLine.usage(AndroidOrientationsCommand(), System.out)
+    }
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsCommand.kt
@@ -9,8 +9,8 @@ import picocli.CommandLine
     descriptionHeading = "%n@|bold,underline Description:|@%n%n",
     parameterListHeading = "%n@|bold,underline Parameters:|@%n",
     optionListHeading = "%n@|bold,underline Options:|@%n",
-    header = ["Information about available orientation versions"],
-    description = ["Information about available orientation versions. For example prints list of available orientation versions"],
+    header = ["Information about available orientations"],
+    description = ["Prints list of available orientations"],
     subcommands = [AndroidOrientationsListCommand::class],
     usageHelpAutoWidth = true
 )

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.android.orientations
 import picocli.CommandLine
 
 @CommandLine.Command(
-    name = "orientations",
+    name = "screen-orientations",
     headerHeading = "",
     synopsisHeading = "%n",
     descriptionHeading = "%n@|bold,underline Description:|@%n%n",

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
@@ -1,0 +1,30 @@
+package ftl.cli.firebase.test.android.orientations
+
+import ftl.android.AndroidCatalog
+import ftl.args.AndroidArgs
+import ftl.config.FtlConstants
+import picocli.CommandLine
+import java.nio.file.Paths
+
+@CommandLine.Command(
+    name = "list",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["List of device orientations available to test against"],
+    description = ["Print current list of Android orientations available to test against"],
+    usageHelpAutoWidth = true
+)
+class AndroidOrientationsListCommand : Runnable {
+    override fun run() {
+        println(AndroidCatalog.supportedOrientationsAsTable(AndroidArgs.load(Paths.get(configPath)).project))
+    }
+
+    @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = FtlConstants.defaultAndroidConfig
+
+    @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["Prints this help message"])
+    var usageHelpRequested: Boolean = false
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
@@ -7,6 +7,7 @@ import ftl.environment.networkConfigurationAsTable
 import ftl.ios.IosCatalog.devicesCatalogAsTable
 import ftl.ios.IosCatalog.localesAsTable
 import ftl.ios.IosCatalog.softwareVersionsAsTable
+import ftl.ios.IosCatalog.supportedOrientationsAsTable
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -29,6 +30,7 @@ class IosTestEnvironmentCommand : Runnable {
         println(localesAsTable(projectId))
         println(providedSoftwareAsTable())
         println(networkConfigurationAsTable())
+        println(supportedOrientationsAsTable(projectId))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsCommand.kt
@@ -10,7 +10,7 @@ import picocli.CommandLine
     parameterListHeading = "%n@|bold,underline Parameters:|@%n",
     optionListHeading = "%n@|bold,underline Options:|@%n",
     header = ["Information about available orientation versions"],
-    description = ["Information about available orientation versions. For example prints list of available orientation versions"],
+    description = ["Prints list of available orientations"],
     subcommands = [IosOrientationsListCommand::class],
     usageHelpAutoWidth = true
 )

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.ios.orientations
 import picocli.CommandLine
 
 @CommandLine.Command(
-    name = "orientations",
+    name = "screen-orientations",
     headerHeading = "",
     synopsisHeading = "%n",
     descriptionHeading = "%n@|bold,underline Description:|@%n%n",

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsCommand.kt
@@ -1,0 +1,21 @@
+package ftl.cli.firebase.test.ios.orientations
+
+import picocli.CommandLine
+
+@CommandLine.Command(
+    name = "orientations",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["Information about available orientation versions"],
+    description = ["Information about available orientation versions. For example prints list of available orientation versions"],
+    subcommands = [IosOrientationsListCommand::class],
+    usageHelpAutoWidth = true
+)
+class IosOrientationsCommand : Runnable {
+    override fun run() {
+        CommandLine.usage(IosOrientationsCommand(), System.out)
+    }
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsListCommand.kt
@@ -1,0 +1,30 @@
+package ftl.cli.firebase.test.ios.orientations
+
+import ftl.args.IosArgs
+import ftl.config.FtlConstants
+import ftl.ios.IosCatalog
+import picocli.CommandLine
+import java.nio.file.Paths
+
+@CommandLine.Command(
+    name = "list",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["List of device orientations available to test against"],
+    description = ["Print current list of iOS orientations available to test against"],
+    usageHelpAutoWidth = true
+)
+class IosOrientationsListCommand : Runnable {
+    override fun run() {
+        println(IosCatalog.supportedOrientationsAsTable(IosArgs.load(Paths.get(configPath)).project))
+    }
+
+    @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = FtlConstants.defaultIosConfig
+
+    @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["Prints this help message"])
+    var usageHelpRequested: Boolean = false
+}

--- a/test_runner/src/main/kotlin/ftl/environment/NetworkConfigurationCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/NetworkConfigurationCatalog.kt
@@ -1,5 +1,6 @@
 package ftl.environment
 
+import ftl.environment.common.asPrintableTable
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 

--- a/test_runner/src/main/kotlin/ftl/environment/ProvidedSoftwareCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ProvidedSoftwareCatalog.kt
@@ -1,5 +1,6 @@
 package ftl.environment
 
+import ftl.environment.common.asTable
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 

--- a/test_runner/src/main/kotlin/ftl/environment/android/ListAndroidDevices.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/android/ListAndroidDevices.kt
@@ -1,6 +1,19 @@
-package ftl.environment
+package ftl.environment.android
 
 import com.google.api.services.testing.model.AndroidModel
+import ftl.environment.FORM
+import ftl.environment.MAKE
+import ftl.environment.MODEL_ID
+import ftl.environment.MODEL_NAME
+import ftl.environment.OS_VERSION_IDS
+import ftl.environment.PHYSICAL_DEVICE
+import ftl.environment.RESOLUTION
+import ftl.environment.TAGS
+import ftl.environment.TestEnvironmentInfo
+import ftl.environment.createTableColumnFor
+import ftl.environment.getOrCreateList
+import ftl.environment.orUnknown
+import ftl.environment.tagToSystemOutColorMapper
 import ftl.util.SystemOutColor
 import ftl.util.applyColorsUsing
 import ftl.util.buildTable

--- a/test_runner/src/main/kotlin/ftl/environment/android/ListAndroidSofwareVersions.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/android/ListAndroidSofwareVersions.kt
@@ -1,7 +1,14 @@
-package ftl.environment
+package ftl.environment.android
 
 import com.google.api.services.testing.model.AndroidVersion
 import com.google.api.services.testing.model.Date
+import ftl.environment.OS_VERSION_ID
+import ftl.environment.TAGS
+import ftl.environment.TestEnvironmentInfo
+import ftl.environment.createTableColumnFor
+import ftl.environment.getOrCreateList
+import ftl.environment.orUnknown
+import ftl.environment.tagToSystemOutColorMapper
 import ftl.reports.api.twoDigitString
 import ftl.util.applyColorsUsing
 import ftl.util.buildTable

--- a/test_runner/src/main/kotlin/ftl/environment/common/ListNetworkConfiguration.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/common/ListNetworkConfiguration.kt
@@ -1,6 +1,9 @@
-package ftl.environment
+package ftl.environment.common
 
 import com.google.api.services.testing.model.NetworkConfiguration
+import ftl.environment.TestEnvironmentInfo
+import ftl.environment.createTableColumnFor
+import ftl.environment.getOrCreateList
 import ftl.util.TableStyle
 import ftl.util.buildTable
 

--- a/test_runner/src/main/kotlin/ftl/environment/common/ListOrientations.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/common/ListOrientations.kt
@@ -1,0 +1,30 @@
+package ftl.environment.common
+
+import com.google.api.services.testing.model.Orientation
+import ftl.environment.TestEnvironmentInfo
+import ftl.environment.createTableColumnFor
+import ftl.environment.getOrCreateList
+import ftl.environment.tagToSystemOutColorMapper
+import ftl.util.applyColorsUsing
+import ftl.util.buildTable
+
+fun List<Orientation>.asPrintableTable() = createOrientationsDetails().createOrientationsTable()
+
+private fun List<Orientation>.createOrientationsDetails() = fold(mutableMapOf<String, MutableList<String>>()) { orientationInfo, orientation ->
+    orientationInfo.apply {
+        getOrCreateList(ORIENTATION_ID).add(orientation.id.orEmpty())
+        getOrCreateList(NAME).add(orientation.name.orEmpty())
+        getOrCreateList(TAG).add(orientation.tags?.joinToString(TAG_SEPARATOR).orEmpty())
+    }
+}
+
+private fun TestEnvironmentInfo.createOrientationsTable() = buildTable(
+    createTableColumnFor(ORIENTATION_ID),
+    createTableColumnFor(NAME),
+    createTableColumnFor(TAG).applyColorsUsing(tagToSystemOutColorMapper)
+)
+
+private const val ORIENTATION_ID = "ORIENTATION_ID"
+private const val NAME = "NAME"
+private const val TAG = "TAG"
+private const val TAG_SEPARATOR = ","

--- a/test_runner/src/main/kotlin/ftl/environment/common/ListProvidedSoftware.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/common/ListProvidedSoftware.kt
@@ -1,4 +1,4 @@
-package ftl.environment
+package ftl.environment.common
 
 import com.google.api.services.testing.model.ProvidedSoftwareCatalog
 import ftl.util.TableColumn

--- a/test_runner/src/main/kotlin/ftl/environment/ios/ListIOsDevices.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ios/ListIOsDevices.kt
@@ -1,6 +1,16 @@
-package ftl.environment
+package ftl.environment.ios
 
 import com.google.api.services.testing.model.IosModel
+import ftl.environment.MODEL_ID
+import ftl.environment.MODEL_NAME
+import ftl.environment.OS_VERSION_IDS
+import ftl.environment.RESOLUTION
+import ftl.environment.TAGS
+import ftl.environment.TestEnvironmentInfo
+import ftl.environment.createTableColumnFor
+import ftl.environment.getOrCreateList
+import ftl.environment.orUnknown
+import ftl.environment.tagToSystemOutColorMapper
 import ftl.util.applyColorsUsing
 import ftl.util.buildTable
 

--- a/test_runner/src/main/kotlin/ftl/environment/ios/ListIOsSofwareVersions.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ios/ListIOsSofwareVersions.kt
@@ -1,6 +1,13 @@
-package ftl.environment
+package ftl.environment.ios
 
 import com.google.api.services.testing.model.IosVersion
+import ftl.environment.OS_VERSION_ID
+import ftl.environment.TAGS
+import ftl.environment.TestEnvironmentInfo
+import ftl.environment.createTableColumnFor
+import ftl.environment.getOrCreateList
+import ftl.environment.orUnknown
+import ftl.environment.tagToSystemOutColorMapper
 import ftl.util.applyColorsUsing
 import ftl.util.buildTable
 

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -1,7 +1,7 @@
 package ftl.ios
 
 import com.google.api.services.testing.model.IosDeviceCatalog
-import ftl.environment.asPrintableTable
+import ftl.environment.android.asPrintableTable
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
@@ -19,6 +19,8 @@ object IosCatalog {
     fun softwareVersionsAsTable(projectId: String) = iosDeviceCatalog(projectId).versions.asPrintableTable()
 
     fun localesAsTable(projectId: String) = iosDeviceCatalog(projectId).runtimeConfiguration.locales.asPrintableTable()
+    
+    fun supportedOrientationsAsTable(projectId: String) = iosDeviceCatalog(projectId).runtimeConfiguration.orientations.asPrintableTable()
 
     fun supportedXcode(version: String, projectId: String) = xcodeVersions(projectId).contains(version)
 

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -2,6 +2,9 @@ package ftl.ios
 
 import com.google.api.services.testing.model.IosDeviceCatalog
 import ftl.environment.android.asPrintableTable
+import ftl.environment.asPrintableTable
+import ftl.environment.common.asPrintableTable
+import ftl.environment.ios.asPrintableTable
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
@@ -19,7 +22,7 @@ object IosCatalog {
     fun softwareVersionsAsTable(projectId: String) = iosDeviceCatalog(projectId).versions.asPrintableTable()
 
     fun localesAsTable(projectId: String) = iosDeviceCatalog(projectId).runtimeConfiguration.locales.asPrintableTable()
-    
+
     fun supportedOrientationsAsTable(projectId: String) = iosDeviceCatalog(projectId).runtimeConfiguration.orientations.asPrintableTable()
 
     fun supportedXcode(version: String, projectId: String) = xcodeVersions(projectId).contains(version)

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -17,8 +17,8 @@ fun main() {
     withGlobalExceptionHandling {
         CommandLine(Main()).execute(
 //            "--debug",
-            "firebase", "test", "android",
-            "orientations", "list",
+            "firebase", "test", "ios",
+            "test-environment",
 //            "--dry",
 //            "--dump-shards",
 //            "--output-style=single",

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -18,7 +18,7 @@ fun main() {
         CommandLine(Main()).execute(
 //            "--debug",
             "firebase", "test", "android",
-            "test-environment",
+            "orientations", "list",
 //            "--dry",
 //            "--dump-shards",
 //            "--output-style=single",

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/orientation/AndroidOrientationCommandListTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/orientation/AndroidOrientationCommandListTest.kt
@@ -1,0 +1,28 @@
+package ftl.cli.firebase.test.android.orientation
+
+import com.google.common.truth.Truth
+import ftl.android.AndroidCatalog
+import ftl.cli.firebase.test.android.orientations.AndroidOrientationsListCommand
+import ftl.cli.firebase.test.android.versions.AndroidVersionsListCommand
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Test
+import picocli.CommandLine
+
+class AndroidOrientationCommandListTest {
+    @Test
+    fun `should execute ListOrientations AndroidCatalog supportedOrientationsAsTable when run AndroidOrientationsListCommand`() {
+        mockkObject(AndroidCatalog) {
+            CommandLine(AndroidOrientationsListCommand()).execute()
+            verify { AndroidCatalog.supportedOrientationsAsTable(any()) }
+        }
+    }
+
+    @Test
+    fun `AndroidOrientationCommandListTest should parse config`() {
+        val cmd = AndroidVersionsListCommand()
+        CommandLine(cmd).parseArgs("--config=a")
+
+        Truth.assertThat(cmd.configPath).isEqualTo("a")
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationCommandListTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationCommandListTest.kt
@@ -1,17 +1,16 @@
-package ftl.cli.firebase.test.android.orientation
+package ftl.cli.firebase.test.android.orientations
 
-import com.google.common.truth.Truth
 import ftl.android.AndroidCatalog
-import ftl.cli.firebase.test.android.orientations.AndroidOrientationsListCommand
 import ftl.cli.firebase.test.android.versions.AndroidVersionsListCommand
 import io.mockk.mockkObject
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import picocli.CommandLine
 
 class AndroidOrientationCommandListTest {
     @Test
-    fun `should execute ListOrientations AndroidCatalog supportedOrientationsAsTable when run AndroidOrientationsListCommand`() {
+    fun `should execute AndroidCatalog supportedOrientationsAsTable when run AndroidOrientationsListCommand`() {
         mockkObject(AndroidCatalog) {
             CommandLine(AndroidOrientationsListCommand()).execute()
             verify { AndroidCatalog.supportedOrientationsAsTable(any()) }
@@ -23,6 +22,6 @@ class AndroidOrientationCommandListTest {
         val cmd = AndroidVersionsListCommand()
         CommandLine(cmd).parseArgs("--config=a")
 
-        Truth.assertThat(cmd.configPath).isEqualTo("a")
+        assertEquals(cmd.configPath, "a")
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationCommandListTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationCommandListTest.kt
@@ -1,0 +1,26 @@
+package ftl.cli.firebase.test.ios.orientations
+
+import ftl.ios.IosCatalog
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import picocli.CommandLine
+
+class IosOrientationCommandListTest {
+    @Test
+    fun `should execute IosCatalog supportedOrientationsAsTable when run IosOrientationsListCommand`() {
+        mockkObject(IosCatalog) {
+            CommandLine(IosOrientationsListCommand()).execute()
+            verify { IosCatalog.supportedOrientationsAsTable(any()) }
+        }
+    }
+
+    @Test
+    fun `IosOrientationsListCommand should parse config`() {
+        val cmd = IosOrientationsListCommand()
+        CommandLine(cmd).parseArgs("--config=a")
+
+        assertEquals(cmd.configPath, "a")
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommandTest.kt
@@ -19,7 +19,7 @@ class NetworkProfilesListCommandTest {
         mockkStatic(
             "ftl.http.ExecuteWithRetryKt",
             "ftl.run.common.PrettyPrintKt",
-            "ftl.environment.ListNetworkConfigurationKt"
+            "ftl.environment.common.ListNetworkConfigurationKt"
         )
     }
 


### PR DESCRIPTION
Fixes #905 

## Test Plan
> How do we know the code works?

1. Execute ` flank firebase test ios|android test-environment ` should print on bottom screen orientation table

2. Execute ` flank firebase test ios|android screen-orientations list ` should print screen orientation table

3. Execute ` flank ios|android screen-orientations list ` should print screen orientation table

```

┌────────────────┬───────────┬─────────┐
│ ORIENTATION_ID │   NAME    │   TAG   │
├────────────────┼───────────┼─────────┤
│   landscape    │ Landscape │         │
│    portrait    │ Portrait  │ default │
│    default     │  Default  │         │
└────────────────┴───────────┴─────────┘

```

## Checklist

- [X] Documented
- [X] Unit tested
- [X] release_notes.md updated
- [X] Solution for iOS
- [X] Solution for Android