### PR TITLE
Process junit xml even when full junit is not enabled

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -33,7 +33,7 @@ Run `./gradlew check` to fix lint issues
 
 ## Adding new gcloud property common to iOS and Android
 
-- Add property to `GcloudYml` and update `keys`
+- Add property to `GcloudYml` and update `keys` in config files
 - Update `IArgs` with new property
 - Update `AndroidArgs` to reference the propery and update `toString`
 - Update `IosArgs` to reference the propery and `toString`

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,7 +3,7 @@
 - [#950](https://github.com/Flank/flank/pull/950) Fix crash when --legacy-junit-result set. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#948](https://github.com/Flank/flank/pull/948) Increment retry tries and change sync tag for jfrogSync. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#946](https://github.com/Flank/flank/pull/946) Added tests for flank scripts. ([piotradamczyk5](https://github.com/piotradamczyk5))
-- 
+- [#935](https://github.com/Flank/flank/pull/935) Process junit xml even when full junit is not enabled. ([kozaxinan](https://github.com/kozaxinan))
 -
 -
 

--- a/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
@@ -161,7 +161,8 @@ data class CommonFlankConfig @JsonIgnore constructor(
             "ignore-failed-tests",
             "keep-file-path",
             "output-style",
-            "disable-results-upload"
+            "disable-results-upload",
+            "full-junit-result"
         )
 
         const val defaultLocalResultsDir = "results"

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -115,6 +115,7 @@ object ReportManager {
         when {
             args.fullJUnitResult -> processFullJunitResult(args, matrices, testShardChunks)
             args.useLegacyJUnitResult -> processJunitXml(testSuite, args, testShardChunks)
+            else -> processJunitXml(testSuite, args, testShardChunks)
         }
         matrices.validateMatrices(args.ignoreFailedTests)
     }

--- a/test_runner/src/test/kotlin/ftl/fixtures/flank.ios.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/flank.ios.yml
@@ -18,3 +18,4 @@ flank:
   num-test-runs: 1
   run-timeout: 60m
   output-style: single
+  full-junit-result: false

--- a/test_runner/src/test/kotlin/ftl/fixtures/flank.local.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/flank.local.yml
@@ -30,3 +30,4 @@ flank:
   num-test-runs: 1
   run-timeout: 60m
   output-style: single
+  full-junit-result: false

--- a/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
@@ -89,6 +89,31 @@ class ReportManagerTest {
     }
 
     @Test
+    fun `uploadJunitXml should be called when legacy junit disabled`() {
+        val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/success_result", AndroidArgs.default())
+        val mockArgs = prepareMockAndroidArgs()
+        every { mockArgs.useLegacyJUnitResult } returns false
+        every { mockArgs.project } returns "projecId"
+
+        val junitTestResult = ReportManager.processXmlFromFile(matrix, mockArgs, ::parseOneSuiteXml)
+        ReportManager.generate(matrix, mockArgs, emptyList())
+        verify { GcStorage.uploadJunitXml(junitTestResult!!, mockArgs) }
+    }
+
+    @Test
+    fun `uploadJunitXml should be called when full junit enabled`() {
+        val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/success_result", AndroidArgs.default())
+        val mockArgs = prepareMockAndroidArgs()
+        every { mockArgs.useLegacyJUnitResult } returns false
+        every { mockArgs.fullJUnitResult } returns true
+        every { mockArgs.project } returns "projecId"
+
+        val junitTestResult = ReportManager.processXmlFromFile(matrix, mockArgs, ::parseOneSuiteXml)
+        ReportManager.generate(matrix, mockArgs, emptyList())
+        verify { GcStorage.uploadJunitXml(junitTestResult!!, mockArgs) }
+    }
+
+    @Test
     fun `uploadResults should be called`() {
         val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/success_result", AndroidArgs.default())
         val mockArgs = prepareMockAndroidArgs()
@@ -106,7 +131,7 @@ class ReportManagerTest {
     }
 
     @Test
-    fun `uploadResults should't be called when disable-results-upload set`() {
+    fun `uploadResults shouldn't be called when disable-results-upload set`() {
         val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/success_result", AndroidArgs.default())
         val mockArgs = prepareMockAndroidArgs()
         every { mockArgs.disableResultsUpload } returns true
@@ -125,7 +150,7 @@ class ReportManagerTest {
     }
 
     @Test
-    fun `uploadResults with FullJUnit should't be called`() {
+    fun `uploadResults without FullJUnit shouldn't be called`() {
         val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/success_result", AndroidArgs.default())
         val mockArgs = prepareMockAndroidArgs()
         mockkObject(GcStorage) {


### PR DESCRIPTION
Fixes #902 

#798 introduced a new argument `full-junit-result`. It is false by default. First problem, it is not added to keys list so flank doctor report new argument as unknown key.

Second problem is about junit xml report for smart flank run. `full-junit-result` and `legacy-junit-result` are used to decide to send junit report. As I understand from #798, there are now there junit result, legacy and full. Consideration; when both flag are true, flank can throw exception at argument checking phase.

## Test Plan
> How do we know the code works?

While using flank without legacy and full junit test report, smart test sharding and junit xml upload need to work.

## Checklist

- [x] Documented
- [x] Unit tested
- [ ] release_notes.md updated (Waiting for review before updating notes)
