### PR TITLE
Fast fail when full-junit-result and legacy-junit-result 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,6 +5,7 @@
 - [#946](https://github.com/Flank/flank/pull/946) Added tests for flank scripts. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#935](https://github.com/Flank/flank/pull/935) Process junit xml even when full junit is not enabled. ([kozaxinan](https://github.com/kozaxinan))
 - [#962](https://github.com/Flank/flank/pull/962) Make table text left aligned. ([pawelpasterz](https://github.com/pawelpasterz))
+- [#965](https://github.com/Flank/flank/pull/965) Fast fail when full-junit-result and legacy-junit-result. ([adamfilipow92](https://github.com/adamfilipow92))
 -
 -
 

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -103,5 +103,5 @@ private fun AndroidArgs.throwMaxTestShardsLimitExceeded(): Nothing {
 
 private fun AndroidArgs.assertParametersConflict() {
     if (useLegacyJUnitResult && fullJUnitResult)
-        throw FlankConfigurationError("Parameters conflict, you cannot set: `useLegacyJUnitResult` and `fullJUnitResult` at the same time")
+        throw FlankConfigurationError("Parameters conflict, you cannot set: `--legacy-junit-result` and `--full-junit-result` at the same time.")
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -19,6 +19,7 @@ fun AndroidArgs.validate() {
     assertRoboTest()
     assertDirectoriesToPull()
     assertMaxTestShardsByDeviceType()
+    assertParametersConflict()
 }
 
 private fun AndroidArgs.assertAdditionalAppTestApks() {
@@ -98,4 +99,9 @@ private fun AndroidArgs.throwMaxTestShardsLimitExceeded(): Nothing {
     throw FlankConfigurationError(
         "max-test-shards must be >= ${IArgs.AVAILABLE_VIRTUAL_SHARD_COUNT_RANGE.first} and <= ${IArgs.AVAILABLE_VIRTUAL_SHARD_COUNT_RANGE.last} for virtual devices, for physical devices max-test-shards must be >= ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.first} and <= ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}, or -1. But current is $maxTestShards"
     )
+}
+
+private fun AndroidArgs.assertParametersConflict() {
+    if (useLegacyJUnitResult && fullJUnitResult)
+        throw FlankConfigurationError("Parameters conflict, you cannot set: `useLegacyJUnitResult` and `fullJUnitResult` at the same time")
 }

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -1566,6 +1566,74 @@ AndroidArgs
         val args = AndroidArgs.load(yaml)
         assertEquals(AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last, args.maxTestShards)
     }
+
+    @Test(expected = FlankConfigurationError::class)
+    fun `should throw when --legacy-junit-result and --full-junit-result set`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          device:
+            - model: blueline
+              version: 28
+              locale: en
+              orientation: portrait
+            - model: Nexus6
+              version: 25
+              locale: en
+              orientation: portrait
+        flank:
+          max-test-shards: -1
+          full-junit-result: true
+          legacy-junit-result: true
+        """.trimIndent()
+        AndroidArgs.load(yaml)
+    }
+    @Test
+    fun `should not throw when --legacy-junit-result set and --full-junit-result not set`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          device:
+            - model: blueline
+              version: 28
+              locale: en
+              orientation: portrait
+            - model: Nexus6
+              version: 25
+              locale: en
+              orientation: portrait
+        flank:
+          max-test-shards: -1
+          full-junit-result: false
+          legacy-junit-result: true
+        """.trimIndent()
+        AndroidArgs.load(yaml)
+    }
+
+    @Test
+    fun `should not throw when --legacy-junit-result not set and --full-junit-result set`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          device:
+            - model: blueline
+              version: 28
+              locale: en
+              orientation: portrait
+            - model: Nexus6
+              version: 25
+              locale: en
+              orientation: portrait
+        flank:
+          max-test-shards: -1
+          full-junit-result: true
+          legacy-junit-result: false
+        """.trimIndent()
+        AndroidArgs.load(yaml)
+    }
 }
 
 private fun AndroidArgs.Companion.load(yamlData: String, cli: AndroidRunCommand? = null): AndroidArgs =


### PR DESCRIPTION
Fixes #954 

## Test Plan
> How do we know the code works?

When full-junit-result and legacy-junit-result set Flank should fast fail with message

```

Parameters conflict, you cannot set: `--legacy-junit-result` and `--full-junit-result` at the same time.

Process finished with exit code 2

```

## Checklist

- [X] Unit tested
- [X] release_notes.md updated
