### PR TITLE
Flank should reflect gcloud exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,16 @@ Smart Flank
 
 ### Exit Codes
 
-Exit code | Description
- --       |         -- |
-0         | All tests passed
-1         | All matrices finished but at least one test failed or inconclusive.
-2         | Usually indicates missing or wrong usage of flags, incorrect parameters, errors in config files.
-3         | At least one matrix not finished (usually a FTL internal error) or unexpected error occurred.
+Exit code  | Description
+ --        |         -- |
+0          | All tests passed
+1          | A general failure occurred. Possible causes include: a filename that does not exist or an HTTP/network error.
+2          | Usually indicates missing or wrong usage of flags, incorrect parameters, errors in config files.
+10         | At least one matrix not finished (usually a FTL internal error) or unexpected error occurred.
+15         | Firebase Test Lab could not determine if the test matrix passed or failed, because of an unexpected error.
+18         | The test environment for this test execution is not supported because of incompatible test dimensions. This error might occur if the selected Android API level is not supported by the selected device type.
+19         | The test matrix was canceled by the user.
+20         | A test infrastructure error occurred.
 
 ## CLI
 

--- a/docs/exit_codes_and_exceptions.md
+++ b/docs/exit_codes_and_exceptions.md
@@ -1,0 +1,12 @@
+# Flank exit codes and exceptions
+
+Exit code  | Returned by exception | Description
+ --        |                    -- |            -- |
+0          | | All tests passed
+1          | FlankGeneralError, FlankTimeoutError | A general failure occurred. Possible causes include: a filename that does not exist or an HTTP/network error.
+2          | FlankConfigurationError, YmlValidationError | Usually indicates missing or wrong usage of flags, incorrect parameters, errors in config files.
+10         | FailedMatrixError | At least one matrix not finished (usually a FTL internal error) or unexpected error occurred.
+15         | FTLError | Firebase Test Lab could not determine if the test matrix passed or failed, because of an unexpected error.
+18         | IncompatibleTestDimensionError | The test environment for this test execution is not supported because of incompatible test dimensions. This error might occur if the selected Android API level is not supported by the selected device type.
+19         | MatrixCanceledError | The test matrix was canceled by the user.
+20         | InfrastructureError | A test infrastructure error occurred.

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,6 +16,8 @@
 - [#915](https://github.com/Flank/flank/pull/915) Update virtual devices sharding limit. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#920](https://github.com/Flank/flank/pull/920) Improve .yml validation on `doctor` command. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#934](https://github.com/Flank/flank/pull/934) Delete incorrect flank snapshot labels. ([piotradamczyk5](https://github.com/piotradamczyk5))
+- [#926](https://github.com/Flank/flank/pull/926) Flank should reflect gcloud exit codes. ([adamfilipow92](https://github.com/adamfilipow92))
+-
 -
 -
 

--- a/test_runner/src/main/kotlin/ftl/args/ArgsFileVisitor.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsFileVisitor.kt
@@ -1,6 +1,6 @@
 package ftl.args
 
-import ftl.util.FlankGeneralFailure
+import ftl.util.FlankCommonException
 import java.io.IOException
 import java.nio.file.FileSystems
 import java.nio.file.FileVisitOption
@@ -46,7 +46,7 @@ class ArgsFileVisitor(glob: String) : SimpleFileVisitor<Path>() {
         val realPath = try {
             beforeGlob.toRealPath(LinkOption.NOFOLLOW_LINKS)
         } catch (e: java.nio.file.NoSuchFileException) {
-            throw FlankGeneralFailure("Failed to resolve path $searchPath")
+            throw FlankCommonException("Failed to resolve path $searchPath")
         }
 
         val searchDepth = if (searchString.contains(RECURSE)) Integer.MAX_VALUE else 1

--- a/test_runner/src/main/kotlin/ftl/args/ArgsFileVisitor.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsFileVisitor.kt
@@ -1,6 +1,6 @@
 package ftl.args
 
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import java.io.IOException
 import java.nio.file.FileSystems
 import java.nio.file.FileVisitOption
@@ -46,7 +46,7 @@ class ArgsFileVisitor(glob: String) : SimpleFileVisitor<Path>() {
         val realPath = try {
             beforeGlob.toRealPath(LinkOption.NOFOLLOW_LINKS)
         } catch (e: java.nio.file.NoSuchFileException) {
-            throw FlankCommonException("Failed to resolve path $searchPath")
+            throw FlankGeneralError("Failed to resolve path $searchPath")
         }
 
         val searchDepth = if (searchString.contains(RECURSE)) Integer.MAX_VALUE else 1

--- a/test_runner/src/main/kotlin/ftl/args/ArgsFileVisitor.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsFileVisitor.kt
@@ -1,6 +1,5 @@
 package ftl.args
 
-import ftl.util.FlankFatalError
 import ftl.util.FlankGeneralFailure
 import java.io.IOException
 import java.nio.file.FileSystems

--- a/test_runner/src/main/kotlin/ftl/args/ArgsFileVisitor.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsFileVisitor.kt
@@ -1,6 +1,7 @@
 package ftl.args
 
 import ftl.util.FlankFatalError
+import ftl.util.FlankGeneralFailure
 import java.io.IOException
 import java.nio.file.FileSystems
 import java.nio.file.FileVisitOption
@@ -46,7 +47,7 @@ class ArgsFileVisitor(glob: String) : SimpleFileVisitor<Path>() {
         val realPath = try {
             beforeGlob.toRealPath(LinkOption.NOFOLLOW_LINKS)
         } catch (e: java.nio.file.NoSuchFileException) {
-            throw FlankFatalError("Failed to resolve path $searchPath")
+            throw FlankGeneralFailure("Failed to resolve path $searchPath")
         }
 
         val searchDepth = if (searchString.contains(RECURSE)) Integer.MAX_VALUE else 1

--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -25,6 +25,7 @@ import ftl.shard.createShardsByShardCount
 import ftl.shard.shardCountByTime
 import ftl.shard.stringShards
 import ftl.util.FlankFatalError
+import ftl.util.FlankGeneralFailure
 import ftl.util.FlankTestMethod
 import ftl.util.assertNotEmpty
 import java.io.File
@@ -82,7 +83,7 @@ object ArgsHelper {
         if (filePaths.size > 1) {
             throw FlankFatalError("'$file' ($filePath) matches multiple files: $filePaths")
         } else if (filePaths.isEmpty()) {
-            throw FlankFatalError("'$file' not found ($filePath)")
+            throw FlankGeneralFailure("'$file' not found ($filePath)")
         }
 
         return filePaths.first().toAbsolutePath().normalize().toString()

--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -25,7 +25,7 @@ import ftl.shard.createShardsByShardCount
 import ftl.shard.shardCountByTime
 import ftl.shard.stringShards
 import ftl.util.FlankFatalError
-import ftl.util.FlankGeneralFailure
+import ftl.util.FlankCommonException
 import ftl.util.FlankTestMethod
 import ftl.util.assertNotEmpty
 import java.io.File
@@ -43,7 +43,7 @@ object ArgsHelper {
 
     fun assertFileExists(file: String, name: String) {
         if (!File(file).exists()) {
-            throw FlankFatalError("'$file' $name doesn't exist")
+            throw FlankCommonException("'$file' $name doesn't exist")
         }
     }
 
@@ -81,9 +81,9 @@ object ArgsHelper {
 
         val filePaths = walkFileTree(file)
         if (filePaths.size > 1) {
-            throw FlankFatalError("'$file' ($filePath) matches multiple files: $filePaths")
+            throw FlankCommonException("'$file' ($filePath) matches multiple files: $filePaths")
         } else if (filePaths.isEmpty()) {
-            throw FlankGeneralFailure("'$file' not found ($filePath)")
+            throw FlankCommonException("'$file' not found ($filePath)")
         }
 
         return filePaths.first().toAbsolutePath().normalize().toString()
@@ -91,14 +91,14 @@ object ArgsHelper {
 
     fun assertGcsFileExists(uri: String) {
         if (!uri.startsWith(GCS_PREFIX)) {
-            throw IllegalArgumentException("must start with $GCS_PREFIX uri: $uri")
+            throw FlankFatalError("must start with $GCS_PREFIX uri: $uri")
         }
 
         val gcsURI = URI.create(uri)
         val bucket = gcsURI.authority
         val path = gcsURI.path.drop(1) // Drop leading slash
 
-        GcStorage.storage.get(bucket, path) ?: throw FlankFatalError("The file at '$uri' does not exist")
+        GcStorage.storage.get(bucket, path) ?: throw FlankCommonException("The file at '$uri' does not exist")
     }
 
     fun validateTestMethods(
@@ -123,7 +123,7 @@ object ArgsHelper {
     // Due to permission issues, the user may not be able to list or create buckets.
     fun createGcsBucket(projectId: String, bucket: String): String {
         if (bucket.isEmpty()) return GcToolResults.getDefaultBucket(projectId)
-            ?: throw RuntimeException("Failed to make bucket for $projectId")
+            ?: throw FlankCommonException("Failed to make bucket for $projectId")
         if (useMock) return bucket
 
         // test lab supports using a special free storage bucket

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -2,6 +2,7 @@ package ftl.args
 
 import com.google.common.annotations.VisibleForTesting
 import ftl.ios.Xctestrun.findTestNames
+import ftl.util.FlankFatalError
 import ftl.util.FlankTestMethod
 
 data class IosArgs(
@@ -80,7 +81,7 @@ internal fun filterTests(validTestMethods: List<String>, testTargetsRgx: List<St
                     return@filter true
                 }
             } catch (e: Exception) {
-                throw IllegalArgumentException("Invalid regex: $target", e)
+                throw FlankFatalError("Invalid regex: $target")
             }
         }
 

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -2,7 +2,7 @@ package ftl.args
 
 import com.google.common.annotations.VisibleForTesting
 import ftl.ios.Xctestrun.findTestNames
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 import ftl.util.FlankTestMethod
 
 data class IosArgs(
@@ -81,7 +81,7 @@ internal fun filterTests(validTestMethods: List<String>, testTargetsRgx: List<St
                     return@filter true
                 }
             } catch (e: Exception) {
-                throw FlankFatalError("Invalid regex: $target")
+                throw FlankConfigurationError("Invalid regex: $target")
             }
         }
 

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -81,7 +81,7 @@ internal fun filterTests(validTestMethods: List<String>, testTargetsRgx: List<St
                     return@filter true
                 }
             } catch (e: Exception) {
-                throw FlankConfigurationError("Invalid regex: $target")
+                throw FlankConfigurationError("Invalid regex: $target", e)
             }
         }
 

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -7,8 +7,8 @@ import ftl.android.UnsupportedModelId
 import ftl.android.UnsupportedVersionId
 import ftl.config.containsPhysicalDevices
 import ftl.config.containsVirtualDevices
-import ftl.util.FlankFatalError
-import ftl.util.IncompatibleTestDimension
+import ftl.util.FlankConfigurationError
+import ftl.util.IncompatibleTestDimensionError
 import java.io.File
 
 fun AndroidArgs.validate() {
@@ -27,7 +27,7 @@ private fun AndroidArgs.assertAdditionalAppTestApks() {
         .map { File(it.test).name }
         .run {
             if (isNotEmpty())
-                throw FlankFatalError("Cannot resolve app apk pair for $this")
+                throw FlankConfigurationError("Cannot resolve app apk pair for $this")
         }
 }
 
@@ -38,27 +38,27 @@ private fun AndroidArgs.assertDevicesSupported() = devices
     .forEach { (device, check) ->
         when (check) {
             SupportedDeviceConfig -> Unit
-            UnsupportedModelId -> throw IncompatibleTestDimension("Unsupported model id, '${device.model}'\nSupported model ids: ${AndroidCatalog.androidModelIds(project)}")
-            UnsupportedVersionId -> throw IncompatibleTestDimension("Unsupported version id, '${device.version}'\nSupported Version ids: ${AndroidCatalog.androidVersionIds(project)}")
-            IncompatibleModelVersion -> throw IncompatibleTestDimension("Incompatible model, '${device.model}', and version, '${device.version}'\nSupported version ids for '${device.model}': $check")
+            UnsupportedModelId -> throw IncompatibleTestDimensionError("Unsupported model id, '${device.model}'\nSupported model ids: ${AndroidCatalog.androidModelIds(project)}")
+            UnsupportedVersionId -> throw IncompatibleTestDimensionError("Unsupported version id, '${device.version}'\nSupported Version ids: ${AndroidCatalog.androidVersionIds(project)}")
+            IncompatibleModelVersion -> throw IncompatibleTestDimensionError("Incompatible model, '${device.model}', and version, '${device.version}'\nSupported version ids for '${device.model}': $check")
         }
     }
 
 private fun AndroidArgs.assertShards() {
-    if (numUniformShards != null && maxTestShards > 1) throw FlankFatalError(
+    if (numUniformShards != null && maxTestShards > 1) throw FlankConfigurationError(
         "Option num-uniform-shards cannot be specified along with max-test-shards. Use only one of them."
     )
 }
 
 private fun AndroidArgs.assertTestTypes() {
-    if (!(isRoboTest or isInstrumentationTest)) throw FlankFatalError(
+    if (!(isRoboTest or isInstrumentationTest)) throw FlankConfigurationError(
         "One of following options must be specified [test, robo-directives, robo-script]."
     )
 }
 
 private fun AndroidArgs.assertRoboTest() {
     // Using both roboDirectives and roboScript may hang test execution on FTL
-    if (roboDirectives.isNotEmpty() && roboScript != null) throw FlankFatalError(
+    if (roboDirectives.isNotEmpty() && roboScript != null) throw FlankConfigurationError(
         "Options robo-directives and robo-script are mutually exclusive, use only one of them."
     )
 }
@@ -70,7 +70,7 @@ private fun AndroidArgs.assertDirectoriesToPull() {
         .filter { !it.startsWith("/sdcard") && !it.startsWith("/data/local/tmp") || !correctNameRegex.matches(it) }
         .takeIf { it.isNotEmpty() }
         ?.also {
-            throw FlankFatalError(
+            throw FlankConfigurationError(
                 "Invalid value for [directories-to-pull]: Invalid path $it.\n" +
                         "Path must be absolute paths under /sdcard or /data/local/tmp (for example, --directories-to-pull /sdcard/tempDir1,/data/local/tmp/tempDir2).\n" +
                         "Path names are restricted to the characters [a-zA-Z0-9_-./+]. "
@@ -95,7 +95,7 @@ private fun AndroidArgs.assertVirtualDevicesShards() {
 }
 
 private fun AndroidArgs.throwMaxTestShardsLimitExceeded(): Nothing {
-    throw FlankFatalError(
+    throw FlankConfigurationError(
         "max-test-shards must be >= ${IArgs.AVAILABLE_VIRTUAL_SHARD_COUNT_RANGE.first} and <= ${IArgs.AVAILABLE_VIRTUAL_SHARD_COUNT_RANGE.last} for virtual devices, for physical devices max-test-shards must be >= ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.first} and <= ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}, or -1. But current is $maxTestShards"
     )
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -8,6 +8,7 @@ import ftl.android.UnsupportedVersionId
 import ftl.config.containsPhysicalDevices
 import ftl.config.containsVirtualDevices
 import ftl.util.FlankFatalError
+import ftl.util.IncompatibleTestDimension
 import java.io.File
 
 fun AndroidArgs.validate() {
@@ -37,9 +38,9 @@ private fun AndroidArgs.assertDevicesSupported() = devices
     .forEach { (device, check) ->
         when (check) {
             SupportedDeviceConfig -> Unit
-            UnsupportedModelId -> throw FlankFatalError("Unsupported model id, '${device.model}'\nSupported model ids: ${AndroidCatalog.androidModelIds(project)}")
-            UnsupportedVersionId -> throw FlankFatalError("Unsupported version id, '${device.version}'\nSupported Version ids: ${AndroidCatalog.androidVersionIds(project)}")
-            IncompatibleModelVersion -> throw FlankFatalError("Incompatible model, '${device.model}', and version, '${device.version}'\nSupported version ids for '${device.model}': $check")
+            UnsupportedModelId -> throw IncompatibleTestDimension("Unsupported model id, '${device.model}'\nSupported model ids: ${AndroidCatalog.androidModelIds(project)}")
+            UnsupportedVersionId -> throw IncompatibleTestDimension("Unsupported version id, '${device.version}'\nSupported Version ids: ${AndroidCatalog.androidVersionIds(project)}")
+            IncompatibleModelVersion -> throw IncompatibleTestDimension("Incompatible model, '${device.model}', and version, '${device.version}'\nSupported version ids for '${device.model}': $check")
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/args/ValidateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateCommonArgs.kt
@@ -1,7 +1,7 @@
 package ftl.args
 
 import ftl.config.FtlConstants
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 
 fun CommonArgs.validate() {
     assertProjectId()
@@ -11,7 +11,7 @@ fun CommonArgs.validate() {
 }
 
 private fun CommonArgs.assertProjectId() {
-    if (project.isEmpty()) throw FlankFatalError(
+    if (project.isEmpty()) throw FlankConfigurationError(
         "The project is not set. Define GOOGLE_CLOUD_PROJECT, set project in flank.yml\n" +
                 "or save service account credential to ${FtlConstants.defaultCredentialPath}\n" +
                 " See https://github.com/GoogleCloudPlatform/google-cloud-java#specifying-a-project-id"
@@ -19,13 +19,13 @@ private fun CommonArgs.assertProjectId() {
 }
 
 private fun CommonArgs.assertShardTime() {
-    if (shardTime <= 0 && shardTime != -1) throw FlankFatalError(
+    if (shardTime <= 0 && shardTime != -1) throw FlankConfigurationError(
         "shard-time must be >= 1 or -1"
     )
 }
 
 private fun CommonArgs.assertRepeatTests() {
-    if (repeatTests < 1) throw FlankFatalError(
+    if (repeatTests < 1) throw FlankConfigurationError(
         "num-test-runs must be >= 1"
     )
 }
@@ -34,11 +34,11 @@ private fun CommonArgs.assertSmartFlankGcsPath() = with(smartFlankGcsPath) {
     when {
         isEmpty() -> Unit
 
-        startsWith(FtlConstants.GCS_PREFIX).not() -> throw FlankFatalError(
+        startsWith(FtlConstants.GCS_PREFIX).not() -> throw FlankConfigurationError(
             "smart-flank-gcs-path must start with gs://"
         )
 
-        count { it == '/' } <= 2 || endsWith(".xml").not() -> throw FlankFatalError(
+        count { it == '/' } <= 2 || endsWith(".xml").not() -> throw FlankConfigurationError(
             "smart-flank-gcs-path must be in the format gs://bucket/foo.xml"
         )
     }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -20,7 +20,7 @@ private fun IosArgs.assertMaxTestShards() { this.maxTestShards
 private fun IosArgs.assertXcodeSupported() = when {
     xcodeVersion == null -> Unit
     IosCatalog.supportedXcode(xcodeVersion, project) -> Unit
-    else -> throw FlankFatalError(("Xcode $xcodeVersion is not a supported Xcode version"))
+    else -> throw IncompatibleTestDimension(("Xcode $xcodeVersion is not a supported Xcode version"))
 }
 
 private fun IosArgs.assertDevicesSupported() = devices.forEach { device ->

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -1,8 +1,8 @@
 package ftl.args
 
 import ftl.ios.IosCatalog
-import ftl.util.FlankFatalError
-import ftl.util.IncompatibleTestDimension
+import ftl.util.FlankConfigurationError
+import ftl.util.IncompatibleTestDimensionError
 
 fun IosArgs.validate() {
     assertXcodeSupported()
@@ -13,17 +13,17 @@ private fun IosArgs.assertMaxTestShards() { this.maxTestShards
     if (
         maxTestShards !in IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE &&
         maxTestShards != -1
-    ) throw FlankFatalError(
+    ) throw FlankConfigurationError(
         "max-test-shards must be >= ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.first} and <= ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}, or -1. But current is $maxTestShards"
     )
 }
 private fun IosArgs.assertXcodeSupported() = when {
     xcodeVersion == null -> Unit
     IosCatalog.supportedXcode(xcodeVersion, project) -> Unit
-    else -> throw IncompatibleTestDimension(("Xcode $xcodeVersion is not a supported Xcode version"))
+    else -> throw IncompatibleTestDimensionError(("Xcode $xcodeVersion is not a supported Xcode version"))
 }
 
 private fun IosArgs.assertDevicesSupported() = devices.forEach { device ->
     if (!IosCatalog.supportedDevice(device.model, device.version, this.project))
-        throw IncompatibleTestDimension("iOS ${device.version} on ${device.model} is not a supported device")
+        throw IncompatibleTestDimensionError("iOS ${device.version} on ${device.model} is not a supported device")
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -2,6 +2,7 @@ package ftl.args
 
 import ftl.ios.IosCatalog
 import ftl.util.FlankFatalError
+import ftl.util.IncompatibleTestDimension
 
 fun IosArgs.validate() {
     assertXcodeSupported()
@@ -24,5 +25,5 @@ private fun IosArgs.assertXcodeSupported() = when {
 
 private fun IosArgs.assertDevicesSupported() = devices.forEach { device ->
     if (!IosCatalog.supportedDevice(device.model, device.version, this.project))
-        throw FlankFatalError("iOS ${device.version} on ${device.model} is not a supported device")
+        throw IncompatibleTestDimension("iOS ${device.version} on ${device.model} is not a supported device")
 }

--- a/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
@@ -8,6 +8,7 @@ import com.google.common.annotations.VisibleForTesting
 import ftl.args.ArgsHelper.yamlMapper
 import ftl.util.loadFile
 import ftl.util.FlankFatalError
+import ftl.util.FlankCommonException
 import java.io.Reader
 import java.nio.file.Files
 import java.nio.file.Path
@@ -124,7 +125,7 @@ object YamlDeprecated {
     private val yamlWriter by lazy { yamlMapper.writerWithDefaultPrettyPrinter() }
 
     fun modify(yamlPath: Path): Boolean {
-        if (yamlPath.toFile().exists().not()) throw FlankFatalError("Flank yml doesn't exist at path $yamlPath")
+        if (yamlPath.toFile().exists().not()) throw FlankCommonException("Flank yml doesn't exist at path $yamlPath")
 
         val (errorDetected, string) = modify(loadFile(yamlPath))
 

--- a/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.google.common.annotations.VisibleForTesting
 import ftl.args.ArgsHelper.yamlMapper
 import ftl.util.loadFile
-import ftl.util.FlankFatalError
-import ftl.util.FlankCommonException
+import ftl.util.FlankConfigurationError
+import ftl.util.FlankGeneralError
 import java.io.Reader
 import java.nio.file.Files
 import java.nio.file.Path
@@ -125,7 +125,7 @@ object YamlDeprecated {
     private val yamlWriter by lazy { yamlMapper.writerWithDefaultPrettyPrinter() }
 
     fun modify(yamlPath: Path): Boolean {
-        if (yamlPath.toFile().exists().not()) throw FlankCommonException("Flank yml doesn't exist at path $yamlPath")
+        if (yamlPath.toFile().exists().not()) throw FlankGeneralError("Flank yml doesn't exist at path $yamlPath")
 
         val (errorDetected, string) = modify(loadFile(yamlPath))
 
@@ -141,7 +141,7 @@ object YamlDeprecated {
 
         if (error) {
             val platform = if (android) "android" else "ios"
-            throw FlankFatalError("Invalid keys detected! Auto fix with: flank $platform doctor --fix")
+            throw FlankConfigurationError("Invalid keys detected! Auto fix with: flank $platform doctor --fix")
         }
 
         return data

--- a/test_runner/src/main/kotlin/ftl/args/yml/YamlErrorConverter.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/YamlErrorConverter.kt
@@ -5,18 +5,18 @@ package ftl.args.yml
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException
 import ftl.args.yml.errors.ConfigurationErrorMessageBuilder
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 
 fun convertConfigurationErrorExceptions(missingParameterError: Exception, yaml: JsonNode?): Throwable {
     val errorMessageBuilder = ConfigurationErrorMessageBuilder
     val errorMessage = missingParameterError.message
     return if (errorMessage != null) {
-        FlankFatalError(errorMessageBuilder(errorMessage, yaml))
+        FlankConfigurationError(errorMessageBuilder(errorMessage, yaml))
     } else {
         missingParameterError
     }
 }
 
 fun convertConfigurationErrorExceptions(treeParsingException: MarkedYAMLException): Throwable {
-    return FlankFatalError(ConfigurationErrorMessageBuilder(treeParsingException))
+    return FlankConfigurationError(ConfigurationErrorMessageBuilder(treeParsingException))
 }

--- a/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
+++ b/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
@@ -17,6 +17,7 @@ import ftl.util.BugsnagInitHelper.initBugsnag
 import ftl.gc.UserAuth
 import ftl.http.HttpTimeoutIncrease
 import ftl.util.FlankFatalError
+import ftl.util.FlankCommonException
 import ftl.util.readRevision
 import java.io.IOException
 import java.nio.file.Path
@@ -63,7 +64,7 @@ object FtlConstants {
         try {
             return@lazy GoogleNetHttpTransport.newTrustedTransport()
         } catch (e: Exception) {
-            throw RuntimeException(e)
+            throw FlankCommonException(e)
         }
     }
 
@@ -79,7 +80,7 @@ object FtlConstants {
                 GoogleApiLogger.silenceComputeEngine()
                 ServiceAccountCredentials.getApplicationDefault()
             } catch (e: IOException) {
-                throw FlankFatalError("Error: Failed to read service account credential.\n${e.message}")
+                throw FlankCommonException("Error: Failed to read service account credential.\n${e.message}")
             }
         }
     }
@@ -101,7 +102,7 @@ object FtlConstants {
         return when (args) {
             is IosArgs -> defaultIosConfig
             is AndroidArgs -> defaultAndroidConfig
-            else -> throw RuntimeException("Unknown config type")
+            else -> throw FlankFatalError("Unknown config type")
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
+++ b/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
@@ -16,8 +16,8 @@ import ftl.args.IosArgs
 import ftl.util.BugsnagInitHelper.initBugsnag
 import ftl.gc.UserAuth
 import ftl.http.HttpTimeoutIncrease
-import ftl.util.FlankFatalError
-import ftl.util.FlankCommonException
+import ftl.util.FlankConfigurationError
+import ftl.util.FlankGeneralError
 import ftl.util.readRevision
 import java.io.IOException
 import java.nio.file.Path
@@ -64,7 +64,7 @@ object FtlConstants {
         try {
             return@lazy GoogleNetHttpTransport.newTrustedTransport()
         } catch (e: Exception) {
-            throw FlankCommonException(e)
+            throw FlankGeneralError(e)
         }
     }
 
@@ -80,7 +80,7 @@ object FtlConstants {
                 GoogleApiLogger.silenceComputeEngine()
                 ServiceAccountCredentials.getApplicationDefault()
             } catch (e: IOException) {
-                throw FlankCommonException("Error: Failed to read service account credential.\n${e.message}")
+                throw FlankGeneralError("Error: Failed to read service account credential.\n${e.message}")
             }
         }
     }
@@ -102,7 +102,7 @@ object FtlConstants {
         return when (args) {
             is IosArgs -> defaultIosConfig
             is AndroidArgs -> defaultAndroidConfig
-            else -> throw FlankFatalError("Unknown config type")
+            else -> throw FlankConfigurationError("Unknown config type")
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/doctor/Doctor.kt
+++ b/test_runner/src/main/kotlin/ftl/doctor/Doctor.kt
@@ -7,7 +7,7 @@ import ftl.args.ArgsHelper
 import ftl.args.IArgs
 import ftl.config.loadAndroidConfig
 import ftl.config.loadIosConfig
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 import ftl.util.loadFile
 import java.io.Reader
 import java.lang.StringBuilder
@@ -58,6 +58,6 @@ private fun preloadConfiguration(data: Path, isAndroid: Boolean) =
     try {
         if (isAndroid) loadAndroidConfig(data) else loadIosConfig(data)
         ""
-    } catch (e: FlankFatalError) {
+    } catch (e: FlankConfigurationError) {
         e.message
     }

--- a/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
+++ b/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
@@ -2,6 +2,8 @@ package ftl.filter
 
 import com.linkedin.dex.parser.TestMethod
 import ftl.config.FtlConstants
+import ftl.util.FlankFatalError
+import ftl.util.FlankCommonException
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -67,7 +69,7 @@ object TestFilters {
 
         companion object {
             fun from(name: String): Size =
-                values().find { it.name.equals(name, true) } ?: throw IllegalArgumentException("Unknown size $name")
+                values().find { it.name.equals(name, true) } ?: throw FlankFatalError("Unknown size $name")
         }
     }
 
@@ -108,7 +110,7 @@ object TestFilters {
             ARGUMENT_TEST_FILE -> fromTestFile(args)
             ARGUMENT_NOT_TEST_FILE -> not(fromTestFile(args))
             ARGUMENT_TEST_SIZE -> withSize(args)
-            else -> throw IllegalArgumentException("Filtering option $command not supported")
+            else -> throw FlankFatalError("Filtering option $command not supported")
         }
     }
 
@@ -125,7 +127,7 @@ object TestFilters {
             // the fully qualified class name or the fully qualified method name.
             return withPackageName(lines)
         } catch (e: IOException) {
-            throw RuntimeException("Unable to read testFile", e)
+            throw FlankCommonException("Unable to read testFile")
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
+++ b/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
@@ -127,7 +127,7 @@ object TestFilters {
             // the fully qualified class name or the fully qualified method name.
             return withPackageName(lines)
         } catch (e: IOException) {
-            throw FlankGeneralError("Unable to read testFile")
+            throw FlankGeneralError("Unable to read testFile", e)
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
+++ b/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
@@ -2,8 +2,8 @@ package ftl.filter
 
 import com.linkedin.dex.parser.TestMethod
 import ftl.config.FtlConstants
-import ftl.util.FlankFatalError
-import ftl.util.FlankCommonException
+import ftl.util.FlankConfigurationError
+import ftl.util.FlankGeneralError
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -69,7 +69,7 @@ object TestFilters {
 
         companion object {
             fun from(name: String): Size =
-                values().find { it.name.equals(name, true) } ?: throw FlankFatalError("Unknown size $name")
+                values().find { it.name.equals(name, true) } ?: throw FlankConfigurationError("Unknown size $name")
         }
     }
 
@@ -110,7 +110,7 @@ object TestFilters {
             ARGUMENT_TEST_FILE -> fromTestFile(args)
             ARGUMENT_NOT_TEST_FILE -> not(fromTestFile(args))
             ARGUMENT_TEST_SIZE -> withSize(args)
-            else -> throw FlankFatalError("Filtering option $command not supported")
+            else -> throw FlankConfigurationError("Filtering option $command not supported")
         }
     }
 
@@ -127,7 +127,7 @@ object TestFilters {
             // the fully qualified class name or the fully qualified method name.
             return withPackageName(lines)
         } catch (e: IOException) {
-            throw FlankCommonException("Unable to read testFile")
+            throw FlankGeneralError("Unable to read testFile")
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
@@ -18,7 +18,7 @@ import ftl.gc.android.mapGcsPathsToApks
 import ftl.gc.android.mapToDeviceFiles
 import ftl.gc.android.setupAndroidTest
 import ftl.run.platform.android.AndroidTestConfig
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.join
 import ftl.util.timeoutToSeconds
 
@@ -84,7 +84,7 @@ object GcAndroidTestMatrix {
         try {
             return GcTesting.get.projects().testMatrices().create(args.project, testMatrix)
         } catch (e: Exception) {
-            throw FlankCommonException(e)
+            throw FlankGeneralError(e)
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
@@ -18,6 +18,7 @@ import ftl.gc.android.mapGcsPathsToApks
 import ftl.gc.android.mapToDeviceFiles
 import ftl.gc.android.setupAndroidTest
 import ftl.run.platform.android.AndroidTestConfig
+import ftl.util.FlankCommonException
 import ftl.util.join
 import ftl.util.timeoutToSeconds
 
@@ -83,7 +84,7 @@ object GcAndroidTestMatrix {
         try {
             return GcTesting.get.projects().testMatrices().create(args.project, testMatrix)
         } catch (e: Exception) {
-            throw RuntimeException(e)
+            throw FlankCommonException(e)
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
@@ -16,7 +16,7 @@ import com.google.api.services.testing.model.ToolResultsHistory
 import ftl.args.IosArgs
 import ftl.ios.Xctestrun
 import ftl.ios.Xctestrun.toByteArray
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.ShardCounter
 import ftl.util.join
 import ftl.util.timeoutToSeconds
@@ -87,7 +87,7 @@ object GcIosTestMatrix {
         try {
             return GcTesting.get.projects().testMatrices().create(args.project, testMatrix)
         } catch (e: Exception) {
-            throw FlankCommonException(e)
+            throw FlankGeneralError(e)
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
@@ -16,6 +16,7 @@ import com.google.api.services.testing.model.ToolResultsHistory
 import ftl.args.IosArgs
 import ftl.ios.Xctestrun
 import ftl.ios.Xctestrun.toByteArray
+import ftl.util.FlankCommonException
 import ftl.util.ShardCounter
 import ftl.util.join
 import ftl.util.timeoutToSeconds
@@ -86,7 +87,7 @@ object GcIosTestMatrix {
         try {
             return GcTesting.get.projects().testMatrices().create(args.project, testMatrix)
         } catch (e: Exception) {
-            throw RuntimeException(e)
+            throw FlankCommonException(e)
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -13,6 +13,7 @@ import ftl.config.FtlConstants.GCS_PREFIX
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.parseAllSuitesXml
 import ftl.reports.xml.xmlToString
+import ftl.util.FlankCommonException
 import ftl.util.ProgressBar
 import ftl.util.join
 import java.io.File
@@ -74,7 +75,7 @@ object GcStorage {
             progress.start("Uploading smart flank XML")
             storage.create(fileBlob, testResult.xmlToString().toByteArray())
         } catch (e: Exception) {
-            throw RuntimeException(e)
+            throw FlankCommonException(e)
         } finally {
             progress.stop()
         }
@@ -141,7 +142,7 @@ object GcStorage {
                 progress.start("Uploading $fileName")
                 storage.create(fileBlob, fileBytes)
             } catch (e: Exception) {
-                throw RuntimeException(e)
+                throw FlankCommonException(e)
             } finally {
                 progress.stop()
             }
@@ -166,7 +167,7 @@ object GcStorage {
                 }
             } catch (e: Exception) {
                 if (ignoreError) return@computeIfAbsent ""
-                throw RuntimeException("Cannot download $gcsUriString", e)
+                throw FlankCommonException("Cannot download $gcsUriString", e)
             }
             outputFile.path
         }

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -13,7 +13,7 @@ import ftl.config.FtlConstants.GCS_PREFIX
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.parseAllSuitesXml
 import ftl.reports.xml.xmlToString
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.ProgressBar
 import ftl.util.join
 import java.io.File
@@ -75,7 +75,7 @@ object GcStorage {
             progress.start("Uploading smart flank XML")
             storage.create(fileBlob, testResult.xmlToString().toByteArray())
         } catch (e: Exception) {
-            throw FlankCommonException(e)
+            throw FlankGeneralError(e)
         } finally {
             progress.stop()
         }
@@ -142,7 +142,7 @@ object GcStorage {
                 progress.start("Uploading $fileName")
                 storage.create(fileBlob, fileBytes)
             } catch (e: Exception) {
-                throw FlankCommonException(e)
+                throw FlankGeneralError(e)
             } finally {
                 progress.stop()
             }
@@ -167,7 +167,7 @@ object GcStorage {
                 }
             } catch (e: Exception) {
                 if (ignoreError) return@computeIfAbsent ""
-                throw FlankCommonException("Cannot download $gcsUriString", e)
+                throw FlankGeneralError("Cannot download $gcsUriString", e)
             }
             outputFile.path
         }

--- a/test_runner/src/main/kotlin/ftl/gc/GcTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcTestMatrix.kt
@@ -3,6 +3,7 @@ package ftl.gc
 import com.google.api.services.testing.model.CancelTestMatrixResponse
 import com.google.api.services.testing.model.TestMatrix
 import ftl.http.executeWithRetry
+import ftl.util.FlankCommonException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -50,7 +51,7 @@ object GcTestMatrix {
             }
         }
 
-        throw RuntimeException("Failed to refresh matrix")
+        throw FlankCommonException("Failed to refresh matrix")
     }
 
     suspend fun cancel(testMatrixId: String, projectId: String): CancelTestMatrixResponse {
@@ -70,6 +71,6 @@ object GcTestMatrix {
             }
         }
 
-        throw RuntimeException("Failed to cancel matrix")
+        throw FlankCommonException("Failed to cancel matrix")
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcTestMatrix.kt
@@ -3,7 +3,7 @@ package ftl.gc
 import com.google.api.services.testing.model.CancelTestMatrixResponse
 import com.google.api.services.testing.model.TestMatrix
 import ftl.http.executeWithRetry
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -51,7 +51,7 @@ object GcTestMatrix {
             }
         }
 
-        throw FlankCommonException("Failed to refresh matrix")
+        throw FlankGeneralError("Failed to refresh matrix")
     }
 
     suspend fun cancel(testMatrixId: String, projectId: String): CancelTestMatrixResponse {
@@ -71,6 +71,6 @@ object GcTestMatrix {
             }
         }
 
-        throw FlankCommonException("Failed to cancel matrix")
+        throw FlankGeneralError("Failed to cancel matrix")
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
@@ -15,7 +15,7 @@ import ftl.config.FtlConstants.applicationName
 import ftl.config.FtlConstants.httpCredential
 import ftl.config.FtlConstants.httpTransport
 import ftl.http.executeWithRetry
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.FTLProjectError
 import ftl.util.PermissionDenied
 import ftl.util.ProjectNotFound
@@ -123,8 +123,8 @@ object GcToolResults {
     } catch (ftlProjectError: FTLProjectError) {
         // flank needs to rewrap the exception with additional info about project
         when (ftlProjectError) {
-            is PermissionDenied -> throw FlankCommonException(permissionDeniedErrorMessage(projectId, ftlProjectError.message))
-            is ProjectNotFound -> throw FlankCommonException(projectNotFoundErrorMessage(projectId, ftlProjectError.message))
+            is PermissionDenied -> throw FlankGeneralError(permissionDeniedErrorMessage(projectId, ftlProjectError.message))
+            is ProjectNotFound -> throw FlankGeneralError(projectNotFoundErrorMessage(projectId, ftlProjectError.message))
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/ios/Parse.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/Parse.kt
@@ -2,7 +2,7 @@ package ftl.ios
 
 import ftl.config.FtlConstants.isMacOS
 import ftl.util.Bash
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.copyBinaryResource
 import java.io.File
 
@@ -20,10 +20,10 @@ object Parse {
     private fun validateFile(path: String) {
         val file = File(path)
         if (!file.exists()) {
-            throw FlankCommonException("File $path does not exist!")
+            throw FlankGeneralError("File $path does not exist!")
         }
 
-        if (file.isDirectory) throw FlankCommonException("$path is a directory!")
+        if (file.isDirectory) throw FlankGeneralError("$path is a directory!")
     }
 
     private fun methodName(matcher: MatchResult): String {

--- a/test_runner/src/main/kotlin/ftl/ios/Parse.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/Parse.kt
@@ -2,6 +2,7 @@ package ftl.ios
 
 import ftl.config.FtlConstants.isMacOS
 import ftl.util.Bash
+import ftl.util.FlankCommonException
 import ftl.util.copyBinaryResource
 import java.io.File
 
@@ -19,10 +20,10 @@ object Parse {
     private fun validateFile(path: String) {
         val file = File(path)
         if (!file.exists()) {
-            throw RuntimeException("File $path does not exist!")
+            throw FlankCommonException("File $path does not exist!")
         }
 
-        if (file.isDirectory) throw RuntimeException("$path is a directory!")
+        if (file.isDirectory) throw FlankCommonException("$path is a directory!")
     }
 
     private fun methodName(matcher: MatchResult): String {

--- a/test_runner/src/main/kotlin/ftl/ios/Xctestrun.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/Xctestrun.kt
@@ -4,6 +4,7 @@ import com.dd.plist.NSArray
 import com.dd.plist.NSDictionary
 import com.dd.plist.NSString
 import com.dd.plist.PropertyListParser
+import ftl.util.FlankCommonException
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Paths
@@ -35,7 +36,7 @@ object Xctestrun {
             }
         }
 
-        throw RuntimeException("No tests found")
+        throw FlankCommonException("No tests found")
     }
 
     // https://github.com/google/xctestrunner/blob/51dbb6b7eb35f2ed55439459ca49e06992bc4da0/xctestrunner/test_runner/xctestrun.py#L129
@@ -60,7 +61,7 @@ object Xctestrun {
     // Parses xctestrun file into a dictonary
     fun parse(xctestrun: File): NSDictionary {
         val testrun = xctestrun.canonicalFile
-        if (!testrun.exists()) throw RuntimeException("$testrun doesn't exist")
+        if (!testrun.exists()) throw FlankCommonException("$testrun doesn't exist")
 
         return PropertyListParser.parse(testrun) as NSDictionary
     }

--- a/test_runner/src/main/kotlin/ftl/ios/Xctestrun.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/Xctestrun.kt
@@ -4,7 +4,7 @@ import com.dd.plist.NSArray
 import com.dd.plist.NSDictionary
 import com.dd.plist.NSString
 import com.dd.plist.PropertyListParser
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Paths
@@ -36,7 +36,7 @@ object Xctestrun {
             }
         }
 
-        throw FlankCommonException("No tests found")
+        throw FlankGeneralError("No tests found")
     }
 
     // https://github.com/google/xctestrunner/blob/51dbb6b7eb35f2ed55439459ca49e06992bc4da0/xctestrunner/test_runner/xctestrun.py#L129
@@ -61,7 +61,7 @@ object Xctestrun {
     // Parses xctestrun file into a dictonary
     fun parse(xctestrun: File): NSDictionary {
         val testrun = xctestrun.canonicalFile
-        if (!testrun.exists()) throw FlankCommonException("$testrun doesn't exist")
+        if (!testrun.exists()) throw FlankGeneralError("$testrun doesn't exist")
 
         return PropertyListParser.parse(testrun) as NSDictionary
     }

--- a/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
+++ b/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
@@ -2,10 +2,10 @@ package ftl.json
 
 import com.google.api.services.testing.model.TestMatrix
 import ftl.util.FTLError
-import ftl.util.FailedMatrix
-import ftl.util.IncompatibleTestDimension
+import ftl.util.FailedMatrixError
+import ftl.util.IncompatibleTestDimensionError
 import ftl.util.InfrastructureError
-import ftl.util.MatrixCanceled
+import ftl.util.MatrixCanceledError
 import ftl.util.MatrixState
 
 class MatrixMap(
@@ -28,23 +28,23 @@ class MatrixMap(
      * @param shouldIgnore [Boolean]
      *        set {true} to ignore failed matrices and exit with status code 0
      *
-     * @throws MatrixCanceled [MatrixCanceled]
+     * @throws MatrixCanceledError [MatrixCanceledError]
      *         at least one matrix canceled by user
      * @throws InfrastructureError [InfrastructureError]
      *         at least one matrix have a test infrastructure error
-     * @throws IncompatibleTestDimension [IncompatibleTestDimension]
+     * @throws IncompatibleTestDimensionError [IncompatibleTestDimensionError]
      *         at least one matrix have a incompatible test dimensions. This error might occur if the selected Android API level is not supported by the selected device type.
      * @throws FTLError [FTLError]
      *         at least one matrix have unexpected error
      */
     fun validateMatrices(shouldIgnore: Boolean = false) {
         map.values.run {
-            firstOrNull { it.canceledByUser() }?.let { throw MatrixCanceled(it.outcomeDetails) }
+            firstOrNull { it.canceledByUser() }?.let { throw MatrixCanceledError(it.outcomeDetails) }
             firstOrNull { it.infrastructureFail() }?.let { throw InfrastructureError(it.outcomeDetails) }
-            firstOrNull { it.incompatibleFail() }?.let { throw IncompatibleTestDimension(it.outcomeDetails) }
+            firstOrNull { it.incompatibleFail() }?.let { throw IncompatibleTestDimensionError(it.outcomeDetails) }
             firstOrNull { it.state != MatrixState.FINISHED }?.let { throw FTLError(it) }
             filter { it.failed() }.let {
-                if (it.isNotEmpty()) throw FailedMatrix(
+                if (it.isNotEmpty()) throw FailedMatrixError(
                     matrices = it,
                     ignoreFailed = shouldIgnore
                 )

--- a/test_runner/src/main/kotlin/ftl/json/OutcomeDetailsFormatter.kt
+++ b/test_runner/src/main/kotlin/ftl/json/OutcomeDetailsFormatter.kt
@@ -49,19 +49,26 @@ private fun TestSuiteOverviewData.buildFailureOutcomeDetailsSummary() =
     }.toString()
 
 private fun InconclusiveDetail?.formatOutcomeDetails() = when {
-    this == null -> "Unknown reason"
-    infrastructureFailure == true -> "Infrastructure failure"
-    abortedByUser == true -> "Test run aborted by user"
-    else -> "Unknown reason"
+    this == null -> UNKNOWN_REASON_MESSAGE
+    infrastructureFailure == true -> INFRASTRUCTURE_FAILURE_MESSAGE
+    abortedByUser == true -> ABORTED_BY_USER_MESSAGE
+    else -> UNKNOWN_REASON_MESSAGE
 }
 
 private fun SkippedDetail?.formatOutcomeDetails(): String = when {
-    this == null -> "Unknown reason"
-    incompatibleDevice == true -> "Incompatible device/OS combination"
-    incompatibleArchitecture == true -> "App does not support the device architecture"
-    incompatibleAppVersion == true -> "App does not support the OS version"
-    else -> "Unknown reason"
+    this == null -> UNKNOWN_REASON_MESSAGE
+    incompatibleDevice == true -> INCOMPATIBLE_DEVICE_MESSAGE
+    incompatibleArchitecture == true -> INCOMPATIBLE_ARCHITECTURE_MESSAGE
+    incompatibleAppVersion == true -> INCOMPATIBLE_APP_VERSION_MESSAGE
+    else -> UNKNOWN_REASON_MESSAGE
 }
+
+private const val UNKNOWN_REASON_MESSAGE = "Unknown reason"
+const val INFRASTRUCTURE_FAILURE_MESSAGE = "Infrastructure failure"
+const val ABORTED_BY_USER_MESSAGE = "Test run aborted by user"
+const val INCOMPATIBLE_DEVICE_MESSAGE = "Incompatible device/OS combination"
+const val INCOMPATIBLE_ARCHITECTURE_MESSAGE = "App does not support the device architecture"
+const val INCOMPATIBLE_APP_VERSION_MESSAGE = "App does not support the device architecture"
 
 private const val NATIVE_CRASH_MESSAGE = " (Native crash)"
 private val flakesMessage: (Int) -> String = { ", $it flaky" }

--- a/test_runner/src/main/kotlin/ftl/json/OutcomeDetailsFormatter.kt
+++ b/test_runner/src/main/kotlin/ftl/json/OutcomeDetailsFormatter.kt
@@ -68,7 +68,7 @@ const val INFRASTRUCTURE_FAILURE_MESSAGE = "Infrastructure failure"
 const val ABORTED_BY_USER_MESSAGE = "Test run aborted by user"
 const val INCOMPATIBLE_DEVICE_MESSAGE = "Incompatible device/OS combination"
 const val INCOMPATIBLE_ARCHITECTURE_MESSAGE = "App does not support the device architecture"
-const val INCOMPATIBLE_APP_VERSION_MESSAGE = "App does not support the device architecture"
+const val INCOMPATIBLE_APP_VERSION_MESSAGE = "App does not support the OS version"
 
 private const val NATIVE_CRASH_MESSAGE = " (Native crash)"
 private val flakesMessage: (Int) -> String = { ", $it flaky" }

--- a/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
@@ -186,3 +186,9 @@ class SavedMatrix(matrix: TestMatrix) {
             }
         }
 }
+
+fun SavedMatrix.canceledByUser() = outcomeDetails == ABORTED_BY_USER_MESSAGE
+
+fun SavedMatrix.infrastructureFail() = outcomeDetails == INFRASTRUCTURE_FAILURE_MESSAGE
+
+fun SavedMatrix.incompatibleFail() = outcomeDetails in arrayOf(INCOMPATIBLE_APP_VERSION_MESSAGE, INCOMPATIBLE_ARCHITECTURE_MESSAGE, INCOMPATIBLE_DEVICE_MESSAGE)

--- a/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
@@ -9,6 +9,7 @@ import ftl.reports.api.createTestExecutionDataListAsync
 import ftl.reports.api.createTestSuitOverviewData
 import ftl.reports.api.data.TestSuiteOverviewData
 import ftl.reports.api.prepareForJUnitResult
+import ftl.util.FlankCommonException
 import ftl.util.MatrixState.ERROR
 import ftl.util.MatrixState.FINISHED
 import ftl.util.MatrixState.INVALID
@@ -91,7 +92,7 @@ class SavedMatrix(matrix: TestMatrix) {
 
     private fun finished(matrix: TestMatrix) {
         if (matrix.state != FINISHED) {
-            throw RuntimeException("Matrix ${matrix.testMatrixId} ${matrix.state} != $FINISHED")
+            throw FlankCommonException("Matrix ${matrix.testMatrixId} ${matrix.state} != $FINISHED")
         }
         billableVirtualMinutes = 0
         billablePhysicalMinutes = 0

--- a/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
@@ -9,7 +9,7 @@ import ftl.reports.api.createTestExecutionDataListAsync
 import ftl.reports.api.createTestSuitOverviewData
 import ftl.reports.api.data.TestSuiteOverviewData
 import ftl.reports.api.prepareForJUnitResult
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.MatrixState.ERROR
 import ftl.util.MatrixState.FINISHED
 import ftl.util.MatrixState.INVALID
@@ -92,7 +92,7 @@ class SavedMatrix(matrix: TestMatrix) {
 
     private fun finished(matrix: TestMatrix) {
         if (matrix.state != FINISHED) {
-            throw FlankCommonException("Matrix ${matrix.testMatrixId} ${matrix.state} != $FINISHED")
+            throw FlankGeneralError("Matrix ${matrix.testMatrixId} ${matrix.state} != $FINISHED")
         }
         billableVirtualMinutes = 0
         billablePhysicalMinutes = 0

--- a/test_runner/src/main/kotlin/ftl/mock/MockServer.kt
+++ b/test_runner/src/main/kotlin/ftl/mock/MockServer.kt
@@ -28,7 +28,7 @@ import ftl.config.FtlConstants
 import ftl.config.FtlConstants.JSON_FACTORY
 import ftl.log.LogbackLogger
 import ftl.util.Bash
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.StepOutcome.failure
 import ftl.util.StepOutcome.inconclusive
 import ftl.util.StepOutcome.skipped
@@ -59,7 +59,7 @@ object MockServer {
 
     private inline fun <reified T> loadCatalog(fileName: String): T {
         val jsonPath = Paths.get("./src/test/kotlin/ftl/fixtures/$fileName")
-        if (!Files.exists(jsonPath)) throw FlankCommonException("Path doesn't exist: $fileName")
+        if (!Files.exists(jsonPath)) throw FlankGeneralError("Path doesn't exist: $fileName")
         return JSON_FACTORY.fromReader(Files.newBufferedReader(jsonPath), T::class.java)
     }
 

--- a/test_runner/src/main/kotlin/ftl/mock/MockServer.kt
+++ b/test_runner/src/main/kotlin/ftl/mock/MockServer.kt
@@ -28,6 +28,7 @@ import ftl.config.FtlConstants
 import ftl.config.FtlConstants.JSON_FACTORY
 import ftl.log.LogbackLogger
 import ftl.util.Bash
+import ftl.util.FlankCommonException
 import ftl.util.StepOutcome.failure
 import ftl.util.StepOutcome.inconclusive
 import ftl.util.StepOutcome.skipped
@@ -58,7 +59,7 @@ object MockServer {
 
     private inline fun <reified T> loadCatalog(fileName: String): T {
         val jsonPath = Paths.get("./src/test/kotlin/ftl/fixtures/$fileName")
-        if (!Files.exists(jsonPath)) throw RuntimeException("Path doesn't exist: $fileName")
+        if (!Files.exists(jsonPath)) throw FlankCommonException("Path doesn't exist: $fileName")
         return JSON_FACTORY.fromReader(Files.newBufferedReader(jsonPath), T::class.java)
     }
 

--- a/test_runner/src/main/kotlin/ftl/mock/TestArtifact.kt
+++ b/test_runner/src/main/kotlin/ftl/mock/TestArtifact.kt
@@ -1,6 +1,6 @@
 package ftl.mock
 
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import java.io.File
 import java.net.InetAddress
 import java.net.InetSocketAddress
@@ -59,7 +59,7 @@ object TestArtifact {
                 wait(attempt)
             }
         }
-        throw FlankCommonException("Unable to connect to '$githubUrl' after $maxRetries attempts!")
+        throw FlankGeneralError("Unable to connect to '$githubUrl' after $maxRetries attempts!")
     }
 
     private fun wait(attempt: Int) {
@@ -80,7 +80,7 @@ object TestArtifact {
         val zipRegex = Regex(".*releases/download/latest/\\H{32}\\.zip$")
         return downloadLinks.find {
             it.attr("href").matches(zipRegex)
-        } ?: throw FlankCommonException("Download link not found in html!")
+        } ?: throw FlankGeneralError("Download link not found in html!")
     }
 
     private fun updateRequired(remoteAssetLink: Element): Boolean {
@@ -98,7 +98,7 @@ object TestArtifact {
     private fun download(src: String, dst: String) {
         val request = Request.Builder().url(src).build()
         val response = httpClient.newCall(request).execute()
-        val body: ResponseBody = response.body ?: throw FlankCommonException("null response body downloading $src")
+        val body: ResponseBody = response.body ?: throw FlankGeneralError("null response body downloading $src")
 
         Files.write(Paths.get(dst), body.bytes())
     }

--- a/test_runner/src/main/kotlin/ftl/mock/TestArtifact.kt
+++ b/test_runner/src/main/kotlin/ftl/mock/TestArtifact.kt
@@ -1,5 +1,6 @@
 package ftl.mock
 
+import ftl.util.FlankCommonException
 import java.io.File
 import java.net.InetAddress
 import java.net.InetSocketAddress
@@ -58,7 +59,7 @@ object TestArtifact {
                 wait(attempt)
             }
         }
-        throw RuntimeException("Unable to connect to '$githubUrl' after $maxRetries attempts!")
+        throw FlankCommonException("Unable to connect to '$githubUrl' after $maxRetries attempts!")
     }
 
     private fun wait(attempt: Int) {
@@ -79,7 +80,7 @@ object TestArtifact {
         val zipRegex = Regex(".*releases/download/latest/\\H{32}\\.zip$")
         return downloadLinks.find {
             it.attr("href").matches(zipRegex)
-        } ?: throw RuntimeException("Download link not found in html!")
+        } ?: throw FlankCommonException("Download link not found in html!")
     }
 
     private fun updateRequired(remoteAssetLink: Element): Boolean {
@@ -97,7 +98,7 @@ object TestArtifact {
     private fun download(src: String, dst: String) {
         val request = Request.Builder().url(src).build()
         val response = httpClient.newCall(request).execute()
-        val body: ResponseBody = response.body ?: throw RuntimeException("null response body downloading $src")
+        val body: ResponseBody = response.body ?: throw FlankCommonException("null response body downloading $src")
 
         Files.write(Paths.get(dst), body.bytes())
     }

--- a/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PRO
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.model.JUnitTestSuite
 import ftl.reports.xml.preprocesor.fixHtmlCodes
+import ftl.util.FlankCommonException
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -20,7 +21,7 @@ private val xmlMapper = XmlMapper(xmlModule)
 internal val xmlPrettyWriter = xmlMapper.writerWithDefaultPrettyPrinter()
 
 private fun xmlText(path: Path): String {
-    if (!path.toFile().exists()) throw RuntimeException("$path doesn't exist!")
+    if (!path.toFile().exists()) throw FlankCommonException("$path doesn't exist!")
     return String(Files.readAllBytes(path))
 }
 

--- a/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PRO
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.model.JUnitTestSuite
 import ftl.reports.xml.preprocesor.fixHtmlCodes
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -21,7 +21,7 @@ private val xmlMapper = XmlMapper(xmlModule)
 internal val xmlPrettyWriter = xmlMapper.writerWithDefaultPrettyPrinter()
 
 private fun xmlText(path: Path): String {
-    if (!path.toFile().exists()) throw FlankCommonException("$path doesn't exist!")
+    if (!path.toFile().exists()) throw FlankGeneralError("$path doesn't exist!")
     return String(Files.readAllBytes(path))
 }
 

--- a/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestSuite.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestSuite.kt
@@ -2,7 +2,7 @@ package ftl.reports.xml.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import java.util.Locale
 
 data class JUnitTestSuite(
@@ -91,7 +91,7 @@ data class JUnitTestSuite(
     }
 
     fun merge(other: JUnitTestSuite): JUnitTestSuite {
-        if (this.name != other.name) throw FlankCommonException("Attempted to merge ${other.name} into ${this.name}")
+        if (this.name != other.name) throw FlankGeneralError("Attempted to merge ${other.name} into ${this.name}")
 
         // tests, failures, errors
         this.tests = mergeInt(this.tests, other.tests)
@@ -109,7 +109,7 @@ data class JUnitTestSuite(
     }
 
     fun mergeTestTimes(other: JUnitTestSuite): JUnitTestSuite {
-        if (this.name != other.name) throw FlankCommonException("Attempted to merge ${other.name} into ${this.name}")
+        if (this.name != other.name) throw FlankGeneralError("Attempted to merge ${other.name} into ${this.name}")
 
         // For each new JUnitTestCase:
         //  * if it failed then pull timing info from old

--- a/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestSuite.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestSuite.kt
@@ -2,6 +2,7 @@ package ftl.reports.xml.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+import ftl.util.FlankCommonException
 import java.util.Locale
 
 data class JUnitTestSuite(
@@ -90,7 +91,7 @@ data class JUnitTestSuite(
     }
 
     fun merge(other: JUnitTestSuite): JUnitTestSuite {
-        if (this.name != other.name) throw RuntimeException("Attempted to merge ${other.name} into ${this.name}")
+        if (this.name != other.name) throw FlankCommonException("Attempted to merge ${other.name} into ${this.name}")
 
         // tests, failures, errors
         this.tests = mergeInt(this.tests, other.tests)
@@ -108,7 +109,7 @@ data class JUnitTestSuite(
     }
 
     fun mergeTestTimes(other: JUnitTestSuite): JUnitTestSuite {
-        if (this.name != other.name) throw RuntimeException("Attempted to merge ${other.name} into ${this.name}")
+        if (this.name != other.name) throw FlankCommonException("Attempted to merge ${other.name} into ${this.name}")
 
         // For each new JUnitTestCase:
         //  * if it failed then pull timing info from old

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -6,7 +6,7 @@ import ftl.args.isInstrumentationTest
 import ftl.run.common.prettyPrint
 import ftl.run.model.AndroidMatrixTestShards
 import ftl.run.platform.android.getAndroidMatrixShards
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 import ftl.util.obfuscatePrettyPrinter
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -16,7 +16,7 @@ suspend fun dumpShards(
     shardFilePath: String = ANDROID_SHARD_FILE,
     obfuscatedOutput: Boolean = false
 ) {
-    if (!args.isInstrumentationTest) throw FlankFatalError(
+    if (!args.isInstrumentationTest) throw FlankConfigurationError(
         "Cannot dump shards for non instrumentation test, ensure test apk has been set."
     )
     val shards: AndroidMatrixTestShards = args.getAndroidMatrixShards()

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -11,7 +11,7 @@ import ftl.run.common.fetchArtifacts
 import ftl.run.common.pollMatrices
 import ftl.run.platform.runAndroidTests
 import ftl.run.platform.runIosTests
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.FlankTimeoutError
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeoutOrNull
@@ -32,7 +32,7 @@ private suspend fun runTests(args: IArgs): TestResult {
     return when (args) {
         is AndroidArgs -> runAndroidTests(args)
         is IosArgs -> runIosTests(args)
-        else -> throw FlankCommonException("Unknown config type")
+        else -> throw FlankGeneralError("Unknown config type")
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -11,6 +11,7 @@ import ftl.run.common.fetchArtifacts
 import ftl.run.common.pollMatrices
 import ftl.run.platform.runAndroidTests
 import ftl.run.platform.runIosTests
+import ftl.util.FlankCommonException
 import ftl.util.FlankTimeoutError
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeoutOrNull
@@ -31,7 +32,7 @@ private suspend fun runTests(args: IArgs): TestResult {
     return when (args) {
         is AndroidArgs -> runAndroidTests(args)
         is IosArgs -> runIosTests(args)
-        else -> throw RuntimeException("Unknown config type")
+        else -> throw FlankCommonException("Unknown config type")
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/common/GetLastArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/GetLastArgs.kt
@@ -4,12 +4,12 @@ import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import java.nio.file.Paths
 
 /** Reads in the last matrices from the localResultDir folder **/
 internal fun getLastArgs(args: IArgs): IArgs {
-    val lastRun = args.getLastGcsPath() ?: throw FlankCommonException("no runs found in results/ folder")
+    val lastRun = args.getLastGcsPath() ?: throw FlankGeneralError("no runs found in results/ folder")
 
     val iosConfig = Paths.get(args.localResultDir, lastRun, FtlConstants.defaultIosConfig)
     val androidConfig = Paths.get(args.localResultDir, lastRun, FtlConstants.defaultAndroidConfig)
@@ -17,6 +17,6 @@ internal fun getLastArgs(args: IArgs): IArgs {
     return when {
         iosConfig.toFile().exists() -> IosArgs.load(iosConfig)
         androidConfig.toFile().exists() -> AndroidArgs.load(androidConfig)
-        else -> throw FlankCommonException("No config file found in the last run folder: $lastRun")
+        else -> throw FlankGeneralError("No config file found in the last run folder: $lastRun")
     }
 }

--- a/test_runner/src/main/kotlin/ftl/run/common/GetLastArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/GetLastArgs.kt
@@ -4,12 +4,12 @@ import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
-import ftl.util.FlankFatalError
+import ftl.util.FlankCommonException
 import java.nio.file.Paths
 
 /** Reads in the last matrices from the localResultDir folder **/
 internal fun getLastArgs(args: IArgs): IArgs {
-    val lastRun = args.getLastGcsPath() ?: throw FlankFatalError("no runs found in results/ folder")
+    val lastRun = args.getLastGcsPath() ?: throw FlankCommonException("no runs found in results/ folder")
 
     val iosConfig = Paths.get(args.localResultDir, lastRun, FtlConstants.defaultIosConfig)
     val androidConfig = Paths.get(args.localResultDir, lastRun, FtlConstants.defaultAndroidConfig)
@@ -17,6 +17,6 @@ internal fun getLastArgs(args: IArgs): IArgs {
     return when {
         iosConfig.toFile().exists() -> IosArgs.load(iosConfig)
         androidConfig.toFile().exists() -> AndroidArgs.load(androidConfig)
-        else -> throw FlankFatalError("No config file found in the last run folder: $lastRun")
+        else -> throw FlankCommonException("No config file found in the last run folder: $lastRun")
     }
 }

--- a/test_runner/src/main/kotlin/ftl/run/common/GetLastMatrices.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/GetLastMatrices.kt
@@ -5,12 +5,12 @@ import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.json.MatrixMap
 import ftl.json.SavedMatrix
-import ftl.util.FlankFatalError
+import ftl.util.FlankCommonException
 import java.nio.file.Paths
 
 /** Reads in the last matrices from the localResultDir folder **/
 internal fun getLastMatrices(args: IArgs): MatrixMap {
-    val lastRun = args.getLastGcsPath() ?: throw FlankFatalError("no runs found in results/ folder")
+    val lastRun = args.getLastGcsPath() ?: throw FlankCommonException("no runs found in results/ folder")
 
     println("Loading run $lastRun")
     return matrixPathToObj(lastRun, args)

--- a/test_runner/src/main/kotlin/ftl/run/common/GetLastMatrices.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/GetLastMatrices.kt
@@ -5,12 +5,12 @@ import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.json.MatrixMap
 import ftl.json.SavedMatrix
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import java.nio.file.Paths
 
 /** Reads in the last matrices from the localResultDir folder **/
 internal fun getLastMatrices(args: IArgs): MatrixMap {
-    val lastRun = args.getLastGcsPath() ?: throw FlankCommonException("no runs found in results/ folder")
+    val lastRun = args.getLastGcsPath() ?: throw FlankGeneralError("no runs found in results/ folder")
 
     println("Loading run $lastRun")
     return matrixPathToObj(lastRun, args)

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -17,7 +17,7 @@ import ftl.run.platform.android.uploadOtherFiles
 import ftl.run.platform.common.afterRunTests
 import ftl.run.platform.common.beforeRunMessage
 import ftl.run.platform.common.beforeRunTests
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -59,7 +59,7 @@ internal suspend fun runAndroidTests(args: AndroidArgs): TestResult = coroutineS
             }
         }
 
-    if (testMatrices.isEmpty()) throw FlankCommonException("There are no tests to run.")
+    if (testMatrices.isEmpty()) throw FlankGeneralError("There are no tests to run.")
 
     println(beforeRunMessage(args, allTestShardChunks))
     TestResult(

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
@@ -5,7 +5,7 @@ import ftl.args.AndroidArgs
 import ftl.run.model.AndroidTestContext
 import ftl.run.model.InstrumentationTestContext
 import ftl.run.model.RoboTestContext
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.asFileReference
 
 @VisibleForTesting
@@ -28,7 +28,7 @@ internal fun AndroidArgs.resolveApks(): List<AndroidTestContext> = listOfNotNull
         InstrumentationTestContext(
             app = (it.app ?: appApk)
                 ?.asFileReference()
-                ?: throw FlankCommonException("Cannot create app-test apks pair for instrumentation tests, missing app apk for test ${it.test}"),
+                ?: throw FlankGeneralError("Cannot create app-test apks pair for instrumentation tests, missing app apk for test ${it.test}"),
             test = it.test.asFileReference()
         )
     }

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
@@ -5,7 +5,7 @@ import ftl.args.AndroidArgs
 import ftl.run.model.AndroidTestContext
 import ftl.run.model.InstrumentationTestContext
 import ftl.run.model.RoboTestContext
-import ftl.util.FlankFatalError
+import ftl.util.FlankCommonException
 import ftl.util.asFileReference
 
 @VisibleForTesting
@@ -28,7 +28,7 @@ internal fun AndroidArgs.resolveApks(): List<AndroidTestContext> = listOfNotNull
         InstrumentationTestContext(
             app = (it.app ?: appApk)
                 ?.asFileReference()
-                ?: throw FlankFatalError("Cannot create app-test apks pair for instrumentation tests, missing app apk for test ${it.test}"),
+                ?: throw FlankCommonException("Cannot create app-test apks pair for instrumentation tests, missing app apk for test ${it.test}"),
             test = it.test.asFileReference()
         )
     }

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunTests.kt
@@ -5,6 +5,7 @@ import ftl.config.FtlConstants
 import ftl.gc.GcStorage
 import ftl.gc.GcTesting
 import ftl.gc.GcToolResults
+import ftl.util.FlankCommonException
 import ftl.util.StopWatch
 import java.io.File
 
@@ -30,9 +31,9 @@ internal fun beforeRunTests(args: IArgs): Pair<StopWatch, String> {
 
 private fun assertMockUrl() {
     if (!FtlConstants.useMock) return
-    if (!GcTesting.get.rootUrl.contains(FtlConstants.localhost)) throw RuntimeException("expected localhost in GcTesting")
-    if (!GcStorage.storageOptions.host.contains(FtlConstants.localhost)) throw RuntimeException("expected localhost in GcStorage")
-    if (!GcToolResults.service.rootUrl.contains(FtlConstants.localhost)) throw RuntimeException("expected localhost in GcToolResults")
+    if (!GcTesting.get.rootUrl.contains(FtlConstants.localhost)) throw FlankCommonException("expected localhost in GcTesting")
+    if (!GcStorage.storageOptions.host.contains(FtlConstants.localhost)) throw FlankCommonException("expected localhost in GcStorage")
+    if (!GcToolResults.service.rootUrl.contains(FtlConstants.localhost)) throw FlankCommonException("expected localhost in GcToolResults")
 }
 
 private fun deleteMockResultDirOnShutDown(args: IArgs, runGcsPath: String) {

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunTests.kt
@@ -5,7 +5,7 @@ import ftl.config.FtlConstants
 import ftl.gc.GcStorage
 import ftl.gc.GcTesting
 import ftl.gc.GcToolResults
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.StopWatch
 import java.io.File
 
@@ -31,9 +31,9 @@ internal fun beforeRunTests(args: IArgs): Pair<StopWatch, String> {
 
 private fun assertMockUrl() {
     if (!FtlConstants.useMock) return
-    if (!GcTesting.get.rootUrl.contains(FtlConstants.localhost)) throw FlankCommonException("expected localhost in GcTesting")
-    if (!GcStorage.storageOptions.host.contains(FtlConstants.localhost)) throw FlankCommonException("expected localhost in GcStorage")
-    if (!GcToolResults.service.rootUrl.contains(FtlConstants.localhost)) throw FlankCommonException("expected localhost in GcToolResults")
+    if (!GcTesting.get.rootUrl.contains(FtlConstants.localhost)) throw FlankGeneralError("expected localhost in GcTesting")
+    if (!GcStorage.storageOptions.host.contains(FtlConstants.localhost)) throw FlankGeneralError("expected localhost in GcStorage")
+    if (!GcToolResults.service.rootUrl.contains(FtlConstants.localhost)) throw FlankGeneralError("expected localhost in GcToolResults")
 }
 
 private fun deleteMockResultDirOnShutDown(args: IArgs, runGcsPath: String) {

--- a/test_runner/src/main/kotlin/ftl/run/status/OutputStyle.kt
+++ b/test_runner/src/main/kotlin/ftl/run/status/OutputStyle.kt
@@ -1,9 +1,9 @@
 package ftl.run.status
 
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 
 enum class OutputStyle { Verbose, Single, Multi }
 
 fun String.asOutputStyle() = capitalize().let { capitalized ->
     OutputStyle.values().find { style -> style.name == capitalized }
-} ?: throw FlankFatalError("Cannot parse output-style: $this, it should be one of ${OutputStyle.values().map { it.name.toLowerCase() }}")
+} ?: throw FlankConfigurationError("Cannot parse output-style: $this, it should be one of ${OutputStyle.values().map { it.name.toLowerCase() }}")

--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -3,7 +3,7 @@ package ftl.shard
 import ftl.args.IArgs
 import ftl.args.IosArgs
 import ftl.reports.xml.model.JUnitTestResult
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 import ftl.util.FlankTestMethod
 import kotlin.math.roundToInt
 
@@ -41,7 +41,7 @@ fun createShardsByShardCount(
     args: IArgs,
     forcedShardCount: Int = -1
 ): List<TestShard> {
-    if (forcedShardCount < -1 || forcedShardCount == 0) throw FlankFatalError("Invalid forcedShardCount value $forcedShardCount")
+    if (forcedShardCount < -1 || forcedShardCount == 0) throw FlankConfigurationError("Invalid forcedShardCount value $forcedShardCount")
     val maxShards = maxShards(args.maxTestShards, forcedShardCount)
 
     val previousMethodDurations = createTestMethodDurationMap(oldTestResult, args)
@@ -54,7 +54,7 @@ fun createShardsByShardCount(
     val shardsCount = matchNumberOfShardsWithTestCount(maxShards, testCount)
 
     // Create the list of shards we will return
-    if (shardsCount <= 0) throw FlankFatalError(
+    if (shardsCount <= 0) throw FlankConfigurationError(
         """Invalid shard count. To debug try: flank ${args.platformName} run --dump-shards
                     | args.maxTestShards: ${args.maxTestShards}
                     | forcedShardCount: $forcedShardCount 

--- a/test_runner/src/main/kotlin/ftl/shard/ShardCount.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/ShardCount.kt
@@ -3,7 +3,7 @@ package ftl.shard
 import ftl.args.IArgs
 import ftl.args.IArgs.Companion.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE
 import ftl.reports.xml.model.JUnitTestResult
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 import ftl.util.FlankTestMethod
 import kotlin.math.ceil
 import kotlin.math.min
@@ -18,7 +18,7 @@ fun shardCountByTime(
     args: IArgs
 ): Int = when {
     args.shardTime == NO_LIMIT -> NO_LIMIT
-    args.shardTime < NO_LIMIT || args.shardTime == 0 -> throw FlankFatalError("Invalid shard time ${args.shardTime}")
+    args.shardTime < NO_LIMIT || args.shardTime == 0 -> throw FlankConfigurationError("Invalid shard time ${args.shardTime}")
     else -> calculateShardCount(testsToRun, oldTestResult, args)
 }
 
@@ -43,7 +43,7 @@ private fun calculateShardCount(
     testsTotalTime <= args.shardTime -> SINGLE_SHARD
     args.maxTestShards == NO_LIMIT -> min(AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last, testsToRunCount)
     else -> shardCount(testsTotalTime, args).also { count ->
-        if (count <= 0) throw FlankFatalError("Invalid shard count $count")
+        if (count <= 0) throw FlankConfigurationError("Invalid shard count $count")
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/util/Bash.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Bash.kt
@@ -19,7 +19,7 @@ object Bash {
 
         if (process.failed()) {
             System.err.println("Error: ${result.stderr}")
-            throw FlankCommonException("Command failed: $cmd")
+            throw FlankGeneralError("Command failed: $cmd")
         }
 
         return result.stdout.trim() + result.stderr.trim()

--- a/test_runner/src/main/kotlin/ftl/util/Bash.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Bash.kt
@@ -19,7 +19,7 @@ object Bash {
 
         if (process.failed()) {
             System.err.println("Error: ${result.stderr}")
-            throw RuntimeException("Command failed: $cmd")
+            throw FlankCommonException("Command failed: $cmd")
         }
 
         return result.stdout.trim() + result.stderr.trim()

--- a/test_runner/src/main/kotlin/ftl/util/FileLoader.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FileLoader.kt
@@ -8,5 +8,5 @@ import java.nio.file.Path
 fun loadFile(filePath: Path): Reader = try {
     Files.newBufferedReader(filePath)
 } catch (fileNotFound: NoSuchFileException) {
-    throw FlankFatalError("File not found: ${fileNotFound.message}")
+    throw FlankGeneralFailure("File not found: ${fileNotFound.message}")
 }

--- a/test_runner/src/main/kotlin/ftl/util/FileLoader.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FileLoader.kt
@@ -8,5 +8,5 @@ import java.nio.file.Path
 fun loadFile(filePath: Path): Reader = try {
     Files.newBufferedReader(filePath)
 } catch (fileNotFound: NoSuchFileException) {
-    throw FlankGeneralFailure("File not found: ${fileNotFound.message}")
+    throw FlankCommonException("File not found: ${fileNotFound.message}")
 }

--- a/test_runner/src/main/kotlin/ftl/util/FileLoader.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FileLoader.kt
@@ -8,5 +8,5 @@ import java.nio.file.Path
 fun loadFile(filePath: Path): Reader = try {
     Files.newBufferedReader(filePath)
 } catch (fileNotFound: NoSuchFileException) {
-    throw FlankCommonException("File not found: ${fileNotFound.message}")
+    throw FlankGeneralError("File not found: ${fileNotFound.message}")
 }

--- a/test_runner/src/main/kotlin/ftl/util/FileReference.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FileReference.kt
@@ -14,7 +14,7 @@ data class FileReference(
 
 private fun FileReference.assertNotEmpty() {
     if (local.isBlank() && gcs.isBlank())
-        throw FlankCommonException("Cannot create empty FileReference")
+        throw FlankGeneralError("Cannot create empty FileReference")
 }
 
 fun String.asFileReference(): FileReference =

--- a/test_runner/src/main/kotlin/ftl/util/FileReference.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FileReference.kt
@@ -14,7 +14,7 @@ data class FileReference(
 
 private fun FileReference.assertNotEmpty() {
     if (local.isBlank() && gcs.isBlank())
-        throw FlankFatalError("Cannot create empty FileReference")
+        throw FlankCommonException("Cannot create empty FileReference")
 }
 
 fun String.asFileReference(): FileReference =

--- a/test_runner/src/main/kotlin/ftl/util/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankException.kt
@@ -12,7 +12,7 @@ sealed class FlankException(message: String? = null, cause: Throwable? = null) :
 /**
  * Thrown when all matrices are finished and at least one test failed/is inconclusive.
  *
- * Exit code: 1
+ * Exit code: 10
  *
  * @param matrices [List]<[SavedMatrix]> List of failed matrices
  */

--- a/test_runner/src/main/kotlin/ftl/util/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankException.kt
@@ -52,7 +52,11 @@ class FlankTimeoutError(val map: Map<String, SavedMatrix>?, val projectId: Strin
  *
  * @param message [String] message to be printed to [System.err]
  */
-class FlankConfigurationError(message: String) : FlankException(message)
+class FlankConfigurationError : FlankException {
+    constructor(message: String) : super(message)
+    constructor(cause: Exception) : super(cause = cause)
+    constructor(message: String, cause: Exception) : super(message, cause)
+}
 
 /**
  * A general failure occurred. Possible causes include: a filename that does not exist or an HTTP/network error.

--- a/test_runner/src/main/kotlin/ftl/util/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankException.kt
@@ -21,7 +21,7 @@ class FailedMatrix(val matrices: List<SavedMatrix>, val ignoreFailed: Boolean = 
  * Thrown when at least one matrix is not finished.
  * Usually indicates Firebase TestLab internal error
  *
- * Exit code: 3
+ * Exit code: 15
  *
  * @param matrix [SavedMatrix] Not finished matrix (with matrix state different then FINISHED)
  */
@@ -72,7 +72,6 @@ sealed class FTLProjectError(exc: IOException) : FlankException("Caused by: $exc
 class PermissionDenied(exc: IOException) : FTLProjectError(exc)
 class ProjectNotFound(exc: IOException) : FTLProjectError(exc)
 
-
 /**
  * A general failure occurred. Possible causes include: a filename that does not exist or an HTTP/network error.
  *
@@ -80,4 +79,31 @@ class ProjectNotFound(exc: IOException) : FTLProjectError(exc)
  *
  * @param message [String] message to be printed to [System.err]
  */
-class FlankGeneralFailure(message: String): FlankException(message)
+class FlankGeneralFailure(message: String) : FlankException(message)
+
+/**
+ * The test environment for this test execution is not supported because of incompatible test dimensions. This error might occur if the selected Android API level is not supported by the selected device type.
+ *
+ * Exit code: 18
+ *
+ * @param message [String] message to be printed to [System.err]
+ */
+class IncompatibleTestDimension(message: String) : FlankException(message)
+
+/**
+ * The test matrix was canceled by the user.
+ *
+ * Exit code: 19
+ *
+ * @param message [String] message to be printed to [System.err]
+ */
+class MatrixCanceled(message: String) : FlankException(message)
+
+/**
+ * A test infrastructure error occurred.
+ *
+ * Exit code: 20
+ *
+ * @param message [String] message to be printed to [System.err]
+ */
+class InfrastructureError(message: String) : FlankException(message)

--- a/test_runner/src/main/kotlin/ftl/util/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankException.kt
@@ -16,7 +16,7 @@ sealed class FlankException(message: String? = null, cause: Throwable? = null) :
  *
  * @param matrices [List]<[SavedMatrix]> List of failed matrices
  */
-class FailedMatrix(val matrices: List<SavedMatrix>, val ignoreFailed: Boolean = false) : FlankException()
+class FailedMatrixError(val matrices: List<SavedMatrix>, val ignoreFailed: Boolean = false) : FlankException()
 
 /**
  * Thrown when at least one matrix is not finished.
@@ -52,7 +52,7 @@ class FlankTimeoutError(val map: Map<String, SavedMatrix>?, val projectId: Strin
  *
  * @param message [String] message to be printed to [System.err]
  */
-class FlankFatalError(message: String) : FlankException(message)
+class FlankConfigurationError(message: String) : FlankException(message)
 
 /**
  * A general failure occurred. Possible causes include: a filename that does not exist or an HTTP/network error.
@@ -61,7 +61,7 @@ class FlankFatalError(message: String) : FlankException(message)
  *
  * @param message [String] message to be printed to [System.err]
  */
-class FlankCommonException : FlankException {
+class FlankGeneralError : FlankException {
     constructor(message: String) : super(message)
     constructor(cause: Exception) : super(cause = cause)
     constructor(message: String, cause: Exception) : super(message, cause)
@@ -69,7 +69,7 @@ class FlankCommonException : FlankException {
 
 /**
  * Base class for project related exceptions.
- * Should be caught and rewrap to FlankCommonException with project id info attached.
+ * Should be caught and rewrap to FlankGeneralError with project id info attached.
  *
  * @param exc [IOException]
  */
@@ -84,7 +84,7 @@ class ProjectNotFound(exc: IOException) : FTLProjectError(exc)
  *
  * @param message [String] message to be printed to [System.err]
  */
-class IncompatibleTestDimension(message: String) : FlankException(message)
+class IncompatibleTestDimensionError(message: String) : FlankException(message)
 
 /**
  * The test matrix was canceled by the user.
@@ -93,7 +93,7 @@ class IncompatibleTestDimension(message: String) : FlankException(message)
  *
  * @param message [String] message to be printed to [System.err]
  */
-class MatrixCanceled(message: String) : FlankException(message)
+class MatrixCanceledError(message: String) : FlankException(message)
 
 /**
  * A test infrastructure error occurred.

--- a/test_runner/src/main/kotlin/ftl/util/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankException.kt
@@ -31,7 +31,7 @@ class FTLError(val matrix: SavedMatrix) : FlankException()
 /**
  * Thrown when doctor command found an error in yml fail and wa unable to fix it
  *
- * Exit code: 1
+ * Exit code: 2
  */
 class YmlValidationError : FlankException()
 
@@ -76,7 +76,6 @@ class FlankCommonException : FlankException {
 sealed class FTLProjectError(exc: IOException) : FlankException("Caused by: $exc")
 class PermissionDenied(exc: IOException) : FTLProjectError(exc)
 class ProjectNotFound(exc: IOException) : FTLProjectError(exc)
-
 
 /**
  * The test environment for this test execution is not supported because of incompatible test dimensions. This error might occur if the selected Android API level is not supported by the selected device type.

--- a/test_runner/src/main/kotlin/ftl/util/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankException.kt
@@ -71,3 +71,13 @@ class FlankCommonException(message: String) : FlankException(message)
 sealed class FTLProjectError(exc: IOException) : FlankException("Caused by: $exc")
 class PermissionDenied(exc: IOException) : FTLProjectError(exc)
 class ProjectNotFound(exc: IOException) : FTLProjectError(exc)
+
+
+/**
+ * A general failure occurred. Possible causes include: a filename that does not exist or an HTTP/network error.
+ *
+ * Exit code: 1
+ *
+ * @param message [String] message to be printed to [System.err]
+ */
+class FlankGeneralFailure(message: String): FlankException(message)

--- a/test_runner/src/main/kotlin/ftl/util/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankException.kt
@@ -2,11 +2,12 @@ package ftl.util
 
 import ftl.json.SavedMatrix
 import java.io.IOException
+import java.lang.Exception
 
 /**
  * Base class for all custom flank's exceptions
  */
-sealed class FlankException(message: String? = null) : Throwable(message)
+sealed class FlankException(message: String? = null, cause: Throwable? = null) : Throwable(message, cause)
 
 /**
  * Thrown when all matrices are finished and at least one test failed/is inconclusive.
@@ -54,13 +55,17 @@ class FlankTimeoutError(val map: Map<String, SavedMatrix>?, val projectId: Strin
 class FlankFatalError(message: String) : FlankException(message)
 
 /**
- * Common flank exception
+ * A general failure occurred. Possible causes include: a filename that does not exist or an HTTP/network error.
  *
  * Exit code: 1
  *
  * @param message [String] message to be printed to [System.err]
  */
-class FlankCommonException(message: String) : FlankException(message)
+class FlankCommonException : FlankException {
+    constructor(message: String) : super(message)
+    constructor(cause: Exception) : super(cause = cause)
+    constructor(message: String, cause: Exception) : super(message, cause)
+}
 
 /**
  * Base class for project related exceptions.
@@ -72,14 +77,6 @@ sealed class FTLProjectError(exc: IOException) : FlankException("Caused by: $exc
 class PermissionDenied(exc: IOException) : FTLProjectError(exc)
 class ProjectNotFound(exc: IOException) : FTLProjectError(exc)
 
-/**
- * A general failure occurred. Possible causes include: a filename that does not exist or an HTTP/network error.
- *
- * Exit code: 1
- *
- * @param message [String] message to be printed to [System.err]
- */
-class FlankGeneralFailure(message: String) : FlankException(message)
 
 /**
  * The test environment for this test execution is not supported because of incompatible test dimensions. This error might occur if the selected Android API level is not supported by the selected device type.

--- a/test_runner/src/main/kotlin/ftl/util/FlankExitCodes.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankExitCodes.kt
@@ -1,0 +1,14 @@
+package ftl.util
+
+
+const val SUCCESS = 0
+const val GENERAL_FAILURE = 1
+const val UNKNOWN_ARGUMENT = 2
+const val NOT_PASSED = 10
+const val UNEXPECTED_ERROR = 15
+const val INCOMPATIBLE_TEST_DIMENSION = 18
+const val CANCELED_BY_USER = 19
+const val INFRASTRUCTURE_ERROR = 20
+
+
+

--- a/test_runner/src/main/kotlin/ftl/util/FlankExitCodes.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FlankExitCodes.kt
@@ -1,14 +1,10 @@
 package ftl.util
 
-
 const val SUCCESS = 0
 const val GENERAL_FAILURE = 1
-const val UNKNOWN_ARGUMENT = 2
+const val CONFIGURATION_FAIL = 2
 const val NOT_PASSED = 10
 const val UNEXPECTED_ERROR = 15
 const val INCOMPATIBLE_TEST_DIMENSION = 18
 const val CANCELED_BY_USER = 19
 const val INFRASTRUCTURE_ERROR = 20
-
-
-

--- a/test_runner/src/main/kotlin/ftl/util/StopWatch.kt
+++ b/test_runner/src/main/kotlin/ftl/util/StopWatch.kt
@@ -12,7 +12,7 @@ class StopWatch {
     }
 
     fun check(alignSeconds: Boolean = false): String {
-        if (startTime == 0L) throw RuntimeException("startTime is zero. start not called")
+        if (startTime == 0L) throw FlankCommonException("startTime is zero. start not called")
 
         val duration = System.currentTimeMillis() - startTime
 

--- a/test_runner/src/main/kotlin/ftl/util/StopWatch.kt
+++ b/test_runner/src/main/kotlin/ftl/util/StopWatch.kt
@@ -12,7 +12,7 @@ class StopWatch {
     }
 
     fun check(alignSeconds: Boolean = false): String {
-        if (startTime == 0L) throw FlankCommonException("startTime is zero. start not called")
+        if (startTime == 0L) throw FlankGeneralError("startTime is zero. start not called")
 
         val duration = System.currentTimeMillis() - startTime
 

--- a/test_runner/src/main/kotlin/ftl/util/Utils.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Utils.kt
@@ -144,7 +144,6 @@ fun withGlobalExceptionHandling(block: () -> Int) {
                 if (t.ignoreFailed) exitProcess(SUCCESS)
                 else exitProcess(NOT_PASSED)
             }
-            is YmlValidationError -> exitProcess(GENERAL_FAILURE)
             is FlankTimeoutError -> {
                 println("\nCanceling flank due to timeout")
                 runBlocking {
@@ -154,13 +153,16 @@ fun withGlobalExceptionHandling(block: () -> Int) {
                 }
                 exitProcess(GENERAL_FAILURE)
             }
+
             is FTLError -> {
                 t.matrix.logError()
                 exitProcess(UNEXPECTED_ERROR)
             }
+
+            is YmlValidationError,
             is FlankFatalError -> {
                 System.err.println(t.message)
-                exitProcess(INFRASTRUCTURE_ERROR)
+                exitProcess(CONFIGURATION_FAIL)
             }
 
             // We need to cover the case where some component in the call stack starts a non-daemon

--- a/test_runner/src/main/kotlin/ftl/util/Utils.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Utils.kt
@@ -140,7 +140,7 @@ fun withGlobalExceptionHandling(block: () -> Int) {
             }
             is FailedMatrix -> {
                 if (t.ignoreFailed) exitProcess(0)
-                else exitProcess(-1)
+                else exitProcess(10)
             }
             is YmlValidationError -> exitProcess(-1)
             is FlankTimeoutError -> {

--- a/test_runner/src/main/kotlin/ftl/util/Utils.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Utils.kt
@@ -41,7 +41,7 @@ fun join(first: String, vararg more: String): String {
 
 fun assertNotEmpty(str: String, e: String) {
     if (str.isEmpty()) {
-        throw FlankFatalError(e)
+        throw FlankCommonException(e)
     }
 }
 
@@ -91,7 +91,7 @@ private val classLoader = Thread.currentThread().contextClassLoader
 
 private fun getResource(name: String): InputStream {
     return classLoader.getResourceAsStream(name)
-        ?: throw RuntimeException("Unable to find resource: $name")
+        ?: throw FlankCommonException("Unable to find resource: $name")
 }
 
 // app version: flank_snapshot
@@ -130,10 +130,6 @@ fun withGlobalExceptionHandling(block: () -> Int) {
         exitProcess(block())
     } catch (t: Throwable) {
         when (t) {
-            is FlankGeneralFailure -> {
-                System.err.println("\n${t.message}")
-                exitProcess(GENERAL_FAILURE)
-            }
             is FlankCommonException -> {
                 System.err.println("\n${t.message}")
                 exitProcess(GENERAL_FAILURE)
@@ -143,9 +139,7 @@ fun withGlobalExceptionHandling(block: () -> Int) {
                 exitProcess(INCOMPATIBLE_TEST_DIMENSION)
             }
             is MatrixCanceled -> exitProcess(CANCELED_BY_USER)
-
             is InfrastructureError -> exitProcess(INFRASTRUCTURE_ERROR)
-
             is FailedMatrix -> {
                 if (t.ignoreFailed) exitProcess(SUCCESS)
                 else exitProcess(NOT_PASSED)
@@ -158,7 +152,7 @@ fun withGlobalExceptionHandling(block: () -> Int) {
                         cancelMatrices(t.map, t.projectId)
                     }
                 }
-                exitProcess(-1)
+                exitProcess(GENERAL_FAILURE)
             }
             is FTLError -> {
                 t.matrix.logError()

--- a/test_runner/src/main/kotlin/ftl/util/Utils.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Utils.kt
@@ -131,7 +131,7 @@ fun withGlobalExceptionHandling(block: () -> Int) {
     } catch (t: Throwable) {
         when (t) {
             is FlankCommonException -> {
-                System.err.println("\n${t.message}")
+                System.err.println(t.message)
                 exitProcess(GENERAL_FAILURE)
             }
             is IncompatibleTestDimension -> {

--- a/test_runner/src/main/kotlin/ftl/util/Utils.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Utils.kt
@@ -134,6 +134,7 @@ fun withGlobalExceptionHandling(block: () -> Int) {
                 System.err.println("\n${t.message}")
                 exitProcess(GENERAL_FAILURE)
             }
+
             is FlankTimeoutError -> {
                 println("\nCanceling flank due to timeout")
                 runBlocking {
@@ -143,17 +144,20 @@ fun withGlobalExceptionHandling(block: () -> Int) {
                 }
                 exitProcess(GENERAL_FAILURE)
             }
+
             is IncompatibleTestDimensionError -> {
                 System.err.println("\n${t.message}")
                 exitProcess(INCOMPATIBLE_TEST_DIMENSION)
             }
+
             is MatrixCanceledError -> exitProcess(CANCELED_BY_USER)
+
             is InfrastructureError -> exitProcess(INFRASTRUCTURE_ERROR)
+
             is FailedMatrixError -> {
                 if (t.ignoreFailed) exitProcess(SUCCESS)
                 else exitProcess(NOT_PASSED)
             }
-
 
             is FTLError -> {
                 t.matrix.logError()

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -8,8 +8,9 @@ fun main() {
     // for debugging. Run test from IntelliJ IDEA
 
     // run "gradle check" to generate required fixtures
-    val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
-        ?: "YOUR PROJECT ID"
+//    val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
+//        ?: "YOUR PROJECT ID"
+    val projectId = "kiwi22"
     val quantity = "single"
     val type = "error"
     // Bugsnag keeps the process alive so we must call exitProcess

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -10,7 +10,7 @@ fun main() {
     // run "gradle check" to generate required fixtures
     val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
         ?: "YOUR PROJECT ID"
-    val quantity = "multiple"
+    val quantity = "single"
     val type = "success"
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151
@@ -18,7 +18,7 @@ fun main() {
         CommandLine(Main()).execute(
 //            "--debug",
             "firebase", "test", "android",
-            "run",
+            "run", 
 //            "--dry",
 //            "--dump-shards",
 //            "--output-style=single",

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -11,14 +11,14 @@ fun main() {
     val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
         ?: "YOUR PROJECT ID"
     val quantity = "single"
-    val type = "success"
+    val type = "error"
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151
     withGlobalExceptionHandling {
         CommandLine(Main()).execute(
 //            "--debug",
             "firebase", "test", "android",
-            "run", 
+            "run",
 //            "--dry",
 //            "--dump-shards",
 //            "--output-style=single",

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -8,9 +8,9 @@ fun main() {
     // for debugging. Run test from IntelliJ IDEA
 
     // run "gradle check" to generate required fixtures
-//    val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
-//        ?: "YOUR PROJECT ID"
-    val projectId = "kiwi22"
+    val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
+        ?: "YOUR PROJECT ID"
+
     val quantity = "single"
     val type = "error"
     // Bugsnag keeps the process alive so we must call exitProcess

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -20,9 +20,9 @@ import ftl.test.util.TestHelper.absolutePath
 import ftl.test.util.TestHelper.assert
 import ftl.test.util.TestHelper.getPath
 import ftl.test.util.assertThrowsWithMessage
-import ftl.util.FlankCommonException
-import ftl.util.FlankFatalError
-import ftl.util.IncompatibleTestDimension
+import ftl.util.FlankGeneralError
+import ftl.util.FlankConfigurationError
+import ftl.util.IncompatibleTestDimensionError
 import ftl.util.asFileReference
 import io.mockk.every
 import io.mockk.mockkStatic
@@ -145,7 +145,7 @@ class AndroidArgsTest {
 
     @Test
     fun `androidArgs invalidModel`() {
-        assertThrowsWithMessage(IncompatibleTestDimension::class, "Unsupported model id") {
+        assertThrowsWithMessage(IncompatibleTestDimensionError::class, "Unsupported model id") {
             AndroidArgs.load(
                 """
             gcloud:
@@ -161,7 +161,7 @@ class AndroidArgsTest {
 
     @Test
     fun `androidArgs invalidVersion`() {
-        assertThrowsWithMessage(IncompatibleTestDimension::class, "Unsupported version id") {
+        assertThrowsWithMessage(IncompatibleTestDimensionError::class, "Unsupported version id") {
             AndroidArgs.load(
                 """
         gcloud:
@@ -177,7 +177,7 @@ class AndroidArgsTest {
 
     @Test
     fun `androidArgs incompatibleModel`() {
-        assertThrowsWithMessage(IncompatibleTestDimension::class, "Incompatible model") {
+        assertThrowsWithMessage(IncompatibleTestDimensionError::class, "Incompatible model") {
             AndroidArgs.load(
                 """
         gcloud:
@@ -681,7 +681,7 @@ AndroidArgs
         assertThat(androidArgs.numUniformShards).isEqualTo(expected)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should throw if numUniformShards is specified along with maxTestShards`() {
         val yaml = """
         gcloud:
@@ -743,7 +743,7 @@ AndroidArgs
         assertThat(androidArgs.directoriesToPull).isEqualTo(listOf("/sdcard/test", "/data/local/tmp/test"))
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should throw FlankFatalError when invalid cli directoriesToPull`() {
         val cli = AndroidRunCommand()
         CommandLine(cli).parseArgs("--directories-to-pull=a,b")
@@ -1163,7 +1163,7 @@ AndroidArgs
         assertThat(args.outputStyle).isEqualTo(OutputStyle.Verbose)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `cli output-style fail on parse`() {
         val yaml = """
         gcloud:
@@ -1196,7 +1196,7 @@ AndroidArgs
         assertEquals(4, chunks.size)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should fail on missing app apk -- yml file`() {
         val yaml = """
         flank:
@@ -1241,7 +1241,7 @@ AndroidArgs
         assertFalse(args.ignoreFailedTests)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should throw if both instrumentation and robo tests are specified`() {
         val yaml = """
         gcloud:
@@ -1317,8 +1317,8 @@ AndroidArgs
         )
     }
 
-    @Test(expected = FlankCommonException::class)
-    fun `should throw FlankCommonException if not tests to be run overall`() {
+    @Test(expected = FlankGeneralError::class)
+    fun `should throw FlankGeneralError if not tests to be run overall`() {
         val yaml = """
         gcloud:
           app: $appApk
@@ -1494,7 +1494,7 @@ AndroidArgs
         assertEquals(10, args.maxTestShards)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should throw when maximum test shards for virtual devices limit exceeded`() {
         val yaml = """
         gcloud:
@@ -1507,7 +1507,7 @@ AndroidArgs
         AndroidArgs.load(yaml)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should throw when maximum test shards for physical devices limit exceeded`() {
         val yaml = """
         gcloud:

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -22,6 +22,7 @@ import ftl.test.util.TestHelper.getPath
 import ftl.test.util.assertThrowsWithMessage
 import ftl.util.FlankCommonException
 import ftl.util.FlankFatalError
+import ftl.util.IncompatibleTestDimension
 import ftl.util.asFileReference
 import io.mockk.every
 import io.mockk.mockkStatic
@@ -144,7 +145,7 @@ class AndroidArgsTest {
 
     @Test
     fun `androidArgs invalidModel`() {
-        assertThrowsWithMessage(FlankFatalError::class, "Unsupported model id") {
+        assertThrowsWithMessage(IncompatibleTestDimension::class, "Unsupported model id") {
             AndroidArgs.load(
                 """
             gcloud:
@@ -160,7 +161,7 @@ class AndroidArgsTest {
 
     @Test
     fun `androidArgs invalidVersion`() {
-        assertThrowsWithMessage(FlankFatalError::class, "Unsupported version id") {
+        assertThrowsWithMessage(IncompatibleTestDimension::class, "Unsupported version id") {
             AndroidArgs.load(
                 """
         gcloud:
@@ -176,7 +177,7 @@ class AndroidArgsTest {
 
     @Test
     fun `androidArgs incompatibleModel`() {
-        assertThrowsWithMessage(FlankFatalError::class, "Incompatible model") {
+        assertThrowsWithMessage(IncompatibleTestDimension::class, "Incompatible model") {
             AndroidArgs.load(
                 """
         gcloud:

--- a/test_runner/src/test/kotlin/ftl/args/ArgsHelperFilePathTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ArgsHelperFilePathTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth
 import ftl.config.FtlConstants.isWindows
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.absolutePath
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import org.junit.Assume.assumeFalse
 import java.io.File
 import org.junit.Rule
@@ -110,7 +110,7 @@ class ArgsHelperFilePathTest {
         Truth.assertThat(actual).isEqualTo(expected)
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun wildCardsInFileNameWithMultipleMatches() {
         makeTmpFile("/tmp/tmp1/app-debug.apk")
         makeTmpFile("/tmp/tmp1/app---debug.apk")
@@ -118,7 +118,7 @@ class ArgsHelperFilePathTest {
         ArgsHelper.evaluateFilePath(inputPath)
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun wildCardsInFilePathWithMultipleMatches() {
         makeTmpFile("/tmp/tmp1/tmp2/tmp3/app-debug.apk")
         makeTmpFile("/tmp/tmp1/tmp2/tmp3/tmp4/app-debug.apk")
@@ -137,13 +137,13 @@ class ArgsHelperFilePathTest {
         Truth.assertThat(actual).isEqualTo(expected)
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun evaluateInvalidFilePath() {
         val testApkPath = "~/flank_test_app/invalid_path/app-debug-*.xctestrun"
         ArgsHelper.evaluateFilePath(testApkPath)
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun evaluateInvalidFilePathWithTilde() {
         val testApkPath = "~/flank_test_app/~/invalid_path/app-debug-*.xctestrun"
         ArgsHelper.evaluateFilePath(testApkPath)

--- a/test_runner/src/test/kotlin/ftl/args/ArgsHelperFilePathTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ArgsHelperFilePathTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth
 import ftl.config.FtlConstants.isWindows
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.absolutePath
-import ftl.util.FlankFatalError
+import ftl.util.FlankCommonException
 import org.junit.Assume.assumeFalse
 import java.io.File
 import org.junit.Rule
@@ -110,7 +110,7 @@ class ArgsHelperFilePathTest {
         Truth.assertThat(actual).isEqualTo(expected)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankCommonException::class)
     fun wildCardsInFileNameWithMultipleMatches() {
         makeTmpFile("/tmp/tmp1/app-debug.apk")
         makeTmpFile("/tmp/tmp1/app---debug.apk")
@@ -118,7 +118,7 @@ class ArgsHelperFilePathTest {
         ArgsHelper.evaluateFilePath(inputPath)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankCommonException::class)
     fun wildCardsInFilePathWithMultipleMatches() {
         makeTmpFile("/tmp/tmp1/tmp2/tmp3/app-debug.apk")
         makeTmpFile("/tmp/tmp1/tmp2/tmp3/tmp4/app-debug.apk")
@@ -137,13 +137,13 @@ class ArgsHelperFilePathTest {
         Truth.assertThat(actual).isEqualTo(expected)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankCommonException::class)
     fun evaluateInvalidFilePath() {
         val testApkPath = "~/flank_test_app/invalid_path/app-debug-*.xctestrun"
         ArgsHelper.evaluateFilePath(testApkPath)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankCommonException::class)
     fun evaluateInvalidFilePathWithTilde() {
         val testApkPath = "~/flank_test_app/~/invalid_path/app-debug-*.xctestrun"
         ArgsHelper.evaluateFilePath(testApkPath)

--- a/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
@@ -16,8 +16,8 @@ import ftl.shard.stringShards
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.absolutePath
 import ftl.test.util.assertThrowsWithMessage
-import ftl.util.FlankCommonException
-import ftl.util.FlankFatalError
+import ftl.util.FlankGeneralError
+import ftl.util.FlankConfigurationError
 import io.mockk.every
 import io.mockk.spyk
 import io.mockk.unmockkAll
@@ -74,7 +74,7 @@ class ArgsHelperTest {
         }
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `assertGcsFileExists failsOnMissingPrefix`() {
         assertGcsFileExists("does-not-exist")
     }
@@ -164,7 +164,7 @@ class ArgsHelperTest {
         assertThat(actual).isEqualTo(expected)
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun evaluateInvalidFilePath() {
         val testApkPath = "~/flank_test_app/invalid_path/app-debug-*.xctestrun"
         ArgsHelper.evaluateFilePath(testApkPath)

--- a/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
@@ -16,6 +16,7 @@ import ftl.shard.stringShards
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.absolutePath
 import ftl.test.util.assertThrowsWithMessage
+import ftl.util.FlankCommonException
 import ftl.util.FlankFatalError
 import io.mockk.every
 import io.mockk.spyk
@@ -73,7 +74,7 @@ class ArgsHelperTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test(expected = FlankFatalError::class)
     fun `assertGcsFileExists failsOnMissingPrefix`() {
         assertGcsFileExists("does-not-exist")
     }
@@ -163,7 +164,7 @@ class ArgsHelperTest {
         assertThat(actual).isEqualTo(expected)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankCommonException::class)
     fun evaluateInvalidFilePath() {
         val testApkPath = "~/flank_test_app/invalid_path/app-debug-*.xctestrun"
         ArgsHelper.evaluateFilePath(testApkPath)

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -13,6 +13,7 @@ import ftl.test.util.TestHelper.absolutePath
 import ftl.test.util.TestHelper.assert
 import ftl.test.util.TestHelper.getPath
 import ftl.test.util.assertThrowsWithMessage
+import ftl.util.FlankFatalError
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assume
@@ -833,7 +834,7 @@ IosArgs
         "ClassFourTest/testFour"
     )
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test(expected = FlankFatalError::class)
     fun `invalid regex filter throws custom exception`() {
         filterTests(listOf("test"), testTargetsRgx = listOf("*."))
     }

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -13,7 +13,7 @@ import ftl.test.util.TestHelper.absolutePath
 import ftl.test.util.TestHelper.assert
 import ftl.test.util.TestHelper.getPath
 import ftl.test.util.assertThrowsWithMessage
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assume
@@ -834,7 +834,7 @@ IosArgs
         "ClassFourTest/testFour"
     )
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `invalid regex filter throws custom exception`() {
         filterTests(listOf("test"), testTargetsRgx = listOf("*."))
     }

--- a/test_runner/src/test/kotlin/ftl/args/yml/ErrorParserTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/yml/ErrorParserTest.kt
@@ -9,7 +9,7 @@ import ftl.args.AndroidArgs
 import ftl.args.yml.errors.ConfigurationErrorMessageBuilder
 import ftl.test.util.TestHelper
 import ftl.test.util.TestHelper.getThrowable
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 import org.junit.Assert
 import org.junit.Test
 
@@ -46,7 +46,7 @@ At line: 23, column: 3
         Assert.assertEquals(expected, buildErrorMessage(instantionError))
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should throw FlankFatalError without device version`() {
         AndroidArgs.load(yamlWithoutDeviceVersion)
     }
@@ -111,12 +111,12 @@ Error node:
         Assert.assertEquals(expectedMessage, actualMessage)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should throw FlankFatalError without model name`() {
         AndroidArgs.load(yamlNoModelName)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should throw FlankFatalError without model node`() {
         AndroidArgs.load(yamlNoModelNode)
     }

--- a/test_runner/src/test/kotlin/ftl/args/yml/FileLoaderTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/yml/FileLoaderTest.kt
@@ -2,28 +2,28 @@ package ftl.args.yml
 
 import ftl.util.loadFile
 import ftl.test.util.TestHelper.getThrowable
-import ftl.util.FlankFatalError
+import ftl.util.FlankCommonException
 import org.junit.Assert
 import org.junit.Test
 import java.nio.file.Paths
 import java.util.UUID
 
 class FileLoaderTest {
-    @Test(expected = FlankFatalError::class)
-    fun `should throws FlankFatalError when file not found`() {
+    @Test(expected = FlankCommonException::class)
+    fun `should throws FlankCommonException when file not found`() {
         val filePath = Paths.get("${UUID.randomUUID()}.yml")
         loadFile(filePath)
     }
 
     @Test
-    fun `should throws FlankFatalError with specific message when file not found`() {
+    fun `should throws FlankCommonException with specific message when file not found`() {
         val filePath = Paths.get("${UUID.randomUUID()}.yml")
         val thrownException = getThrowable { loadFile(filePath) }
 
         val expectedExceptionMessage = "File not found: $filePath"
         Assert.assertEquals(expectedExceptionMessage, thrownException.message)
 
-        val expectedExceptionType = FlankFatalError::class
+        val expectedExceptionType = FlankCommonException::class
         Assert.assertEquals(expectedExceptionType, thrownException::class)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/args/yml/FileLoaderTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/yml/FileLoaderTest.kt
@@ -2,28 +2,28 @@ package ftl.args.yml
 
 import ftl.util.loadFile
 import ftl.test.util.TestHelper.getThrowable
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import org.junit.Assert
 import org.junit.Test
 import java.nio.file.Paths
 import java.util.UUID
 
 class FileLoaderTest {
-    @Test(expected = FlankCommonException::class)
-    fun `should throws FlankCommonException when file not found`() {
+    @Test(expected = FlankGeneralError::class)
+    fun `should throws FlankGeneralError when file not found`() {
         val filePath = Paths.get("${UUID.randomUUID()}.yml")
         loadFile(filePath)
     }
 
     @Test
-    fun `should throws FlankCommonException with specific message when file not found`() {
+    fun `should throws FlankGeneralError with specific message when file not found`() {
         val filePath = Paths.get("${UUID.randomUUID()}.yml")
         val thrownException = getThrowable { loadFile(filePath) }
 
         val expectedExceptionMessage = "File not found: $filePath"
         Assert.assertEquals(expectedExceptionMessage, thrownException.message)
 
-        val expectedExceptionType = FlankCommonException::class
+        val expectedExceptionType = FlankGeneralError::class
         Assert.assertEquals(expectedExceptionType, thrownException::class)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/args/yml/YamlDeprecatedTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/yml/YamlDeprecatedTest.kt
@@ -3,7 +3,7 @@ package ftl.args.yml
 import com.google.common.truth.Truth.assertThat
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemOutRule
@@ -137,7 +137,7 @@ class YamlDeprecatedTest {
         assertThat(output).isEqualTo(expected)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should throw FlankFatalError when yaml is bad formatted`() {
         YamlDeprecated.modify(
             TestHelper.getPath("src/test/kotlin/ftl/args/yml/test_error_yaml_cases/flank-bad-yaml-formatting.yml")

--- a/test_runner/src/test/kotlin/ftl/filter/TestFiltersTest.kt
+++ b/test_runner/src/test/kotlin/ftl/filter/TestFiltersTest.kt
@@ -6,6 +6,7 @@ import com.linkedin.dex.parser.TestMethod
 import ftl.filter.TestFilters.fromTestTargets
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper
+import ftl.util.FlankFatalError
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -153,7 +154,7 @@ class TestFiltersTest {
         assertThat(filter.shouldRun(WITHOUT_SMALL_ANNOTATION)).isFalse()
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test(expected = FlankFatalError::class)
     fun testFilteringBySizeInvalidWillThrowException() {
         fromTestTargets(listOf("size foo"))
     }

--- a/test_runner/src/test/kotlin/ftl/filter/TestFiltersTest.kt
+++ b/test_runner/src/test/kotlin/ftl/filter/TestFiltersTest.kt
@@ -6,7 +6,7 @@ import com.linkedin.dex.parser.TestMethod
 import ftl.filter.TestFilters.fromTestTargets
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -154,7 +154,7 @@ class TestFiltersTest {
         assertThat(filter.shouldRun(WITHOUT_SMALL_ANNOTATION)).isFalse()
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun testFilteringBySizeInvalidWillThrowException() {
         fromTestTargets(listOf("size foo"))
     }

--- a/test_runner/src/test/kotlin/ftl/gc/GcToolResultsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcToolResultsTest.kt
@@ -8,7 +8,7 @@ import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.getThrowable
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.PermissionDenied
 import ftl.util.ProjectNotFound
 import io.mockk.every
@@ -96,8 +96,8 @@ class GcToolResultsTest {
         }
     }
 
-    @Test(expected = FlankCommonException::class)
-    fun `getDefaultBucket on PermissionDenied error should throw FlankCommonException`() {
+    @Test(expected = FlankGeneralError::class)
+    fun `getDefaultBucket on PermissionDenied error should throw FlankGeneralError`() {
         mockkObject(GcToolResults) {
             every { GcToolResults.service.applicationName } returns projectId
             every { GcToolResults.service.Projects().initializeSettings(projectId) } throws PermissionDenied(IOException())
@@ -105,8 +105,8 @@ class GcToolResultsTest {
         }
     }
 
-    @Test(expected = FlankCommonException::class)
-    fun `getDefaultBucket on ProjectNotFound error should throw FlankCommonException`() {
+    @Test(expected = FlankGeneralError::class)
+    fun `getDefaultBucket on ProjectNotFound error should throw FlankGeneralError`() {
         mockkObject(GcToolResults) {
             every { GcToolResults.service.applicationName } returns projectId
             every { GcToolResults.service.Projects().initializeSettings(projectId) } throws ProjectNotFound(IOException())

--- a/test_runner/src/test/kotlin/ftl/ios/ParseTest.kt
+++ b/test_runner/src/test/kotlin/ftl/ios/ParseTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import ftl.config.FtlConstants.isWindows
 import ftl.mock.TestArtifact.fixturesPath
 import ftl.test.util.FlankTestRunner
+import ftl.util.FlankCommonException
 import org.junit.Assume.assumeFalse
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -87,7 +88,7 @@ class ParseTest {
         checkObjcTests(results)
     }
 
-    @Test(expected = RuntimeException::class)
+    @Test(expected = FlankCommonException::class)
     fun `parseObjcTests fileNotFound`() {
         Parse.parseObjcTests("./BinaryThatDoesNotExist")
     }
@@ -100,12 +101,12 @@ class ParseTest {
         checkSwiftTests(results)
     }
 
-    @Test(expected = RuntimeException::class)
+    @Test(expected = FlankCommonException::class)
     fun `parseSwiftTests fileNotFound`() {
         Parse.parseSwiftTests("./BinaryThatDoesNotExist")
     }
 
-    @Test(expected = RuntimeException::class)
+    @Test(expected = FlankCommonException::class)
     fun `parseSwiftTests tmpFolder`() {
         Parse.parseSwiftTests("/tmp")
     }

--- a/test_runner/src/test/kotlin/ftl/ios/ParseTest.kt
+++ b/test_runner/src/test/kotlin/ftl/ios/ParseTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import ftl.config.FtlConstants.isWindows
 import ftl.mock.TestArtifact.fixturesPath
 import ftl.test.util.FlankTestRunner
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import org.junit.Assume.assumeFalse
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -88,7 +88,7 @@ class ParseTest {
         checkObjcTests(results)
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun `parseObjcTests fileNotFound`() {
         Parse.parseObjcTests("./BinaryThatDoesNotExist")
     }
@@ -101,12 +101,12 @@ class ParseTest {
         checkSwiftTests(results)
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun `parseSwiftTests fileNotFound`() {
         Parse.parseSwiftTests("./BinaryThatDoesNotExist")
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun `parseSwiftTests tmpFolder`() {
         Parse.parseSwiftTests("/tmp")
     }

--- a/test_runner/src/test/kotlin/ftl/ios/XctestrunTest.kt
+++ b/test_runner/src/test/kotlin/ftl/ios/XctestrunTest.kt
@@ -11,6 +11,7 @@ import java.nio.file.Paths
 import org.junit.Test
 import org.junit.runner.RunWith
 import ftl.test.util.TestHelper.normalizeLineEnding
+import ftl.util.FlankCommonException
 
 @RunWith(FlankTestRunner::class)
 class XctestrunTest {
@@ -45,7 +46,7 @@ class XctestrunTest {
         assertThat(dict.containsKey("OnlyTestIdentifiers")).isFalse()
     }
 
-    @Test(expected = RuntimeException::class)
+    @Test(expected = FlankCommonException::class)
     fun `parse fileNotFound`() {
         Xctestrun.parse("./XctestrunThatDoesNotExist")
     }

--- a/test_runner/src/test/kotlin/ftl/ios/XctestrunTest.kt
+++ b/test_runner/src/test/kotlin/ftl/ios/XctestrunTest.kt
@@ -11,7 +11,7 @@ import java.nio.file.Paths
 import org.junit.Test
 import org.junit.runner.RunWith
 import ftl.test.util.TestHelper.normalizeLineEnding
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 
 @RunWith(FlankTestRunner::class)
 class XctestrunTest {
@@ -46,7 +46,7 @@ class XctestrunTest {
         assertThat(dict.containsKey("OnlyTestIdentifiers")).isFalse()
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun `parse fileNotFound`() {
         Xctestrun.parse("./XctestrunThatDoesNotExist")
     }

--- a/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
@@ -2,7 +2,7 @@ package ftl.reports.xml
 
 import com.google.common.truth.Truth.assertThat
 import ftl.test.util.TestHelper.normalizeLineEnding
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import org.junit.Assert
 import java.nio.file.Paths
 import org.junit.Test
@@ -247,7 +247,7 @@ junit.framework.Assert.fail(Assert.java:50)</failure>
     @Test
     fun `parse androidPassXml`() {
         val testSuite = parseOneSuiteXml(androidPassXml)
-            .testsuites?.first() ?: throw FlankCommonException("Missing test suite")
+            .testsuites?.first() ?: throw FlankGeneralError("Missing test suite")
 
         with(testSuite) {
             assertThat(name).isEqualTo("")
@@ -276,7 +276,7 @@ junit.framework.Assert.fail(Assert.java:50)</failure>
     @Test
     fun `parse androidFailXml`() {
         val testSuite = parseOneSuiteXml(androidFailXml)
-            .testsuites?.first() ?: throw FlankCommonException("Missing test suite")
+            .testsuites?.first() ?: throw FlankGeneralError("Missing test suite")
 
         with(testSuite) {
             assertThat(name).isEqualTo("")

--- a/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
@@ -2,6 +2,7 @@ package ftl.reports.xml
 
 import com.google.common.truth.Truth.assertThat
 import ftl.test.util.TestHelper.normalizeLineEnding
+import ftl.util.FlankCommonException
 import org.junit.Assert
 import java.nio.file.Paths
 import org.junit.Test
@@ -246,7 +247,7 @@ junit.framework.Assert.fail(Assert.java:50)</failure>
     @Test
     fun `parse androidPassXml`() {
         val testSuite = parseOneSuiteXml(androidPassXml)
-            .testsuites?.first() ?: throw RuntimeException("Missing test suite")
+            .testsuites?.first() ?: throw FlankCommonException("Missing test suite")
 
         with(testSuite) {
             assertThat(name).isEqualTo("")
@@ -275,7 +276,7 @@ junit.framework.Assert.fail(Assert.java:50)</failure>
     @Test
     fun `parse androidFailXml`() {
         val testSuite = parseOneSuiteXml(androidFailXml)
-            .testsuites?.first() ?: throw RuntimeException("Missing test suite")
+            .testsuites?.first() ?: throw FlankCommonException("Missing test suite")
 
         with(testSuite) {
             assertThat(name).isEqualTo("")

--- a/test_runner/src/test/kotlin/ftl/run/platform/android/ResolveApksKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/android/ResolveApksKtTest.kt
@@ -3,7 +3,7 @@ package ftl.run.platform.android
 import ftl.args.AndroidArgs
 import ftl.args.yml.AppTestPair
 import ftl.run.model.InstrumentationTestContext
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import ftl.util.asFileReference
 import io.mockk.every
 import io.mockk.mockk
@@ -53,7 +53,7 @@ class ResolveApksKtTest {
         )
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun `should fail on missing app apk`() {
         mockk<AndroidArgs> {
             every { appApk } returns null

--- a/test_runner/src/test/kotlin/ftl/run/platform/android/ResolveApksKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/android/ResolveApksKtTest.kt
@@ -3,7 +3,7 @@ package ftl.run.platform.android
 import ftl.args.AndroidArgs
 import ftl.args.yml.AppTestPair
 import ftl.run.model.InstrumentationTestContext
-import ftl.util.FlankFatalError
+import ftl.util.FlankCommonException
 import ftl.util.asFileReference
 import io.mockk.every
 import io.mockk.mockk
@@ -53,7 +53,7 @@ class ResolveApksKtTest {
         )
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankCommonException::class)
     fun `should fail on missing app apk`() {
         mockk<AndroidArgs> {
             every { appApk } returns null

--- a/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
+++ b/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
@@ -7,7 +7,7 @@ import ftl.reports.xml.model.JUnitTestCase
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.model.JUnitTestSuite
 import ftl.test.util.FlankTestRunner
-import ftl.util.FlankFatalError
+import ftl.util.FlankConfigurationError
 import ftl.util.FlankTestMethod
 import io.mockk.every
 import io.mockk.mockk
@@ -105,7 +105,7 @@ class ShardTest {
         assertThat(ms).isLessThan(5000)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `createShardsByShardCount throws on forcedShardCount = 0`() {
         createShardsByShardCount(
                 listOf(),
@@ -148,17 +148,17 @@ class ShardTest {
                 mockArgs(-1, shardTime))
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `shardCountByTime throws on invalid shard time -3`() {
         shardCountByTime(-3)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `shardCountByTime throws on invalid shard time -2`() {
         shardCountByTime(-2)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `shardCountByTime throws on invalid shard time 0`() {
         shardCountByTime(0)
     }
@@ -171,7 +171,7 @@ class ShardTest {
         assertThat(shardCountByTime(3)).isEqualTo(1)
     }
 
-    @Test(expected = FlankFatalError::class)
+    @Test(expected = FlankConfigurationError::class)
     fun `should terminate with exit status == 3 test targets is 0 and maxTestShards == -1`() {
         createShardsByShardCount(emptyList(), JUnitTestResult(mutableListOf()), mockArgs(-1))
     }

--- a/test_runner/src/test/kotlin/ftl/test/util/LocalGcs.kt
+++ b/test_runner/src/test/kotlin/ftl/test/util/LocalGcs.kt
@@ -2,7 +2,7 @@ package ftl.test.util
 
 import com.google.cloud.storage.BlobInfo
 import ftl.gc.GcStorage
-import ftl.util.FlankCommonException
+import ftl.util.FlankGeneralError
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -14,7 +14,7 @@ object LocalGcs {
 
     private fun uploadToMockGcs(path: Path) {
         if (!path.toFile().exists()) {
-            throw FlankCommonException("File doesn't exist at path $path")
+            throw FlankGeneralError("File doesn't exist at path $path")
         }
 
         val fileName = path.fileName.toString()

--- a/test_runner/src/test/kotlin/ftl/test/util/LocalGcs.kt
+++ b/test_runner/src/test/kotlin/ftl/test/util/LocalGcs.kt
@@ -2,6 +2,7 @@ package ftl.test.util
 
 import com.google.cloud.storage.BlobInfo
 import ftl.gc.GcStorage
+import ftl.util.FlankCommonException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -13,7 +14,7 @@ object LocalGcs {
 
     private fun uploadToMockGcs(path: Path) {
         if (!path.toFile().exists()) {
-            throw RuntimeException("File doesn't exist at path $path")
+            throw FlankCommonException("File doesn't exist at path $path")
         }
 
         val fileName = path.fileName.toString()

--- a/test_runner/src/test/kotlin/ftl/util/BashTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/BashTest.kt
@@ -15,7 +15,7 @@ class BashTest {
         assertThat(Bash.execute("echo a 1>&2")).isEqualTo("a")
     }
 
-    @Test(expected = RuntimeException::class)
+    @Test(expected = FlankCommonException::class)
     fun executeStderrExitCode1() {
         assertThat(Bash.execute("echo not an error 1>&2; exit 1")).isEmpty()
     }

--- a/test_runner/src/test/kotlin/ftl/util/BashTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/BashTest.kt
@@ -15,7 +15,7 @@ class BashTest {
         assertThat(Bash.execute("echo a 1>&2")).isEqualTo("a")
     }
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun executeStderrExitCode1() {
         assertThat(Bash.execute("echo not an error 1>&2; exit 1")).isEmpty()
     }

--- a/test_runner/src/test/kotlin/ftl/util/StopWatchTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/StopWatchTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 
 class StopWatchTest {
 
-    @Test(expected = RuntimeException::class)
+    @Test(expected = FlankCommonException::class)
     fun `stopWatch errorOnCheckWithoutStart`() {
         StopWatch().check()
     }

--- a/test_runner/src/test/kotlin/ftl/util/StopWatchTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/StopWatchTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 
 class StopWatchTest {
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun `stopWatch errorOnCheckWithoutStart`() {
         StopWatch().check()
     }

--- a/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
@@ -53,7 +53,7 @@ class UtilsTest {
     @After
     fun tearDown() = unmockkAll()
 
-    @Test(expected = FlankCommonException::class)
+    @Test(expected = FlankGeneralError::class)
     fun `readTextResource errors`() {
         readTextResource("does not exist")
     }
@@ -77,7 +77,7 @@ class UtilsTest {
         assertThat(randomName.last()).isNotEqualTo('/')
     }
 
-    @Test(expected = FailedMatrix::class)
+    @Test(expected = FailedMatrixError::class)
     fun testExitCodeForFailed() {
         val testExecutions = listOf(
             createStepExecution(1, "Success"),
@@ -106,7 +106,7 @@ class UtilsTest {
         MatrixMap(mutableMapOf("" to finishedMatrix), "MockPath").validateMatrices()
     }
 
-    @Test(expected = MatrixCanceled::class)
+    @Test(expected = MatrixCanceledError::class)
     fun testExitCodeForInconclusive() { // inconclusive is treated as a failure
         val testExecutions = listOf(
             createStepExecution(-2, "Inconclusive")
@@ -150,7 +150,7 @@ class UtilsTest {
         val finishedMatrix = SavedMatrix(testMatrix)
         try {
             MatrixMap(mutableMapOf("" to finishedMatrix), "MockPath").validateMatrices(shouldIgnore)
-        } catch (t: FailedMatrix) {
+        } catch (t: FailedMatrixError) {
             assertTrue(t.ignoreFailed)
         } catch (_: Throwable) {
             fail()
@@ -160,7 +160,7 @@ class UtilsTest {
     @Test
     fun `should terminate process with exit code 10 if FailedMatrix exception is thrown`() {
         // given
-        val block = { throw FailedMatrix(listOf(testMatrix1, testMatrix2)) }
+        val block = { throw FailedMatrixError(listOf(testMatrix1, testMatrix2)) }
 
         // will
         exit.expectSystemExitWithStatus(NOT_PASSED)
@@ -208,7 +208,7 @@ class UtilsTest {
     fun `should terminate process with exit code 2 if FlankFatalError is thrown`() {
         // given
         val message = "test error was thrown"
-        val block = { throw FlankFatalError(message) }
+        val block = { throw FlankConfigurationError(message) }
 
         // will
         exit.expectSystemExitWithStatus(2)
@@ -225,7 +225,7 @@ class UtilsTest {
         // given
         val message = "not flank related error thrown"
 
-        val block = { throw FlankCommonException(message) }
+        val block = { throw FlankGeneralError(message) }
 
         // will
         exit.expectSystemExitWithStatus(GENERAL_FAILURE)
@@ -246,7 +246,7 @@ class UtilsTest {
         every { FtlConstants.bugsnag } returns mockk {
             every { notify(any<Throwable>()) } returns true
         }
-        val block = { throw FlankCommonException(message) }
+        val block = { throw FlankGeneralError(message) }
 
         // will
         exit.expectSystemExitWithStatus(GENERAL_FAILURE)
@@ -262,7 +262,7 @@ class UtilsTest {
     fun `should terminate process with exit code 0 if at least one matrix failed and ignore-failed-tests flag is true`() {
         // given
         val block = {
-            throw FailedMatrix(
+            throw FailedMatrixError(
                 matrices = listOf(testMatrix1, testMatrix2),
                 ignoreFailed = true
             )
@@ -279,7 +279,7 @@ class UtilsTest {
     fun `should terminate process with exit code 1 if there is not tests to run overall`() {
         // given
         val message = "No tests to run"
-        val block = { throw FlankCommonException(message) }
+        val block = { throw FlankGeneralError(message) }
 
         // will
         exit.expectSystemExitWithStatus(GENERAL_FAILURE)

--- a/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
@@ -225,7 +225,7 @@ class UtilsTest {
         // given
         val message = "not flank related error thrown"
 
-        val block = { throw RuntimeException(message) }
+        val block = { throw FlankCommonException(message) }
 
         // will
         exit.expectSystemExitWithStatus(3)
@@ -246,7 +246,7 @@ class UtilsTest {
         every { FtlConstants.bugsnag } returns mockk {
             every { notify(any<Throwable>()) } returns true
         }
-        val block = { throw RuntimeException(message) }
+        val block = { throw FlankCommonException(message) }
 
         // will
         exit.expectSystemExitWithStatus(3)

--- a/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
@@ -53,7 +53,7 @@ class UtilsTest {
     @After
     fun tearDown() = unmockkAll()
 
-    @Test(expected = RuntimeException::class)
+    @Test(expected = FlankCommonException::class)
     fun `readTextResource errors`() {
         readTextResource("does not exist")
     }
@@ -106,7 +106,7 @@ class UtilsTest {
         MatrixMap(mutableMapOf("" to finishedMatrix), "MockPath").validateMatrices()
     }
 
-    @Test(expected = FailedMatrix::class)
+    @Test(expected = MatrixCanceled::class)
     fun testExitCodeForInconclusive() { // inconclusive is treated as a failure
         val testExecutions = listOf(
             createStepExecution(-2, "Inconclusive")
@@ -158,20 +158,20 @@ class UtilsTest {
     }
 
     @Test
-    fun `should terminate process with exit code 1 if FailedMatrix exception is thrown`() {
+    fun `should terminate process with exit code 10 if FailedMatrix exception is thrown`() {
         // given
         val block = { throw FailedMatrix(listOf(testMatrix1, testMatrix2)) }
 
         // will
-        exit.expectSystemExitWithStatus(1)
+        exit.expectSystemExitWithStatus(NOT_PASSED)
 
         // when
         withGlobalExceptionHandling(block)
     }
 
     @Test
-    fun `should terminate process with exit code 1 if YmlValidationError is thrown`() {
-        exit.expectSystemExitWithStatus(1)
+    fun `should terminate process with exit code 2 if YmlValidationError is thrown`() {
+        exit.expectSystemExitWithStatus(CONFIGURATION_FAIL)
         val block = { throw YmlValidationError() }
         withGlobalExceptionHandling(block)
     }
@@ -190,12 +190,12 @@ class UtilsTest {
     }
 
     @Test
-    fun `should terminate process with exit code 3 if FTLError is thrown`() {
+    fun `should terminate process with exit code 15 if FTLError is thrown`() {
         // given
         val block = { throw FTLError(testMatrix1) }
 
         // will
-        exit.expectSystemExitWithStatus(3)
+        exit.expectSystemExitWithStatus(UNEXPECTED_ERROR)
         exit.checkAssertionAfterwards {
             assertTrue(output.log.contains("Matrix is ${testMatrix1.state}"))
         }
@@ -221,14 +221,14 @@ class UtilsTest {
     }
 
     @Test
-    fun `should terminate process with exit code 3 if not flank related exception is thrown`() {
+    fun `should terminate process with exit code 1 if not flank related exception is thrown`() {
         // given
         val message = "not flank related error thrown"
 
         val block = { throw FlankCommonException(message) }
 
         // will
-        exit.expectSystemExitWithStatus(3)
+        exit.expectSystemExitWithStatus(GENERAL_FAILURE)
         exit.checkAssertionAfterwards {
             assertTrue(err.log.contains(message))
         }
@@ -249,7 +249,7 @@ class UtilsTest {
         val block = { throw FlankCommonException(message) }
 
         // will
-        exit.expectSystemExitWithStatus(3)
+        exit.expectSystemExitWithStatus(GENERAL_FAILURE)
         exit.checkAssertionAfterwards {
             assertTrue(err.log.contains(message))
         }
@@ -269,7 +269,7 @@ class UtilsTest {
         }
 
         // will
-        exit.expectSystemExitWithStatus(0)
+        exit.expectSystemExitWithStatus(SUCCESS)
 
         // when
         withGlobalExceptionHandling(block)
@@ -282,9 +282,9 @@ class UtilsTest {
         val block = { throw FlankCommonException(message) }
 
         // will
-        exit.expectSystemExitWithStatus(1)
+        exit.expectSystemExitWithStatus(GENERAL_FAILURE)
         exit.checkAssertionAfterwards {
-            assertTrue(output.log.contains(message))
+            assertTrue(err.log.contains(message))
         }
 
         // when
@@ -346,7 +346,7 @@ class UtilsTest {
         processStarted.await()
         simulatedMain.join(10 * 1000L)
         assertTrue("Our simulated main thread should have completed but instead it hung...", completed.get())
-        assertEquals(3, exitCode.get())
+        assertEquals(UNEXPECTED_ERROR, exitCode.get())
         File(VERIFICATION_FILE).also {
             assertTrue("Verification file should exists, process might not have started", it.exists())
             assertTrue(it.inputStream().readBytes().toString(Charsets.UTF_8).contains(VERIFICATION_MESSAGE))


### PR DESCRIPTION
Fixes #802 

## Test Plan
> How do we know the code works?

Flank exit codes reflect gcloud exit codes

## Comparision

Documentation about the current state can be found [here](docs/exit_codes_and_exceptions.md), please keep in mind this is only my interpretation and feel free to request changes.

Exit code | Gcloud | Flank
-- | -- | -- 
0 | All test executions passed. | All tests passed 
1 |  A general failure occurred. Possible causes include: a filename that does not exist or an HTTP/network error. | All matrices finished but at least one test failed or inconclusive. 
2 |  Testing exited because unknown commands or arguments were provided. | Usually indicates missing or wrong usage of flags, incorrect parameters, errors in config files. 
3 | | At least one matrix not finished (usually a FTL internal error) or unexpected error occurred. 
10 |  One or more test cases (tested classes or class methods) within a test execution did not pass. 
15 |  Firebase Test Lab could not determine if the test matrix passed or failed, because of an unexpected error. 
18 |  The test environment for this test execution is not supported because of incompatible test dimensions. This error might occur if the selected Android API level is not supported by the selected device type. 
19 |  The test matrix was canceled by the user. 
20 |  A test infrastructure error occurred. 

## Mapping plan Flank -> Gcloud and test plan

Status | Gcloud Code | Old Flank Code  | Description
-- | -- | -- | --
✅  | 0 | 0 | All test executions passed.
✅  | 10  | 1 | One or more test cases (tested classes or class methods) within a test execution did not pass.
✅  | 1 |  2 | Apk, yml not found or an HTTP/network error
✅  | 2 | 2 | Unknown commands
✅  | 18  | 2 | The test environment for this test execution is not supported because of incompatible test dimensions. Eg. device not support selected API level
✅  | 15 | 3 | Unexpected errors from gcloud 
✅  | 19 | 3 | The test matrix was canceled by the user.
✅  | 20 | 3 | A test infrastructure error occurred. 

## Checklist

- [X] Exit codes changed
- [X] Check exceptions what Flank throws and refractor to types reflected gcloud exit codes
- [X] Documented
- [X] Unit tested
- [X] release_notes.md updated
- [X] readme.md updated
