### PR TITLE
Make table text left aligned

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,7 @@
 - [#948](https://github.com/Flank/flank/pull/948) Increment retry tries and change sync tag for jfrogSync. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#946](https://github.com/Flank/flank/pull/946) Added tests for flank scripts. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#935](https://github.com/Flank/flank/pull/935) Process junit xml even when full junit is not enabled. ([kozaxinan](https://github.com/kozaxinan))
+- [#962](https://github.com/Flank/flank/pull/962) Make table text left aligned. ([pawelpasterz](https://github.com/pawelpasterz))
 -
 -
 

--- a/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
+++ b/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
@@ -16,8 +16,11 @@ data class TableColumn(
 
 private data class DataWithSize(
     val data: String,
-    val columnSize: Int
-)
+    val columnSize: Int,
+    val centered: Boolean
+) {
+    constructor(data: String, columnSize: Int) : this(data, columnSize, data.matches("-?\\d+(\\.\\d+)?".toRegex()))
+}
 
 private const val DEFAULT_COLUMN_PADDING = 2
 
@@ -58,7 +61,9 @@ fun buildTable(vararg tableColumns: TableColumn, tableStyle: TableStyle = TableS
     val rowSizes = tableColumns.map { it.columnSize }
     val builder = StringBuilder().apply {
         startTable(rowSizes)
-        tableColumns.map { DataWithSize(it.header, it.columnSize) }.apply { appendDataRow(this) }
+        tableColumns
+                .map { DataWithSize(data = it.header, columnSize = it.columnSize, centered = true) }
+                .apply { appendDataRow(this) }
         rowSeparator(rowSizes)
         appendData(tableColumns, rowSizes, tableStyle)
         endTable(rowSizes)
@@ -125,12 +130,17 @@ private fun StringBuilder.appendTableSeparator(startChar: Char, middleChar: Char
 private fun StringBuilder.appendDataRow(data: List<DataWithSize>) {
     append(TABLE_VERTICAL_LINE)
     data.forEach {
-        append(it.leftAligned())
+        if (it.centered) append(it.center()) else append(it.leftAligned())
         append(TABLE_VERTICAL_LINE)
     }
     appendln()
 }
 
 private fun DataWithSize.leftAligned() = String.format("%-${columnSize}s", " $data")
+
+private fun DataWithSize.center() = String.format(
+        "%-" + columnSize + "s",
+        String.format("%" + (data.length + (columnSize - data.length) / 2) + "s", this.data)
+)
 
 inline fun TableColumn.applyColorsUsing(mapper: (String) -> SystemOutColor) = copy(dataColor = data.map(mapper))

--- a/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
+++ b/test_runner/src/main/kotlin/ftl/util/LogTableBuilder.kt
@@ -124,18 +124,13 @@ private fun StringBuilder.appendTableSeparator(startChar: Char, middleChar: Char
 
 private fun StringBuilder.appendDataRow(data: List<DataWithSize>) {
     append(TABLE_VERTICAL_LINE)
-    data.forEach { (data, size) ->
-        append(data.center(size))
+    data.forEach {
+        append(it.leftAligned())
         append(TABLE_VERTICAL_LINE)
     }
     appendln()
 }
 
-private fun String.center(columnSize: Int): String? {
-    return String.format(
-        "%-" + columnSize + "s",
-        String.format("%" + (length + (columnSize - length) / 2) + "s", this)
-    )
-}
+private fun DataWithSize.leftAligned() = String.format("%-${columnSize}s", " $data")
 
 inline fun TableColumn.applyColorsUsing(mapper: (String) -> SystemOutColor) = copy(dataColor = data.map(mapper))


### PR DESCRIPTION
Fixes #958 

## Test Plan
> How do we know the code works?

Text for any list option (example: `flank android locales list`) is left aligned. Same as for `gcloud`

## Checklist

- [x] release_notes.md updated
