### PR TITLE
Fix version printing on Flank release 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,5 @@
 ## next (unreleased)
--
+- [#952](https://github.com/Flank/flank/pull/952) Fix version printing on Flank release
 -
 -
 

--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -140,11 +140,11 @@ tasks.jacocoTestReport {
     }
 }
 
-val runningOnBitrise get() = System.getenv("BITRISE_IO") != null
+val runningOnCI get() = System.getenv("CI") != null
 
 tasks.withType<KotlinCompile>().configureEach {
     // https://devcenter.bitrise.io/builds/available-environment-variables/
-    kotlinOptions.allWarningsAsErrors = runningOnBitrise
+    kotlinOptions.allWarningsAsErrors = runningOnCI
 }
 
 application {
@@ -288,7 +288,7 @@ val processCliAsciiDoc by tasks.registering {
 
 val updateVersion by tasks.registering {
     shouldRunAfter(tasks.processResources)
-    if (!runningOnBitrise) doLast {
+    if (!runningOnCI) doLast {
         File("$buildDir/resources/main/version.txt").writeText("local_snapshot")
         File("$buildDir/resources/main/revision.txt").writeText(execAndGetStdout("git", "rev-parse", "HEAD"))
     }


### PR DESCRIPTION
Fixes #951 

Change param runningOnBitrise to more generic runningOnCI

## Test Plan
> How do we know the code works?
Need to run a build to check the version update.
.

## Checklist

- [x] release_notes.md updated
