### PR TITLE
Disable Auto Doc Generation

### DIFF
--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -281,9 +281,9 @@ val processCliAsciiDoc by tasks.registering {
     }
 }
 
-tasks.assemble {
-    dependsOn(processCliAsciiDoc)
-}
+//tasks.assemble {
+//dependsOn(processCliAsciiDoc)
+//}
 // end --- ASCII doc generation ---
 
 val updateVersion by tasks.registering {


### PR DESCRIPTION
Disable CLI AsciiDoc as per discussion around it creating unnecessary pull request spam

## Test Plan
> How do we know the code works?
No more AutoDoc generation when we submit pull requests
.

## Checklist

- [ ] Documented (Shall we create a feature for this or other?)
