### PR TITLE
Improve error message on IOS

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,6 @@
 ## next (unreleased)
-- [#952](https://github.com/Flank/flank/pull/952) Fix version printing on Flank release
+- [#937](https://github.com/Flank/flank/pull/968) ([sloox](https://github.com/Sloox))
+- [#952](https://github.com/Flank/flank/pull/952) Fix version printing on Flank release ([sloox](https://github.com/Sloox))
 - [#950](https://github.com/Flank/flank/pull/950) Fix crash when --legacy-junit-result set. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#948](https://github.com/Flank/flank/pull/948) Increment retry tries and change sync tag for jfrogSync. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#946](https://github.com/Flank/flank/pull/946) Added tests for flank scripts. ([piotradamczyk5](https://github.com/piotradamczyk5))

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,5 @@
 ## next (unreleased)
-- [#937](https://github.com/Flank/flank/pull/968) ([sloox](https://github.com/Sloox))
+- [#937](https://github.com/Flank/flank/pull/968) Improve error message on IOS when test or xctestrun-file not found ([sloox](https://github.com/Sloox))
 - [#952](https://github.com/Flank/flank/pull/952) Fix version printing on Flank release ([sloox](https://github.com/Sloox))
 - [#950](https://github.com/Flank/flank/pull/950) Fix crash when --legacy-junit-result set. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#948](https://github.com/Flank/flank/pull/948) Increment retry tries and change sync tag for jfrogSync. ([piotradamczyk5](https://github.com/piotradamczyk5))

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,5 @@
 ## next (unreleased)
-- [#937](https://github.com/Flank/flank/pull/968) Improve error message on IOS when test or xctestrun-file not found ([sloox](https://github.com/Sloox))
+- [#937](https://github.com/Flank/flank/pull/968) Improve error message on iOS when test or xctestrun-file not found ([sloox](https://github.com/Sloox))
 - [#952](https://github.com/Flank/flank/pull/952) Fix version printing on Flank release ([sloox](https://github.com/Sloox))
 - [#950](https://github.com/Flank/flank/pull/950) Fix crash when --legacy-junit-result set. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#948](https://github.com/Flank/flank/pull/948) Increment retry tries and change sync tag for jfrogSync. ([piotradamczyk5](https://github.com/piotradamczyk5))

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -62,7 +62,7 @@ IosArgs
 private fun IosArgs.calculateShardChunks() = if (disableSharding)
     listOf(emptyList()) else
     ArgsHelper.calculateShards(
-        filteredTests = filterTests(findTestNames(xctestrunFile), testTargets)
+        filteredTests = filterTests(findTestNames(xctestrunFile.orEmpty()), testTargets)
             .distinct()
             .map { FlankTestMethod(it, ignored = false) },
         args = this

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -62,7 +62,7 @@ IosArgs
 private fun IosArgs.calculateShardChunks() = if (disableSharding)
     listOf(emptyList()) else
     ArgsHelper.calculateShards(
-        filteredTests = filterTests(findTestNames(xctestrunFile.orEmpty()), testTargets)
+        filteredTests = filterTests(findTestNames(xctestrunFile), testTargets)
             .distinct()
             .map { FlankTestMethod(it, ignored = false) },
         args = this

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -19,7 +19,7 @@ private fun IosArgs.assertMaxTestShards() { this.maxTestShards
     )
 }
 private fun IosArgs.assertTestTypes() {
-    if (this.xctestrunFile.isNullOrBlank() or this.xctestrunZip.isNullOrBlank())
+    if (xctestrunFile.isNullOrBlank() or xctestrunZip.isNullOrBlank())
         throw FlankConfigurationError("Both of following options must be specified [test, xctestrun-file].")
 }
 private fun IosArgs.assertXcodeSupported() = when {

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -19,7 +19,7 @@ private fun IosArgs.assertMaxTestShards() { this.maxTestShards
     )
 }
 private fun IosArgs.assertTestTypes() {
-    if(this.xctestrunFile.isNullOrBlank() or this.xctestrunZip.isNullOrBlank())
+    if (this.xctestrunFile.isNullOrBlank() or this.xctestrunZip.isNullOrBlank())
         throw FlankConfigurationError("Both of following options must be specified [test, xctestrun-file].")
 }
 private fun IosArgs.assertXcodeSupported() = when {

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -7,6 +7,7 @@ import ftl.util.IncompatibleTestDimensionError
 fun IosArgs.validate() {
     assertXcodeSupported()
     assertDevicesSupported()
+    assertTestTypes()
     assertMaxTestShards()
 }
 private fun IosArgs.assertMaxTestShards() { this.maxTestShards
@@ -16,6 +17,10 @@ private fun IosArgs.assertMaxTestShards() { this.maxTestShards
     ) throw FlankConfigurationError(
         "max-test-shards must be >= ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.first} and <= ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}, or -1. But current is $maxTestShards"
     )
+}
+private fun IosArgs.assertTestTypes() {
+    if(this.xctestrunFile.isNullOrBlank() or this.xctestrunZip.isNullOrBlank())
+        throw FlankConfigurationError("Both of following options must be specified [test, xctestrun-file].")
 }
 private fun IosArgs.assertXcodeSupported() = when {
     xcodeVersion == null -> Unit

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -19,7 +19,7 @@ private fun IosArgs.assertMaxTestShards() { this.maxTestShards
     )
 }
 private fun IosArgs.assertTestTypes() {
-    if (xctestrunFile.isNullOrBlank() or xctestrunZip.isNullOrBlank())
+    if (xctestrunFile.isBlank() or xctestrunZip.isBlank())
         throw FlankConfigurationError("Both of following options must be specified [test, xctestrun-file].")
 }
 private fun IosArgs.assertXcodeSupported() = when {

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -916,6 +916,51 @@ IosArgs
         val args = IosArgs.load(yaml)
         assertEquals(IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last, args.maxTestShards)
     }
+
+    @Test(expected = FlankConfigurationError::class)
+    fun `verify appropriate error message when test and xctestrun not set`() {
+        val yaml = """
+        gcloud:
+        flank:
+          max-test-shards: -1
+        """.trimIndent()
+        val args = IosArgs.load(yaml)
+    }
+
+    @Test(expected = FlankConfigurationError::class)
+    fun `verify appropriate error message when xctestrun not set`() {
+        val yaml = """
+        gcloud:
+          test: $testPath
+        flank:
+          max-test-shards: -1
+        """.trimIndent()
+        val args = IosArgs.load(yaml)
+    }
+
+    @Test(expected = FlankConfigurationError::class)
+    fun `verify appropriate error message when test not set`() {
+        val yaml = """
+        gcloud:
+          xctestrun-file: $testPath
+        flank:
+          max-test-shards: -1
+        """.trimIndent()
+        val args = IosArgs.load(yaml)
+    }
+
+    @Test
+    fun `verify no error message when test and xctestrun-file set`() {
+        val yaml = """
+        gcloud:
+          test: $testPath
+          xctestrun-file: $testPath
+        flank:
+          max-test-shards: -1
+        """.trimIndent()
+        val args = IosArgs.load(yaml)
+    }
 }
 
-private fun IosArgs.Companion.load(yamlData: String, cli: IosRunCommand? = null): IosArgs = load(StringReader(yamlData), cli)
+private fun IosArgs.Companion.load(yamlData: String, cli: IosRunCommand? = null): IosArgs =
+    load(StringReader(yamlData), cli)

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -924,7 +924,7 @@ IosArgs
         flank:
           max-test-shards: -1
         """.trimIndent()
-        val args = IosArgs.load(yaml)
+        IosArgs.load(yaml)
     }
 
     @Test(expected = FlankConfigurationError::class)
@@ -935,7 +935,7 @@ IosArgs
         flank:
           max-test-shards: -1
         """.trimIndent()
-        val args = IosArgs.load(yaml)
+        IosArgs.load(yaml)
     }
 
     @Test(expected = FlankConfigurationError::class)
@@ -946,7 +946,7 @@ IosArgs
         flank:
           max-test-shards: -1
         """.trimIndent()
-        val args = IosArgs.load(yaml)
+        IosArgs.load(yaml)
     }
 
     @Test
@@ -958,7 +958,7 @@ IosArgs
         flank:
           max-test-shards: -1
         """.trimIndent()
-        val args = IosArgs.load(yaml)
+        IosArgs.load(yaml)
     }
 }
 


### PR DESCRIPTION
Improve error message on IOS when test or xctestrun-file not found
Fixes #937 

## Test Plan
> How do we know the code works?
Tested for the cases where test and xctestrun-file not specified. Instead of an exception an appropriate message that correlates to what is outputted by android is displayed.

## Checklist

- [x] Unit tested
- [x] release_notes.md updated
