### PR TITLE
Implement network-profiles describe feature

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,6 +8,7 @@
 - [#965](https://github.com/Flank/flank/pull/965) Fast fail when full-junit-result and legacy-junit-result. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#970](https://github.com/Flank/flank/pull/970) Fixing Flood of snapshot  releases. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#972](https://github.com/Flank/flank/pull/972) Fix printing release version. ([piotradamczyk5](https://github.com/piotradamczyk5))
+- [#964](https://github.com/Flank/flank/pull/964) Implement network-profiles describe feature. ([pawelpasterz](https://github.com/pawelpasterz))
 -
 -
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/NetworkProfilesCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/NetworkProfilesCommand.kt
@@ -1,5 +1,6 @@
 package ftl.cli.firebase.test
 
+import ftl.cli.firebase.test.networkprofiles.NetworkProfilesDescribeCommand
 import ftl.cli.firebase.test.networkprofiles.NetworkProfilesListCommand
 import picocli.CommandLine
 
@@ -7,7 +8,8 @@ import picocli.CommandLine
     name = "network-profiles",
     synopsisHeading = "",
     subcommands = [
-        NetworkProfilesListCommand::class
+        NetworkProfilesListCommand::class,
+        NetworkProfilesDescribeCommand::class
     ],
     usageHelpAutoWidth = true
 )

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesDescribeCommand.kt
@@ -17,8 +17,8 @@ import picocli.CommandLine
 )
 class NetworkProfilesDescribeCommand : Runnable {
     override fun run() {
-        if (profile.isBlank()) throw FlankConfigurationError("Argument PROFILE_ID must be specified.")
-        println(networkProfileDescription(profile))
+        if (profileId.isBlank()) throw FlankConfigurationError("Argument PROFILE_ID must be specified.")
+        println(networkProfileDescription(profileId))
     }
 
     @CommandLine.Parameters(
@@ -28,5 +28,5 @@ class NetworkProfilesDescribeCommand : Runnable {
             defaultValue = "",
             description = ["The network profile to describe, found" +
             " using \$ gcloud beta firebase test network-profiles list."])
-    var profile: String = ""
+    var profileId: String = ""
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesDescribeCommand.kt
@@ -1,0 +1,32 @@
+package ftl.cli.firebase.test.networkprofiles
+
+import ftl.environment.networkProfileDescription
+import ftl.util.FlankConfigurationError
+import picocli.CommandLine
+
+@CommandLine.Command(
+    name = "describe",
+    sortOptions = false,
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["Describe a network profile "],
+    usageHelpAutoWidth = true
+)
+class NetworkProfilesDescribeCommand : Runnable {
+    override fun run() {
+        if (profile.isBlank()) throw FlankConfigurationError("Argument PROFILE_ID must be specified.")
+        println(networkProfileDescription(profile))
+    }
+
+    @CommandLine.Parameters(
+            index = "0",
+            arity = "1",
+            paramLabel = "PROFILE_ID",
+            defaultValue = "",
+            description = ["The network profile to describe, found" +
+            " using \$ gcloud beta firebase test network-profiles list."])
+    var profile: String = ""
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesDescribeCommand.kt
@@ -22,11 +22,11 @@ class NetworkProfilesDescribeCommand : Runnable {
     }
 
     @CommandLine.Parameters(
-            index = "0",
-            arity = "1",
-            paramLabel = "PROFILE_ID",
-            defaultValue = "",
-            description = ["The network profile to describe, found" +
+        index = "0",
+        arity = "1",
+        paramLabel = "PROFILE_ID",
+        defaultValue = "",
+        description = ["The network profile to describe, found" +
             " using \$ gcloud beta firebase test network-profiles list."])
     var profileId: String = ""
 }

--- a/test_runner/src/main/kotlin/ftl/environment/NetworkConfigurationCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/NetworkConfigurationCatalog.kt
@@ -4,11 +4,11 @@ import ftl.environment.common.asPrintableTable
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
-fun networkConfigurationAsTable() = networkConfiguration().asPrintableTable()
+fun networkConfigurationAsTable() = getNetworkConfiguration().asPrintableTable()
 
-private fun networkConfiguration() = GcTesting.get.testEnvironmentCatalog()
-    .get("NETWORK_CONFIGURATION")
-    .executeWithRetry()
-    ?.networkConfigurationCatalog
-    ?.configurations
-    .orEmpty()
+fun getNetworkConfiguration() = GcTesting.get.testEnvironmentCatalog()
+        .get("NETWORK_CONFIGURATION")
+        .executeWithRetry()
+        ?.networkConfigurationCatalog
+        ?.configurations
+        .orEmpty()

--- a/test_runner/src/main/kotlin/ftl/environment/NetworkConfigurationCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/NetworkConfigurationCatalog.kt
@@ -7,8 +7,8 @@ import ftl.http.executeWithRetry
 fun networkConfigurationAsTable() = getNetworkConfiguration().asPrintableTable()
 
 fun getNetworkConfiguration() = GcTesting.get.testEnvironmentCatalog()
-        .get("NETWORK_CONFIGURATION")
-        .executeWithRetry()
-        ?.networkConfigurationCatalog
-        ?.configurations
-        .orEmpty()
+    .get("NETWORK_CONFIGURATION")
+    .executeWithRetry()
+    ?.networkConfigurationCatalog
+    ?.configurations
+    .orEmpty()

--- a/test_runner/src/main/kotlin/ftl/environment/NetworkProfileDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/NetworkProfileDescription.kt
@@ -13,21 +13,21 @@ private fun NetworkConfiguration?.toNullProof() = this?.run {
     NetworkConfigurationWrapper(
             downRule = wrappedOrEmpty(downRule),
             upRule = wrappedOrEmpty(upRule),
-            id = id.toStringOrEmpty()
+            id = id.toStringOrUnableToFetch()
     )
 }
 
 private fun wrappedOrEmpty(rule: TrafficRule?) = rule?.let {
     Rule(
-            bandwidth = it.bandwidth.toStringOrEmpty(),
-            delay = it.delay.toStringOrEmpty(),
-            packetLossRatio = it.packetLossRatio.toStringOrEmpty()
+            bandwidth = it.bandwidth.toStringOrUnableToFetch(),
+            delay = it.delay.toStringOrUnableToFetch(),
+            packetLossRatio = it.packetLossRatio.toStringOrUnableToFetch()
     )
 } ?: emptyRule
 
 private const val UNABLE = "[Unable to fetch]"
 
-private fun Any?.toStringOrEmpty() = this?.toString() ?: UNABLE
+private fun Any?.toStringOrUnableToFetch() = this?.toString() ?: UNABLE
 
 private val emptyRule: Rule
     get() = Rule(UNABLE, UNABLE, UNABLE)

--- a/test_runner/src/main/kotlin/ftl/environment/NetworkProfileDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/NetworkProfileDescription.kt
@@ -1,0 +1,51 @@
+package ftl.environment
+
+import com.google.api.services.testing.model.NetworkConfiguration
+import com.google.api.services.testing.model.TrafficRule
+
+fun networkProfileDescription(profile: String) = getNetworkConfiguration()
+        .find { it.id?.toUpperCase() == profile.toUpperCase() }
+        .wrapWithKotlinObject()
+        .prepareDescription()
+        ?: "Unable to fetch profile [$profile] description"
+
+private fun NetworkConfiguration?.wrapWithKotlinObject() = this?.run {
+    NetworkConfigurationWrapper(
+            downRule = wrappedOrEmpty(downRule),
+            upRule = wrappedOrEmpty(upRule),
+            id = id.toStringOrEmpty()
+    )
+}
+
+private fun wrappedOrEmpty(rule: TrafficRule?) = rule?.let {
+    Rule(
+            bandwidth = it.bandwidth.toStringOrEmpty(),
+            delay = it.delay.toStringOrEmpty(),
+            packetLossRatio = it.packetLossRatio.toStringOrEmpty()
+    )
+} ?: emptyRule
+
+private const val UNABLE = "[Unable to fetch]"
+
+private fun Any?.toStringOrEmpty() = this?.toString() ?: UNABLE
+
+private val emptyRule: Rule
+    get() = Rule(UNABLE, UNABLE, UNABLE)
+
+private fun NetworkConfigurationWrapper?.prepareDescription() = this?.run {
+    """
+downRule:
+  bandwidth: ${downRule.bandwidth}
+  delay: ${downRule.delay}
+  packetLossRatio: ${downRule.packetLossRatio}
+id: $id
+upRule:
+  bandwidth: ${upRule.bandwidth}
+  delay: ${upRule.delay}
+  packetLossRatio: ${upRule.packetLossRatio}
+""".trimIndent()
+}
+
+private data class NetworkConfigurationWrapper(val downRule: Rule, val upRule: Rule, val id: String)
+
+private data class Rule(val bandwidth: String, val delay: String, val packetLossRatio: String)

--- a/test_runner/src/main/kotlin/ftl/environment/NetworkProfileDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/NetworkProfileDescription.kt
@@ -5,11 +5,11 @@ import com.google.api.services.testing.model.TrafficRule
 
 fun networkProfileDescription(profile: String) = getNetworkConfiguration()
         .find { it.id?.toUpperCase() == profile.toUpperCase() }
-        .wrapWithKotlinObject()
+        .toNullProof()
         .prepareDescription()
         ?: "Unable to fetch profile [$profile] description"
 
-private fun NetworkConfiguration?.wrapWithKotlinObject() = this?.run {
+private fun NetworkConfiguration?.toNullProof() = this?.run {
     NetworkConfigurationWrapper(
             downRule = wrappedOrEmpty(downRule),
             upRule = wrappedOrEmpty(upRule),

--- a/test_runner/src/main/kotlin/ftl/environment/NetworkProfileDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/NetworkProfileDescription.kt
@@ -4,24 +4,24 @@ import com.google.api.services.testing.model.NetworkConfiguration
 import com.google.api.services.testing.model.TrafficRule
 
 fun networkProfileDescription(profile: String) = getNetworkConfiguration()
-        .find { it.id?.toUpperCase() == profile.toUpperCase() }
-        .toNullProof()
-        .prepareDescription()
-        ?: "Unable to fetch profile [$profile] description"
+    .find { it.id?.toUpperCase() == profile.toUpperCase() }
+    .toNullProof()
+    .prepareDescription()
+    ?: "Unable to fetch profile [$profile] description"
 
 private fun NetworkConfiguration?.toNullProof() = this?.run {
     NetworkConfigurationWrapper(
-            downRule = wrappedOrEmpty(downRule),
-            upRule = wrappedOrEmpty(upRule),
-            id = id.toStringOrUnableToFetch()
+        downRule = wrappedOrEmpty(downRule),
+        upRule = wrappedOrEmpty(upRule),
+        id = id.toStringOrUnableToFetch()
     )
 }
 
 private fun wrappedOrEmpty(rule: TrafficRule?) = rule?.let {
     Rule(
-            bandwidth = it.bandwidth.toStringOrUnableToFetch(),
-            delay = it.delay.toStringOrUnableToFetch(),
-            packetLossRatio = it.packetLossRatio.toStringOrUnableToFetch()
+        bandwidth = it.bandwidth.toStringOrUnableToFetch(),
+        delay = it.delay.toStringOrUnableToFetch(),
+        packetLossRatio = it.packetLossRatio.toStringOrUnableToFetch()
     )
 } ?: emptyRule
 

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/NetworkProfilesCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/NetworkProfilesCommandTest.kt
@@ -17,10 +17,11 @@ class NetworkProfilesCommandTest {
         NetworkProfilesCommand().run()
 
         val expected = listOf(
-            "network-profiles [COMMAND]",
-            "Commands:",
-            "  list  List all network profiles available for testing",
-            ""
+                "network-profiles [COMMAND]",
+                "Commands:",
+                "  list      List all network profiles available for testing",
+                "  describe  Describe a network profile",
+                ""
         ).joinToString("\n")
 
         val actual = systemOutRule.log.normalizeLineEnding()

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfileDescribeTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfileDescribeTest.kt
@@ -1,0 +1,152 @@
+package ftl.cli.firebase.test.networkprofiles
+
+import com.google.api.services.testing.model.NetworkConfiguration
+import com.google.api.services.testing.model.TrafficRule
+import ftl.environment.getNetworkConfiguration
+import ftl.test.util.assertThrowsWithMessage
+import ftl.test.util.runMainCommand
+import ftl.util.FlankConfigurationError
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.contrib.java.lang.system.SystemOutRule
+
+class NetworkProfileDescribeTest {
+
+    @get:Rule
+    val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @Before
+    fun setup() {
+        mockkStatic("ftl.environment.NetworkConfigurationCatalogKt")
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `should throw the configuration error if no PROFILE_ID parameter provided`() {
+        assertThrowsWithMessage(FlankConfigurationError::class, "Argument PROFILE_ID must be specified.") {
+            NetworkProfilesDescribeCommand().run()
+        }
+    }
+
+    @Test
+    fun `should print profile description if data exists`() {
+        val configs = listOf(
+                NetworkConfiguration().apply {
+                    downRule = makeRule(0.5f)
+                    upRule = makeRule(0.8f)
+                    id = "ANY"
+                },
+                NetworkConfiguration().apply {
+                    downRule = makeRule(0.1f)
+                    upRule = makeRule(0.2f)
+                    id = "DIFFERENT"
+                }
+        )
+        every { getNetworkConfiguration() } returns configs
+
+        systemOutRule.clearLog()
+        runMainCommand("network-profiles", "describe", "ANY")
+
+        val result = systemOutRule.log.trim()
+        val expected = """
+            downRule:
+              bandwidth: 0.5
+              delay: 0.5s
+              packetLossRatio: 0.5
+            id: ANY
+            upRule:
+              bandwidth: 0.8
+              delay: 0.8s
+              packetLossRatio: 0.8
+        """.trimIndent()
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should handle case when API answers with null for configuration request`() {
+        every { getNetworkConfiguration() } returns emptyList()
+
+        systemOutRule.clearLog()
+        runMainCommand("network-profiles", "describe", "NON-EXISTING")
+
+        val result = systemOutRule.log.trim()
+        val expected = "Unable to fetch profile [NON-EXISTING] description"
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should print message if unable to find provided profile`() {
+        val configs = listOf(
+                NetworkConfiguration().apply {
+                    downRule = makeRule(0.456f)
+                    id = "ANY_1"
+                    upRule = makeRule(0.111f)
+                },
+                NetworkConfiguration().apply {
+                    downRule = makeRule(0.0976f)
+                    id = "ANY_2"
+                    upRule = makeRule(0.234f)
+                },
+                NetworkConfiguration().apply {
+                    downRule = makeRule(0.1f)
+                    id = "ANY_3"
+                    upRule = makeRule(0.11233f)
+                }
+        )
+        every { getNetworkConfiguration() } returns configs
+
+        systemOutRule.clearLog()
+        runMainCommand("network-profiles", "describe", "NON-EXISTING")
+
+        val result = systemOutRule.log.trim()
+        val expected = "Unable to fetch profile [NON-EXISTING] description"
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should handle possible null values`() {
+        val configs = listOf(
+                NetworkConfiguration().apply {
+                    downRule = makeRule(0.456f)
+                    id = "WITH_NULLS"
+                    upRule = TrafficRule().apply { packetLossRatio = 0.123f }
+                }
+        )
+        every { getNetworkConfiguration() } returns configs
+
+        systemOutRule.clearLog()
+        runMainCommand("network-profiles", "describe", "WITH_NULLS")
+
+        val result = systemOutRule.log.trim()
+        val expected = """
+            downRule:
+              bandwidth: 0.456
+              delay: 0.456s
+              packetLossRatio: 0.456
+            id: WITH_NULLS
+            upRule:
+              bandwidth: [Unable to fetch]
+              delay: [Unable to fetch]
+              packetLossRatio: 0.123
+        """.trimIndent()
+
+        assertEquals(expected, result)
+    }
+}
+
+private fun makeRule(ratio: Float) = TrafficRule().apply {
+    bandwidth = ratio
+    delay = "${ratio}s"
+    packetLossRatio = ratio
+}

--- a/test_runner/src/test/kotlin/ftl/test/util/TestHelper.kt
+++ b/test_runner/src/test/kotlin/ftl/test/util/TestHelper.kt
@@ -2,12 +2,14 @@
 
 package ftl.test.util
 
+import ftl.Main
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import org.junit.Assert
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
+import picocli.CommandLine
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.reflect.KClass
@@ -68,3 +70,5 @@ inline fun <reified T : Any> should(crossinline match: T.() -> Boolean): T = moc
 internal fun <T : Throwable> assertThrowsWithMessage(clazz: KClass<T>, message: String, block: () -> Unit) {
     assertThrows(clazz.java) { block() }.also { assertTrue(it.message?.contains(message) ?: false) }
 }
+
+internal fun runMainCommand(vararg args: String) = CommandLine(Main()).execute(*args)


### PR DESCRIPTION
Fixes #963 

## Test Plan
> How do we know the code works?

Run `flank network-profiles describe LTE` and see the result:
```
downRule:
  bandwidth: 16000.0
  delay: 0.040s
  packetLossRatio: 0.001
id: LTE
upRule:
  bandwidth: 16000.0
  delay: 0.040s
  packetLossRatio: 0.001
```
Compare it with `gcloud alpha firebase test network-profiles describe LTE` output

## Checklist

- [x] Documented
- [x] Unit tested
- [x] release_notes.md updated
