### PR TITLE
Run *list commands when flank.yml not found should display right output 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -23,6 +23,9 @@
 - [#934](https://github.com/Flank/flank/pull/934) Delete incorrect flank snapshot labels. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#926](https://github.com/Flank/flank/pull/926) Flank should reflect gcloud exit codes. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#917](https://github.com/Flank/flank/pull/917) Fix an incorrect outcome. ([pawelpasterz](https://github.com/pawelpasterz))
+- [#939](https://github.com/Flank/flank/pull/939) Run *list commands when flank.yml not found should display right output. ([adamfilipow92](https://github.com/adamfilipow92))
+-
+-
 
 ## v20.07.0
 - [#857](https://github.com/Flank/flank/pull/857) Added multimodule setup for test app. ([piotradamczyk5](https://github.com/piotradamczyk5))

--- a/test_runner/docs/ascii/flank.jar_-android-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-android-run.adoc
@@ -163,9 +163,6 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
-*--app*=_<app>_::
-  The path to the application binary file. The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
-
 *--test*=_<test>_::
   The path to the binary file containing instrumentation tests. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
 
@@ -177,6 +174,9 @@ Configuration is read from flank.yml
 
 *--no-auto-google-login*::
   Google account not logged in (default behavior). Use --auto-google-login to enable
+
+*--app*=_<app>_::
+  The path to the application binary file. The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
 
 *--use-orchestrator*::
   Whether each test runs in its own Instrumentation instance with the Android Test Orchestrator (default: Orchestrator is used. To disable, use --no-use-orchestrator). Orchestrator is only compatible with AndroidJUnitRunner v1.0 or higher. See https://developer.android.com/training/testing/junit-runner.html#using-android-test-orchestrator for more information about Android Test Orchestrator.

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-android-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-android-run.adoc
@@ -175,9 +175,6 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
-*--app*=_<app>_::
-  The path to the application binary file. The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
-
 *--test*=_<test>_::
   The path to the binary file containing instrumentation tests. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
 
@@ -189,6 +186,9 @@ Configuration is read from flank.yml
 
 *--no-auto-google-login*::
   Google account not logged in (default behavior). Use --auto-google-login to enable
+
+*--app*=_<app>_::
+  The path to the application binary file. The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
 
 *--use-orchestrator*::
   Whether each test runs in its own Instrumentation instance with the Android Test Orchestrator (default: Orchestrator is used. To disable, use --no-use-orchestrator). Orchestrator is only compatible with AndroidJUnitRunner v1.0 or higher. See https://developer.android.com/training/testing/junit-runner.html#using-android-test-orchestrator for more information about Android Test Orchestrator.

--- a/test_runner/docs/ascii/flank.jar_-firebase-test-ios-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-firebase-test-ios-run.adoc
@@ -154,14 +154,14 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
-*--test*=_<test>_::
-  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
-
 *--xctestrun-file*=_<xctestrunFile>_::
   The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
 
 *--xcode-version*=_<xcodeVersion>_::
   The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
+
+*--test*=_<test>_::
+  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
 
 *--test-targets*=_<testTargets>_[,_<testTargets>_...]::
   A list of one or more test method names to run (default: run all test targets).

--- a/test_runner/docs/ascii/flank.jar_-ios-run.adoc
+++ b/test_runner/docs/ascii/flank.jar_-ios-run.adoc
@@ -146,14 +146,14 @@ Configuration is read from flank.yml
 *--disable-results-upload*::
   Disables flank results upload on gcloud storage.
 
-*--test*=_<test>_::
-  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
-
 *--xctestrun-file*=_<xctestrunFile>_::
   The path to an .xctestrun file that will override any .xctestrun file contained in the --test package. Because the .xctestrun file contains environment variables along with test methods to run and/or ignore, this can be useful for customizing or sharding test suites. The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
 
 *--xcode-version*=_<xcodeVersion>_::
   The version of Xcode that should be used to run an XCTest. Defaults to the latest Xcode version supported in Firebase Test Lab. This Xcode version must be supported by all iOS versions selected in the test matrix.
+
+*--test*=_<test>_::
+  The path to the test package (a zip file containing the iOS app and XCTest files). The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://. Note: any .xctestrun file in this zip file will be ignored if --xctestrun-file is specified.
 
 *--test-targets*=_<testTargets>_[,_<testTargets>_...]::
   A list of one or more test method names to run (default: run all test targets).

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgsCompanion.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgsCompanion.kt
@@ -32,8 +32,7 @@ open class AndroidArgsCompanion : IArgs.ICompanion {
     fun load(yamlPath: Path, cli: AndroidRunCommand? = null) =
         load(loadFile(yamlPath), cli)
 
-    fun default() =
-        createAndroidArgs(defaultAndroidConfig())
+    fun default() = createAndroidArgs(defaultAndroidConfig())
 
     @VisibleForTesting
     internal fun load(yamlReader: Reader, cli: AndroidRunCommand? = null) =

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgsCompanion.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgsCompanion.kt
@@ -12,6 +12,7 @@ import ftl.config.loadAndroidConfig
 import ftl.config.plus
 import ftl.util.loadFile
 import java.io.Reader
+import java.nio.file.Files
 import java.nio.file.Path
 
 open class AndroidArgsCompanion : IArgs.ICompanion {
@@ -24,11 +25,15 @@ open class AndroidArgsCompanion : IArgs.ICompanion {
         )
     }
 
-    fun default() =
-        createAndroidArgs(defaultAndroidConfig())
+    fun loadOrDefault(yamlPath: Path, cli: AndroidRunCommand? = null) =
+        if (Files.exists(yamlPath)) load(yamlPath, cli)
+        else default()
 
     fun load(yamlPath: Path, cli: AndroidRunCommand? = null) =
         load(loadFile(yamlPath), cli)
+
+    fun default() =
+        createAndroidArgs(defaultAndroidConfig())
 
     @VisibleForTesting
     internal fun load(yamlReader: Reader, cli: AndroidRunCommand? = null) =

--- a/test_runner/src/main/kotlin/ftl/args/CreateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateIosArgs.kt
@@ -18,8 +18,8 @@ private fun createIosArgs(
     commonArgs: CommonArgs
 ) = IosArgs(
     commonArgs = commonArgs.copy(maxTestShards = convertToShardCount(commonArgs.maxTestShards)),
-    xctestrunZip = gcloud.test!!.processFilePath("from test"),
-    xctestrunFile = gcloud.xctestrunFile!!.processFilePath("from xctestrun-file"),
+    xctestrunZip = gcloud.test?.processFilePath("from test").orEmpty(),
+    xctestrunFile = gcloud.xctestrunFile?.processFilePath("from xctestrun-file").orEmpty(),
     xcodeVersion = gcloud.xcodeVersion,
     testTargets = flank.testTargets!!.filterNotNull()
 )

--- a/test_runner/src/main/kotlin/ftl/args/IosArgsCompanion.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgsCompanion.kt
@@ -12,6 +12,7 @@ import ftl.config.loadIosConfig
 import ftl.config.plus
 import ftl.util.loadFile
 import java.io.Reader
+import java.nio.file.Files
 import java.nio.file.Path
 
 open class IosArgsCompanion : IArgs.ICompanion {
@@ -24,11 +25,15 @@ open class IosArgsCompanion : IArgs.ICompanion {
         )
     }
 
-    fun default() =
-        createIosArgs(defaultIosConfig())
+    fun loadOrDefault(yamlPath: Path, cli: IosRunCommand? = null) =
+        if (Files.exists(yamlPath)) load(yamlPath, cli)
+        else default()
 
     fun load(yamlPath: Path, cli: IosRunCommand? = null) =
         load(loadFile(yamlPath), cli)
+
+    fun default() =
+        createIosArgs(defaultIosConfig())
 
     @VisibleForTesting
     internal fun load(yamlReader: Reader, cli: IosRunCommand? = null) =

--- a/test_runner/src/main/kotlin/ftl/args/IosArgsCompanion.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgsCompanion.kt
@@ -32,8 +32,7 @@ open class IosArgsCompanion : IArgs.ICompanion {
     fun load(yamlPath: Path, cli: IosRunCommand? = null) =
         load(loadFile(yamlPath), cli)
 
-    fun default() =
-        createIosArgs(defaultIosConfig())
+    fun default() = createIosArgs(defaultIosConfig())
 
     @VisibleForTesting
     internal fun load(yamlReader: Reader, cli: IosRunCommand? = null) =

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
@@ -24,7 +24,7 @@ import java.nio.file.Paths
 )
 class AndroidTestEnvironmentCommand : Runnable {
     override fun run() {
-        val projectId = AndroidArgs.load(Paths.get(configPath)).project
+        val projectId = AndroidArgs.loadOrDefault(Paths.get(configPath)).project
         println(devicesCatalogAsTable(projectId))
         println(supportedVersionsAsTable(projectId))
         println(localesAsTable(projectId))

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesListCommand.kt
@@ -19,7 +19,7 @@ import java.nio.file.Paths
 )
 class AndroidLocalesListCommand : Runnable {
     override fun run() {
-        println(AndroidCatalog.localesAsTable(projectId = AndroidArgs.load(Paths.get(configPath)).project))
+        println(AndroidCatalog.localesAsTable(projectId = AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelsListCommand.kt
@@ -19,8 +19,7 @@ import java.nio.file.Paths
 )
 class AndroidModelsListCommand : Runnable {
     override fun run() {
-        val config = AndroidArgs.load(Paths.get(configPath))
-        println(AndroidCatalog.devicesCatalogAsTable(config.project))
+        println(AndroidCatalog.devicesCatalogAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
@@ -19,7 +19,7 @@ import java.nio.file.Paths
 )
 class AndroidOrientationsListCommand : Runnable {
     override fun run() {
-        println(AndroidCatalog.supportedOrientationsAsTable(AndroidArgs.load(Paths.get(configPath)).project))
+        println(AndroidCatalog.supportedOrientationsAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsListCommand.kt
@@ -19,7 +19,7 @@ import java.nio.file.Paths
 )
 class AndroidVersionsListCommand : Runnable {
     override fun run() {
-        println(supportedVersionsAsTable(AndroidArgs.load(Paths.get(configPath)).project))
+        println(supportedVersionsAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
@@ -24,7 +24,7 @@ import java.nio.file.Paths
 )
 class IosTestEnvironmentCommand : Runnable {
     override fun run() {
-        val projectId = IosArgs.load(Paths.get(configPath)).project
+        val projectId = IosArgs.loadOrDefault(Paths.get(configPath)).project
         println(devicesCatalogAsTable(projectId))
         println(softwareVersionsAsTable(projectId))
         println(localesAsTable(projectId))

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesListCommand.kt
@@ -19,7 +19,7 @@ import java.nio.file.Paths
 )
 class IosLocalesListCommand : Runnable {
     override fun run() {
-        println(localesAsTable(projectId = IosArgs.load(Paths.get(configPath)).project))
+        println(localesAsTable(projectId = IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelsListCommand.kt
@@ -19,7 +19,7 @@ import java.nio.file.Paths
 )
 class IosModelsListCommand : Runnable {
     override fun run() {
-        println(devicesCatalogAsTable(IosArgs.load(Paths.get(configPath)).project))
+        println(devicesCatalogAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsListCommand.kt
@@ -19,7 +19,7 @@ import java.nio.file.Paths
 )
 class IosOrientationsListCommand : Runnable {
     override fun run() {
-        println(IosCatalog.supportedOrientationsAsTable(IosArgs.load(Paths.get(configPath)).project))
+        println(IosCatalog.supportedOrientationsAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsListCommand.kt
@@ -19,7 +19,7 @@ import java.nio.file.Paths
 )
 class IosVersionsListCommand : Runnable {
     override fun run() {
-        println(softwareVersionsAsTable(IosArgs.load(Paths.get(configPath)).project))
+        println(softwareVersionsAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsFileTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsFileTest.kt
@@ -12,6 +12,7 @@ import ftl.test.util.TestHelper.absolutePath
 import ftl.test.util.TestHelper.assert
 import ftl.test.util.TestHelper.getPath
 import ftl.test.util.TestHelper.getString
+import ftl.util.FlankGeneralError
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -31,6 +32,7 @@ class AndroidArgsFileTest {
     @JvmField
     val systemOutRule = SystemOutRule().muteForSuccessfulTests()!!
 
+    private val ymlNotFound = getPath("not_found.yml")
     private val localYamlFile = getPath("src/test/kotlin/ftl/fixtures/flank.local.yml")
     private val gcsYamlFile = getPath("src/test/kotlin/ftl/fixtures/flank.gcs.yml")
     private val appApkLocal = getString("../test_projects/android/apks/app-debug.apk")
@@ -223,5 +225,15 @@ class AndroidArgsFileTest {
     fun `verify output style value from uml file`() {
         val args = AndroidArgs.load(localYamlFile)
         assertEquals(OutputStyle.Single, args.outputStyle)
+    }
+
+    @Test(expected = FlankGeneralError::class)
+    fun `should throw if load and yamlFile not found`() {
+        AndroidArgs.load(ymlNotFound)
+    }
+
+    @Test
+    fun `should not throw if loadOrDefault and yamlFile not found`() {
+        AndroidArgs.loadOrDefault(ymlNotFound)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsFileTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsFileTest.kt
@@ -7,6 +7,7 @@ import ftl.run.status.OutputStyle
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.assert
 import ftl.test.util.TestHelper.getPath
+import ftl.util.FlankGeneralError
 import org.junit.Assert.assertEquals
 import org.junit.Assume
 import org.junit.Rule
@@ -26,6 +27,7 @@ class IosArgsFileTest {
     @JvmField
     val systemOutRule = SystemOutRule().muteForSuccessfulTests()!!
 
+    private val ymlNotFound = getPath("not_found.yml")
     private val yamlFile = getPath("src/test/kotlin/ftl/fixtures/flank.ios.yml")
     private val yamlFile2 = getPath("src/test/kotlin/ftl/fixtures/flank2.ios.yml")
     private val xctestrunZip = getPath("src/test/kotlin/ftl/fixtures/tmp/earlgrey_example.zip")
@@ -104,5 +106,15 @@ class IosArgsFileTest {
     fun `verify output style value from uml file`() {
         val args = IosArgs.load(yamlFile)
         assertEquals(OutputStyle.Single, args.outputStyle)
+    }
+
+    @Test(expected = FlankGeneralError::class)
+    fun `should throw if load and yamlFile not found`() {
+        IosArgs.load(ymlNotFound)
+    }
+
+    @Test
+    fun `should not throw if loadOrDefault and yamlFile not found`() {
+        IosArgs.loadOrDefault(ymlNotFound)
     }
 }


### PR DESCRIPTION
Fixes #925 

## Test Plan
> How do we know the code works?

Try run flank commands for

```
models
orientations
locales
test-environment
network

```

, without flank.yml this should display lists instead of ```flank.yml``` not found



## Checklist

- [X] Unit tested
- [X] release_notes.md updated
