### PR TITLE
Fixing Flood of snapshot  releases 

### DIFF
--- a/flank-scripts/src/main/kotlin/flank/scripts/release/hub/DeleteOldRelease.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/release/hub/DeleteOldRelease.kt
@@ -14,6 +14,6 @@ class DeleteOldReleaseCommand : CliktCommand(name = "deleteOldRelease", help = "
     }
 }
 
-fun deleteOldRelease(tag: String) = "$DELETE_RELEASE_COMMAND \"$tag\"".runCommand()
+fun deleteOldRelease(tag: String) = "$DELETE_RELEASE_COMMAND $tag\".runCommand()
 
 private const val DELETE_RELEASE_COMMAND = "hub release delete"

--- a/flank-scripts/src/main/kotlin/flank/scripts/release/hub/DeleteOldRelease.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/release/hub/DeleteOldRelease.kt
@@ -14,6 +14,6 @@ class DeleteOldReleaseCommand : CliktCommand(name = "deleteOldRelease", help = "
     }
 }
 
-fun deleteOldRelease(tag: String) = "$DELETE_RELEASE_COMMAND $tag\".runCommand()
+fun deleteOldRelease(tag: String) = "$DELETE_RELEASE_COMMAND $tag".runCommand()
 
 private const val DELETE_RELEASE_COMMAND = "hub release delete"

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,7 @@
 - [#935](https://github.com/Flank/flank/pull/935) Process junit xml even when full junit is not enabled. ([kozaxinan](https://github.com/kozaxinan))
 - [#962](https://github.com/Flank/flank/pull/962) Make table text left aligned. ([pawelpasterz](https://github.com/pawelpasterz))
 - [#965](https://github.com/Flank/flank/pull/965) Fast fail when full-junit-result and legacy-junit-result. ([adamfilipow92](https://github.com/adamfilipow92))
+- [#970](https://github.com/Flank/flank/pull/970) Fixing Flood of snapshot  releases. ([piotradamczyk5](https://github.com/piotradamczyk5))
 -
 -
 


### PR DESCRIPTION
Fixes #960

## Test Plan
> How do we know the code works?

Old `flank_snapshot` releasees are removed before publishing new one

## Checklist

- [x] release_notes.md updated
