### PR TITLE
Fix crash when --legacy-junit-result set

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,6 @@
 ## next (unreleased)
 - [#952](https://github.com/Flank/flank/pull/952) Fix version printing on Flank release
+- [#950](https://github.com/Flank/flank/pull/950) Fix crash when --legacy-junit-result set. ([adamfilipow92](https://github.com/adamfilipow92))
 -
 -
 

--- a/test_runner/src/main/kotlin/ftl/reports/util/MatrixPath.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/MatrixPath.kt
@@ -1,0 +1,11 @@
+package ftl.reports.util
+
+import java.io.File
+import java.nio.file.Paths
+
+fun File.getMatrixPath(objectName: String) = getShardName()?.asObjectPath(objectName)
+
+private fun File.getShardName() = shardNameRegex.find(toString())?.value?.removePrefix("/")?.removeSuffix("/")
+private val shardNameRegex = "/.*(shard_|matrix_)\\d+(-rerun_\\d+)?/".toRegex()
+
+private fun String.asObjectPath(objectName: String) = Paths.get(objectName, this).toString()

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -44,9 +44,8 @@ object ReportManager {
         // xmlFile path changes based on if local-result-dir is used. may or may not contain objName
         // 2019-03-22_17-20-53.594000_ftrh/shard_0/test_result_1.xml or shard_0/test_result_1.xml
         val objName = matrices.runPath // 2019-03-22_17-20-53.594000_ftrh
-
         // shard location in path changes based on iOS or Android.
-        val matchResult = Regex("/.*(shard_\\d+)(-rerun_\\d+)?/").find(xmlFile.toString())
+        val matchResult = xmlFile.getWeblinkFromFile()
         val shardName = matchResult?.value?.removePrefix("/")?.removeSuffix("/") // shard_0 || shard_0-rerun_1
         val matrixPath = Paths.get(objName, shardName).toString() // 2019-03-22_17-20-53.594000_ftrh/shard_0
 
@@ -215,3 +214,5 @@ object ReportManager {
         GcStorage.uploadJunitXml(newTestResult, args)
     }
 }
+@VisibleForTesting
+internal fun File.getWeblinkFromFile() =  Regex("/.*(shard_|matrix_)\\d+(-rerun_\\d+)?/").find(toString())

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -22,7 +22,6 @@ import ftl.shard.createTestMethodDurationMap
 import ftl.util.Artifacts
 import ftl.util.resolveLocalRunPath
 import java.io.File
-import java.nio.file.Paths
 import kotlin.math.roundToInt
 
 object ReportManager {
@@ -43,20 +42,13 @@ object ReportManager {
     private fun getWebLink(matrices: MatrixMap, xmlFile: File): String {
         // xmlFile path changes based on if local-result-dir is used. may or may not contain objName
         // 2019-03-22_17-20-53.594000_ftrh/shard_0/test_result_1.xml or shard_0/test_result_1.xml
-        val objName = matrices.runPath // 2019-03-22_17-20-53.594000_ftrh
-        // shard location in path changes based on iOS or Android.
-        val matchResult = xmlFile.getWeblinkFromFile()
-        val shardName = matchResult?.value?.removePrefix("/")?.removeSuffix("/") // shard_0 || shard_0-rerun_1
-        val matrixPath = Paths.get(objName, shardName).toString() // 2019-03-22_17-20-53.594000_ftrh/shard_0
-
-        var webLink = ""
-        val savedMatrix = matrices.map.values.firstOrNull { it.gcsPath.endsWith(matrixPath) }
-        if (savedMatrix != null) {
-            webLink = savedMatrix.webLink
-        } else {
-            println("WARNING: Matrix path not found in JSON. $matrixPath")
+        val matrixPath = xmlFile.getMatrixPath(matrices.runPath)
+        return matrixPath?.let { path ->
+            matrices.map.values.firstOrNull { it.gcsPath.endsWith(path) }
+        }.let { savedMatrix ->
+            if (savedMatrix == null) println("WARNING: Matrix path not found in JSON. $matrixPath")
+            savedMatrix?.webLink.orEmpty()
         }
-        return webLink
     }
 
     private val deviceStringRgx = Regex("([^-]+-[^-]+-[^-]+-[^-]+).*")
@@ -214,5 +206,3 @@ object ReportManager {
         GcStorage.uploadJunitXml(newTestResult, args)
     }
 }
-@VisibleForTesting
-internal fun File.getWeblinkFromFile() =  Regex("/.*(shard_|matrix_)\\d+(-rerun_\\d+)?/").find(toString())

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -40,10 +40,7 @@ object ReportManager {
     }
 
     private fun getWebLink(matrices: MatrixMap, xmlFile: File): String = xmlFile.getMatrixPath(matrices.runPath)
-        ?.let { path ->
-            matrices.map.values.firstOrNull { savedMatrix -> savedMatrix.gcsPath.endsWith(path) }?.webLink
-                ?: "".also { println("WARNING: Matrix path not found in JSON. $path") }
-        } ?: "".also { println("WARNING: Matrix path not found in JSON.") }
+        ?.findMatrixPath(matrices) ?: "".also { println("WARNING: Matrix path not found in JSON.") }
 
     private val deviceStringRgx = Regex("([^-]+-[^-]+-[^-]+-[^-]+).*")
 
@@ -200,3 +197,7 @@ object ReportManager {
         GcStorage.uploadJunitXml(newTestResult, args)
     }
 }
+
+private fun String.findMatrixPath(matrices: MatrixMap) =
+    matrices.map.values.firstOrNull { savedMatrix -> savedMatrix.gcsPath.endsWith(this) }?.webLink
+        ?: "".also { println("WARNING: Matrix path not found in JSON. $this") }

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -39,17 +39,11 @@ object ReportManager {
         return xmlFiles
     }
 
-    private fun getWebLink(matrices: MatrixMap, xmlFile: File): String {
-        // xmlFile path changes based on if local-result-dir is used. may or may not contain objName
-        // 2019-03-22_17-20-53.594000_ftrh/shard_0/test_result_1.xml or shard_0/test_result_1.xml
-        val matrixPath = xmlFile.getMatrixPath(matrices.runPath)
-        return matrixPath?.let { path ->
-            matrices.map.values.firstOrNull { it.gcsPath.endsWith(path) }
-        }.let { savedMatrix ->
-            if (savedMatrix == null) println("WARNING: Matrix path not found in JSON. $matrixPath")
-            savedMatrix?.webLink.orEmpty()
-        }
-    }
+    private fun getWebLink(matrices: MatrixMap, xmlFile: File): String = xmlFile.getMatrixPath(matrices.runPath)
+        ?.let { path ->
+            matrices.map.values.firstOrNull { savedMatrix -> savedMatrix.gcsPath.endsWith(path) }?.webLink
+                ?: "".also { println("WARNING: Matrix path not found in JSON. $path") }
+        } ?: "".also { println("WARNING: Matrix path not found in JSON.") }
 
     private val deviceStringRgx = Regex("([^-]+-[^-]+-[^-]+-[^-]+).*")
 

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -11,8 +11,8 @@ fun main() {
     val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
         ?: "YOUR PROJECT ID"
 
-    val quantity = "single"
-    val type = "error"
+    val quantity = "multiple"
+    val type = "success"
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151
     withGlobalExceptionHandling {
@@ -23,7 +23,8 @@ fun main() {
 //            "--dry",
 //            "--dump-shards",
 //            "--output-style=single",
-            "--full-junit-result",
+//            "--full-junit-result",
+//            "--legacy-junit-result",
             "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
             "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"

--- a/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
@@ -8,7 +8,7 @@ import ftl.reports.FullJUnitReport
 import ftl.reports.JUnitReport
 import ftl.reports.MatrixResultsReport
 import ftl.reports.util.ReportManager
-import ftl.reports.util.getWeblinkFromFile
+import ftl.reports.util.getMatrixPath
 import ftl.reports.xml.model.JUnitTestCase
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.model.JUnitTestSuite
@@ -29,7 +29,6 @@ import org.junit.contrib.java.lang.system.SystemErrRule
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
 import java.io.File
-import java.nio.file.Files
 
 @RunWith(FlankTestRunner::class)
 class ReportManagerTest {
@@ -205,7 +204,8 @@ class ReportManagerTest {
     fun `should get weblink from legacy path and ios path`() {
         val legacyPath = File("results/2020-08-06_12-08-55.641213_jGpY/matrix_0/NexusLowRes-28-en-portrait/test_result_1.xml")
         val iosPath = File("results/test_dir/shard_0/iphone8-12.0-en-portrait/test_result_0.xml")
-        assertEquals("/2020-08-06_12-08-55.641213_jGpY/matrix_0/", legacyPath.getWeblinkFromFile()?.value)
-        assertEquals("/test_dir/shard_0/", iosPath.getWeblinkFromFile()?.value)
+        val objectName = "object_name"
+        assertEquals("object_name/2020-08-06_12-08-55.641213_jGpY/matrix_0", legacyPath.getMatrixPath(objectName))
+        assertEquals("object_name/test_dir/shard_0", iosPath.getMatrixPath(objectName))
     }
 }

--- a/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
@@ -8,6 +8,7 @@ import ftl.reports.FullJUnitReport
 import ftl.reports.JUnitReport
 import ftl.reports.MatrixResultsReport
 import ftl.reports.util.ReportManager
+import ftl.reports.util.getWeblinkFromFile
 import ftl.reports.xml.model.JUnitTestCase
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.model.JUnitTestSuite
@@ -21,11 +22,14 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemErrRule
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
+import java.io.File
+import java.nio.file.Files
 
 @RunWith(FlankTestRunner::class)
 class ReportManagerTest {
@@ -195,5 +199,13 @@ class ReportManagerTest {
 
         assertThat(ReportManager.getDeviceString(""))
             .isEqualTo("")
+    }
+
+    @Test
+    fun `should get weblink from legacy path and ios path`() {
+        val legacyPath = File("results/2020-08-06_12-08-55.641213_jGpY/matrix_0/NexusLowRes-28-en-portrait/test_result_1.xml")
+        val iosPath = File("results/test_dir/shard_0/iphone8-12.0-en-portrait/test_result_0.xml")
+        assertEquals("/2020-08-06_12-08-55.641213_jGpY/matrix_0/", legacyPath.getWeblinkFromFile()?.value)
+        assertEquals("/test_dir/shard_0/", iosPath.getWeblinkFromFile()?.value)
     }
 }


### PR DESCRIPTION
Fixes #947 

## Test Plan
> How do we know the code works?

When using --legacy-junit-result flank, shouldn't throw an exception. 

## Checklist

- [X] Unit tested
- [X] release_notes.md updated
