### PR TITLE
feat: add locales description command for ios and android

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,7 @@
 - [#987](https://github.com/Flank/flank/pull/987) Flank Error Monitoring readme addition ([sloox](https://github.com/Sloox))
 - [#990](https://github.com/Flank/flank/pull/990) Fix: exclusion of @Suppress test. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#988](https://github.com/Flank/flank/pull/988) Add versions description command for ios and android. ([adamfilipow92](https://github.com/adamfilipow92))
+- [#969](https://github.com/Flank/flank/pull/969) Add locales description command for ios and android. ([adamfilipow92](https://github.com/adamfilipow92))
 -
 
 ## v20.08.1
@@ -17,6 +18,7 @@
 - [#970](https://github.com/Flank/flank/pull/970) Fixing Flood of snapshot  releases. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#972](https://github.com/Flank/flank/pull/972) Fix printing release version. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#964](https://github.com/Flank/flank/pull/964) Implement network-profiles describe feature. ([pawelpasterz](https://github.com/pawelpasterz))
+-
 
 ## v20.08.0
 - [#890](https://github.com/Flank/flank/pull/890) Convert bitrise ubuntu workflow into GitHub actions. ([piotradamczyk5](https://github.com/piotradamczyk5))

--- a/release_notes.md
+++ b/release_notes.md
@@ -18,7 +18,6 @@
 - [#970](https://github.com/Flank/flank/pull/970) Fixing Flood of snapshot  releases. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#972](https://github.com/Flank/flank/pull/972) Fix printing release version. ([piotradamczyk5](https://github.com/piotradamczyk5))
 - [#964](https://github.com/Flank/flank/pull/964) Implement network-profiles describe feature. ([pawelpasterz](https://github.com/pawelpasterz))
--
 
 ## v20.08.0
 - [#890](https://github.com/Flank/flank/pull/890) Convert bitrise ubuntu workflow into GitHub actions. ([piotradamczyk5](https://github.com/piotradamczyk5))

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -2,10 +2,12 @@ package ftl.android
 
 import com.google.api.services.testing.model.AndroidDevice
 import com.google.api.services.testing.model.AndroidDeviceCatalog
+import com.google.api.services.testing.model.Locale
 import ftl.environment.android.asPrintableTable
 import ftl.environment.android.getDescription
 import ftl.environment.asPrintableTable
 import ftl.environment.common.asPrintableTable
+import ftl.environment.getLocaleDescription
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
@@ -36,7 +38,11 @@ object AndroidCatalog {
 
     fun supportedOrientationsAsTable(projectId: String) = deviceCatalog(projectId).runtimeConfiguration.orientations.asPrintableTable()
 
-    fun localesAsTable(projectId: String) = deviceCatalog(projectId).runtimeConfiguration.locales.asPrintableTable()
+    fun localesAsTable(projectId: String) = getLocales(projectId).asPrintableTable()
+
+    fun getLocaleDescription(projectId: String, locale: String) = getLocales(projectId).getLocaleDescription(locale)
+
+    private fun getLocales(projectId: String): List<Locale> = deviceCatalog(projectId).runtimeConfiguration.locales
 
     fun androidModelIds(projectId: String) =
         modelMap.getOrPut(projectId) { deviceCatalog(projectId).models.map { it.id } }

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -2,7 +2,6 @@ package ftl.android
 
 import com.google.api.services.testing.model.AndroidDevice
 import com.google.api.services.testing.model.AndroidDeviceCatalog
-import com.google.api.services.testing.model.Locale
 import ftl.environment.android.asPrintableTable
 import ftl.environment.android.getDescription
 import ftl.environment.asPrintableTable
@@ -42,7 +41,7 @@ object AndroidCatalog {
 
     fun getLocaleDescription(projectId: String, locale: String) = getLocales(projectId).getLocaleDescription(locale)
 
-    private fun getLocales(projectId: String): List<Locale> = deviceCatalog(projectId).runtimeConfiguration.locales
+    private fun getLocales(projectId: String) = deviceCatalog(projectId).runtimeConfiguration.locales
 
     fun androidModelIds(projectId: String) =
         modelMap.getOrPut(projectId) { deviceCatalog(projectId).models.map { it.id } }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesCommand.kt
@@ -11,7 +11,7 @@ import picocli.CommandLine
     optionListHeading = "%n@|bold,underline Options:|@%n",
     header = ["Information about available locales on device"],
     description = ["Information about available locales on device. For example prints list of available locales to test against"],
-    subcommands = [AndroidLocalesListCommand::class],
+    subcommands = [AndroidLocalesListCommand::class, AndroidLocalesDescribeCommand::class],
     usageHelpAutoWidth = true
 )
 class AndroidLocalesCommand : Runnable {

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommand.kt
@@ -1,0 +1,38 @@
+package ftl.cli.firebase.test.android.configuration
+
+import ftl.android.AndroidCatalog.getLocaleDescription
+import ftl.args.AndroidArgs
+import ftl.config.FtlConstants
+import ftl.util.FlankConfigurationError
+import picocli.CommandLine
+import java.nio.file.Paths
+
+@CommandLine.Command(
+    name = "describe",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["Describe a locales "],
+    usageHelpAutoWidth = true
+)
+class AndroidLocalesDescribeCommand : Runnable {
+    override fun run() {
+        if (locale.isBlank()) throw FlankConfigurationError("Argument LOCALE must be specified.")
+        print(getLocaleDescription(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, locale))
+    }
+
+    @CommandLine.Parameters(
+        index = "0",
+        arity = "1",
+        paramLabel = "LOCALE",
+        defaultValue = "",
+        description = ["The locale to describe, found" +
+                " using \$ gcloud alpha firebase test android locales describe\n."]
+    )
+    var locale: String = ""
+
+    @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = FtlConstants.defaultAndroidConfig
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommand.kt
@@ -29,7 +29,7 @@ class AndroidLocalesDescribeCommand : Runnable {
         paramLabel = "LOCALE",
         defaultValue = "",
         description = ["The locale to describe, found" +
-                " using \$ gcloud alpha firebase test android locales describe\n."]
+                " using \$ gcloud firebase test android locales list\n."]
     )
     var locale: String = ""
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesCommand.kt
@@ -11,7 +11,7 @@ import picocli.CommandLine
     optionListHeading = "%n@|bold,underline Options:|@%n",
     header = ["Information about available locales on device"],
     description = ["Information about available locales on device. For example prints list of available locales to test against"],
-    subcommands = [IosLocalesListCommand::class],
+    subcommands = [IosLocalesListCommand::class, IosLocalesDescribeCommand::class],
     usageHelpAutoWidth = true
 )
 class IosLocalesCommand : Runnable {

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommand.kt
@@ -29,7 +29,7 @@ class IosLocalesDescribeCommand : Runnable {
         paramLabel = "LOCALE",
         defaultValue = "",
         description = ["The locale to describe, found" +
-                " using \$ gcloud alpha firebase test android locales describe\n."]
+                " using \$ gcloud firebase test android locales list\n."]
     )
     var locale: String = ""
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommand.kt
@@ -1,0 +1,38 @@
+package ftl.cli.firebase.test.ios.configuration
+
+import ftl.args.IosArgs
+import ftl.config.FtlConstants
+import ftl.ios.IosCatalog.getLocaleDescription
+import ftl.util.FlankConfigurationError
+import picocli.CommandLine
+import java.nio.file.Paths
+
+@CommandLine.Command(
+    name = "describe",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["Describe a locales "],
+    usageHelpAutoWidth = true
+)
+class IosLocalesDescribeCommand : Runnable {
+    override fun run() {
+        if (locale.isBlank()) throw FlankConfigurationError("Argument LOCALE must be specified.")
+        print(getLocaleDescription(IosArgs.loadOrDefault(Paths.get(configPath)).project, locale))
+    }
+
+    @CommandLine.Parameters(
+        index = "0",
+        arity = "1",
+        paramLabel = "LOCALE",
+        defaultValue = "",
+        description = ["The locale to describe, found" +
+                " using \$ gcloud alpha firebase test android locales describe\n."]
+    )
+    var locale: String = ""
+
+    @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = FtlConstants.defaultAndroidConfig
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommand.kt
@@ -29,10 +29,10 @@ class IosLocalesDescribeCommand : Runnable {
         paramLabel = "LOCALE",
         defaultValue = "",
         description = ["The locale to describe, found" +
-                " using \$ gcloud firebase test android locales list\n."]
+                " using \$ gcloud firebase test ios locales list\n."]
     )
     var locale: String = ""
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
-    var configPath: String = FtlConstants.defaultAndroidConfig
+    var configPath: String = FtlConstants.defaultIosConfig
 }

--- a/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
@@ -9,6 +9,14 @@ private fun List<Locale>.findLocales(locale: String) = find { it.id == locale }
 private fun Locale.prepareDescription() = """
     id: $id
     name: $name
-""".trimIndent()
+""".trimIndent().addTagsIfExists(this)
+
+private fun String.addTagsIfExists(locale: Locale) =
+    if (locale.tags.isNullOrEmpty().not()) StringBuilder(this).appendln("\ntags:").appendTagsToList(locale).toString()
+    else this
+
+private fun StringBuilder.appendTagsToList(locale: Locale) = apply {
+    locale.tags.filterNotNull().forEach { tag -> appendln("- $tag") }
+}
 
 private fun String?.orErrorMessage(locale: String) = this ?: "ERROR: $locale is not a valid locale".trimIndent()

--- a/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
@@ -1,0 +1,14 @@
+package ftl.environment
+
+import com.google.api.services.testing.model.Locale
+
+fun List<Locale>.getLocaleDescription(locale: String) = findLocales(locale)?.prepareDescription().orErrorMessage(locale)
+
+private fun List<Locale>.findLocales(locale: String) = find { it.id == locale }
+
+private fun Locale.prepareDescription() = """
+    id: $id
+    name: $name
+""".trimIndent()
+
+private fun String?.orErrorMessage(locale: String) = this ?: "ERROR: $locale is not a valid locale".trimIndent()

--- a/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
@@ -9,14 +9,18 @@ private fun List<Locale>.findLocales(localeId: String) = find { it.id == localeI
 private fun Locale.prepareDescription() = """
     id: $id
     name: $name
-""".trimIndent().addTagsIfExists(this)
+""".trimIndent().addRegionIfExist(region).addTagsIfExists(this)
+
+private fun String.addRegionIfExist(region: String?) =
+    if (!region.isNullOrEmpty()) StringBuilder(this).appendln("\nregion: $region").toString()
+    else this
 
 private fun String.addTagsIfExists(locale: Locale) =
-    if (locale.tags.isNullOrEmpty().not()) StringBuilder(this).appendln("\ntags:").appendTagsToList(locale)
+    if (!locale.tags.isNullOrEmpty()) StringBuilder(this).appendln("\ntags:").appendTagsToList(locale)
     else this
 
 private fun StringBuilder.appendTagsToList(locale: Locale) = apply {
     locale.tags.filterNotNull().forEach { tag -> appendln("- $tag") }
 }.toString().trim()
 
-private fun String?.orErrorMessage(locale: String) = this ?: "ERROR: '$locale' is not a valid locale".trimIndent()
+private fun String?.orErrorMessage(locale: String) = this ?: "ERROR: '$locale' is not a valid locale"

--- a/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
@@ -1,6 +1,7 @@
 package ftl.environment
 
 import com.google.api.services.testing.model.Locale
+import ftl.util.FlankGeneralError
 
 fun List<Locale>.getLocaleDescription(localeId: String) = findLocales(localeId)?.prepareDescription().orErrorMessage(localeId).plus("\n")
 
@@ -23,4 +24,4 @@ private fun StringBuilder.appendTagsToList(locale: Locale) = apply {
     locale.tags.filterNotNull().forEach { tag -> appendln("- $tag") }
 }.trim().toString()
 
-private fun String?.orErrorMessage(locale: String) = this ?: "ERROR: '$locale' is not a valid locale"
+private fun String?.orErrorMessage(locale: String) = this ?: throw FlankGeneralError("ERROR: '$locale' is not a valid locale")

--- a/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
@@ -2,9 +2,9 @@ package ftl.environment
 
 import com.google.api.services.testing.model.Locale
 
-fun List<Locale>.getLocaleDescription(locale: String) = findLocales(locale)?.prepareDescription().orErrorMessage(locale)
+fun List<Locale>.getLocaleDescription(localeId: String) = findLocales(localeId)?.prepareDescription().orErrorMessage(localeId)
 
-private fun List<Locale>.findLocales(locale: String) = find { it.id == locale }
+private fun List<Locale>.findLocales(localeId: String) = find { it.id == localeId }
 
 private fun Locale.prepareDescription() = """
     id: $id
@@ -12,11 +12,11 @@ private fun Locale.prepareDescription() = """
 """.trimIndent().addTagsIfExists(this)
 
 private fun String.addTagsIfExists(locale: Locale) =
-    if (locale.tags.isNullOrEmpty().not()) StringBuilder(this).appendln("\ntags:").appendTagsToList(locale).toString()
+    if (locale.tags.isNullOrEmpty().not()) StringBuilder(this).appendln("\ntags:").appendTagsToList(locale)
     else this
 
 private fun StringBuilder.appendTagsToList(locale: Locale) = apply {
     locale.tags.filterNotNull().forEach { tag -> appendln("- $tag") }
-}
+}.toString().trim()
 
 private fun String?.orErrorMessage(locale: String) = this ?: "ERROR: $locale is not a valid locale".trimIndent()

--- a/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
@@ -2,7 +2,7 @@ package ftl.environment
 
 import com.google.api.services.testing.model.Locale
 
-fun List<Locale>.getLocaleDescription(localeId: String) = findLocales(localeId)?.prepareDescription().orErrorMessage(localeId)
+fun List<Locale>.getLocaleDescription(localeId: String) = findLocales(localeId)?.prepareDescription().orErrorMessage(localeId).plus("\n")
 
 private fun List<Locale>.findLocales(localeId: String) = find { it.id == localeId }
 
@@ -12,7 +12,7 @@ private fun Locale.prepareDescription() = """
 """.trimIndent().addRegionIfExist(region).addTagsIfExists(this)
 
 private fun String.addRegionIfExist(region: String?) =
-    if (!region.isNullOrEmpty()) StringBuilder(this).appendln("\nregion: $region").toString()
+    if (!region.isNullOrEmpty()) StringBuilder(this).appendln("\nregion: $region").trim().toString()
     else this
 
 private fun String.addTagsIfExists(locale: Locale) =
@@ -21,6 +21,6 @@ private fun String.addTagsIfExists(locale: Locale) =
 
 private fun StringBuilder.appendTagsToList(locale: Locale) = apply {
     locale.tags.filterNotNull().forEach { tag -> appendln("- $tag") }
-}.toString().trim()
+}.trim().toString()
 
 private fun String?.orErrorMessage(locale: String) = this ?: "ERROR: '$locale' is not a valid locale"

--- a/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/LocalesDescription.kt
@@ -19,4 +19,4 @@ private fun StringBuilder.appendTagsToList(locale: Locale) = apply {
     locale.tags.filterNotNull().forEach { tag -> appendln("- $tag") }
 }.toString().trim()
 
-private fun String?.orErrorMessage(locale: String) = this ?: "ERROR: $locale is not a valid locale".trimIndent()
+private fun String?.orErrorMessage(locale: String) = this ?: "ERROR: '$locale' is not a valid locale".trimIndent()

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -1,11 +1,12 @@
 package ftl.ios
 
 import com.google.api.services.testing.model.IosDeviceCatalog
-import ftl.environment.android.asPrintableTable
+import com.google.api.services.testing.model.Locale
 import ftl.environment.asPrintableTable
 import ftl.environment.common.asPrintableTable
 import ftl.environment.ios.asPrintableTable
 import ftl.environment.ios.getDescription
+import ftl.environment.getLocaleDescription
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
@@ -27,6 +28,10 @@ object IosCatalog {
     private fun getVersionsList(projectId: String) = iosDeviceCatalog(projectId).versions
 
     fun localesAsTable(projectId: String) = iosDeviceCatalog(projectId).runtimeConfiguration.locales.asPrintableTable()
+
+    fun getLocaleDescription(projectId: String, locale: String) = getLocales(projectId).getLocaleDescription(locale)
+
+    private fun getLocales(projectId: String): List<Locale> = iosDeviceCatalog(projectId).runtimeConfiguration.locales
 
     fun supportedOrientationsAsTable(projectId: String) = iosDeviceCatalog(projectId).runtimeConfiguration.orientations.asPrintableTable()
 

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -1,7 +1,6 @@
 package ftl.ios
 
 import com.google.api.services.testing.model.IosDeviceCatalog
-import com.google.api.services.testing.model.Locale
 import ftl.environment.asPrintableTable
 import ftl.environment.common.asPrintableTable
 import ftl.environment.ios.asPrintableTable
@@ -31,7 +30,7 @@ object IosCatalog {
 
     fun getLocaleDescription(projectId: String, locale: String) = getLocales(projectId).getLocaleDescription(locale)
 
-    private fun getLocales(projectId: String): List<Locale> = iosDeviceCatalog(projectId).runtimeConfiguration.locales
+    private fun getLocales(projectId: String) = iosDeviceCatalog(projectId).runtimeConfiguration.locales
 
     fun supportedOrientationsAsTable(projectId: String) = iosDeviceCatalog(projectId).runtimeConfiguration.orientations.asPrintableTable()
 

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommandTest.kt
@@ -1,0 +1,38 @@
+package ftl.cli.firebase.test.android.configuration
+
+import ftl.android.AndroidCatalog
+import ftl.util.FlankConfigurationError
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.contrib.java.lang.system.SystemOutRule
+import picocli.CommandLine
+
+class AndroidLocalesDescribeCommandTest {
+    @get:Rule
+    val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @Test
+    fun `should execute AndroidCatalog getLocaleDescription when run AndroidLocalesDescribeCommand`() {
+        mockkObject(AndroidCatalog) {
+            CommandLine(AndroidLocalesDescribeCommand()).execute("pl")
+            verify { AndroidCatalog.getLocaleDescription(any(), any()) }
+        }
+    }
+
+    @Test(expected = FlankConfigurationError::class)
+    fun `should throw if locale not specified`() {
+        systemOutRule.clearLog()
+        CommandLine(AndroidLocalesDescribeCommand()).execute()
+    }
+
+    @Test
+    fun `should return error message if locale not exists`() {
+        systemOutRule.clearLog()
+        CommandLine(AndroidLocalesDescribeCommand()).execute("test")
+        val result = systemOutRule.log.trim()
+        assertEquals("ERROR: test is not a valid locale", result)
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommandTest.kt
@@ -32,6 +32,6 @@ class AndroidLocalesDescribeCommandTest {
         systemOutRule.clearLog()
         CommandLine(AndroidLocalesDescribeCommand()).execute("test")
         val result = systemOutRule.log.trim()
-        assertEquals("ERROR: test is not a valid locale", result)
+        assertEquals("ERROR: 'test' is not a valid locale", result)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommandTest.kt
@@ -1,6 +1,7 @@
 package ftl.cli.firebase.test.android.configuration
 
 import ftl.android.AndroidCatalog
+import ftl.test.util.TestHelper.getThrowable
 import ftl.util.FlankConfigurationError
 import io.mockk.mockkObject
 import io.mockk.verify
@@ -29,9 +30,7 @@ class AndroidLocalesDescribeCommandTest {
 
     @Test
     fun `should return error message if locale not exists`() {
-        systemOutRule.clearLog()
-        CommandLine(AndroidLocalesDescribeCommand()).execute("test")
-        val result = systemOutRule.log.trim()
-        assertEquals("ERROR: 'test' is not a valid locale", result)
+        val exception = getThrowable { CommandLine(AndroidLocalesDescribeCommand()).execute("test") }
+        assertEquals("ERROR: 'test' is not a valid locale", exception.message)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommandTest.kt
@@ -24,7 +24,6 @@ class AndroidLocalesDescribeCommandTest {
 
     @Test(expected = FlankConfigurationError::class)
     fun `should throw if locale not specified`() {
-        systemOutRule.clearLog()
         CommandLine(AndroidLocalesDescribeCommand()).execute()
     }
 

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
@@ -1,0 +1,38 @@
+package ftl.cli.firebase.test.ios.configuration
+
+import ftl.ios.IosCatalog
+import ftl.util.FlankConfigurationError
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.contrib.java.lang.system.SystemOutRule
+import picocli.CommandLine
+
+class IosLocalesDescribeCommandTest {
+    @get:Rule
+    val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @Test
+    fun `should execute IosCatalog findLocale when run IosLocalesDescribeCommand`() {
+        mockkObject(IosCatalog) {
+            CommandLine(IosLocalesDescribeCommand()).execute("pl")
+            verify { IosCatalog.getLocaleDescription(any(), any()) }
+        }
+    }
+
+    @Test(expected = FlankConfigurationError::class)
+    fun `should throw if locale not specified`() {
+        systemOutRule.clearLog()
+        CommandLine(IosLocalesDescribeCommand()).execute()
+    }
+
+    @Test
+    fun `should return error message if locale not exists`() {
+        systemOutRule.clearLog()
+        CommandLine(IosLocalesDescribeCommand()).execute("test")
+        val result = systemOutRule.log.trim()
+        assertEquals("ERROR: test is not a valid locale", result)
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
@@ -35,6 +35,6 @@ class IosLocalesDescribeCommandTest {
         systemOutRule.clearLog()
         CommandLine(IosLocalesDescribeCommand()).execute("test", "--config=$simpleFlankPath")
         val result = systemOutRule.log.trim()
-        assertEquals("ERROR: test is not a valid locale", result)
+        assertEquals("ERROR: 'test' is not a valid locale", result)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
@@ -1,6 +1,7 @@
 package ftl.cli.firebase.test.ios.configuration
 
 import ftl.ios.IosCatalog
+import ftl.test.util.TestHelper
 import ftl.util.FlankConfigurationError
 import io.mockk.mockkObject
 import io.mockk.verify
@@ -14,10 +15,12 @@ class IosLocalesDescribeCommandTest {
     @get:Rule
     val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
 
+    private val simpleFlankPath = TestHelper.getPath("src/test/kotlin/ftl/fixtures/simple-ios-flank.yml")
+
     @Test
     fun `should execute IosCatalog getLocaleDescription when run IosLocalesDescribeCommand`() {
         mockkObject(IosCatalog) {
-            CommandLine(IosLocalesDescribeCommand()).execute("pl")
+            CommandLine(IosLocalesDescribeCommand()).execute("pl", "--config=$simpleFlankPath")
             verify { IosCatalog.getLocaleDescription(any(), any()) }
         }
     }
@@ -25,13 +28,13 @@ class IosLocalesDescribeCommandTest {
     @Test(expected = FlankConfigurationError::class)
     fun `should throw if locale not specified`() {
         systemOutRule.clearLog()
-        CommandLine(IosLocalesDescribeCommand()).execute()
+        CommandLine(IosLocalesDescribeCommand()).execute("--config=$simpleFlankPath")
     }
 
     @Test
     fun `should return error message if locale not exists`() {
         systemOutRule.clearLog()
-        CommandLine(IosLocalesDescribeCommand()).execute("test")
+        CommandLine(IosLocalesDescribeCommand()).execute("test", "--config=$simpleFlankPath")
         val result = systemOutRule.log.trim()
         assertEquals("ERROR: test is not a valid locale", result)
     }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
@@ -2,6 +2,7 @@ package ftl.cli.firebase.test.ios.configuration
 
 import ftl.ios.IosCatalog
 import ftl.test.util.TestHelper
+import ftl.test.util.TestHelper.getThrowable
 import ftl.util.FlankConfigurationError
 import io.mockk.mockkObject
 import io.mockk.verify
@@ -32,9 +33,8 @@ class IosLocalesDescribeCommandTest {
 
     @Test
     fun `should return error message if locale not exists`() {
-        systemOutRule.clearLog()
-        CommandLine(IosLocalesDescribeCommand()).execute("test", "--config=$simpleFlankPath")
-        val result = systemOutRule.log.trim()
+        val exception = getThrowable { CommandLine(IosLocalesDescribeCommand()).execute("test", "--config=$simpleFlankPath") }
+        val result = exception.message
         assertEquals("ERROR: 'test' is not a valid locale", result)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
@@ -15,7 +15,7 @@ class IosLocalesDescribeCommandTest {
     val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
 
     @Test
-    fun `should execute IosCatalog findLocale when run IosLocalesDescribeCommand`() {
+    fun `should execute IosCatalog getLocaleDescription when run IosLocalesDescribeCommand`() {
         mockkObject(IosCatalog) {
             CommandLine(IosLocalesDescribeCommand()).execute("pl")
             verify { IosCatalog.getLocaleDescription(any(), any()) }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommandTest.kt
@@ -27,7 +27,6 @@ class IosLocalesDescribeCommandTest {
 
     @Test(expected = FlankConfigurationError::class)
     fun `should throw if locale not specified`() {
-        systemOutRule.clearLog()
         CommandLine(IosLocalesDescribeCommand()).execute("--config=$simpleFlankPath")
     }
 

--- a/test_runner/src/test/kotlin/ftl/environment/LocalesDescribeTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/LocalesDescribeTest.kt
@@ -14,7 +14,7 @@ class LocalesDescribeTest {
             tags = listOf("one", "second")
         })
 
-        val localesDescription = locales.getLocaleDescription("test")
+        val localesDescription = locales.getLocaleDescription("test").trim()
         val expected = """
                 id: test
                 name: name_test
@@ -32,7 +32,7 @@ class LocalesDescribeTest {
             name = "name_test"
         })
 
-        val localesDescription = locales.getLocaleDescription("test")
+        val localesDescription = locales.getLocaleDescription("test").trim()
         val expected = """
                 id: test
                 name: name_test

--- a/test_runner/src/test/kotlin/ftl/environment/LocalesDescribeTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/LocalesDescribeTest.kt
@@ -1,0 +1,42 @@
+package ftl.environment
+
+import com.google.api.services.testing.model.Locale
+import org.junit.Assert
+import org.junit.Test
+
+class LocalesDescribeTest {
+
+    @Test
+    fun `should return locales with tag if any tag exists`() {
+        val locales = listOf(Locale().apply {
+            id = "test"
+            name = "name_test"
+            tags = listOf("one", "second")
+        })
+
+        val localesDescription = locales.getLocaleDescription("test")
+        val expected = """
+                id: test
+                name: name_test
+                tags:
+                - one
+                - second
+            """.trimIndent()
+        Assert.assertEquals(expected, localesDescription)
+    }
+
+    @Test
+    fun `should return locales without tag header if no tags`() {
+        val locales = listOf(Locale().apply {
+            id = "test"
+            name = "name_test"
+        })
+
+        val localesDescription = locales.getLocaleDescription("test")
+        val expected = """
+                id: test
+                name: name_test
+            """.trimIndent()
+        Assert.assertEquals(expected, localesDescription)
+    }
+}


### PR DESCRIPTION
Fixes #966 

## Test Plan
> How do we know the code works?

When run 

```

     flank firebase test android|ios locales describe LOCALE_ID

```

flank should return output like gcloud cli when execute

```

gcloud alpha firebase test android|ios locales describe LOCALE_ID


```

example for ``` flank firebase test android locales describe en ```

```

id: en
name: English
tags:
- default

```

example for ``` flank firebase test android locales describe pl ```

```

id: pl
name: Polish

```

example for the wrong LOCALE_ID ``` flank firebase test android locales describe test ```

```

ERROR: 'test' is not a valid locale

```

## Checklist

- [X] Unit tested
- [X] release_notes.md updated
