### PR TITLE
Fix printing release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,12 @@ jobs:
             else 
               echo "::set-env name=RELEASE_TAG::flank_snapshot";
               echo "::set-env name=MVN_VERSION::flank_snapshot"; 
-          fi;     
+          fi;
+
+    - name: Store version variables to file
+      run: |
           echo "$GITHUB_SHA" > ./test_runner/src/main/resources/revision.txt
-          echo "$RELEASE_TAG" > ./test_runner/src/main/resources/version.txt
+          echo "$MVN_VERSION" > ./test_runner/src/main/resources/version.txt
     
     - name: Update bugsnag
       run: flankScripts release updateBugsnag --bugsnag-api-key=${{ secrets.BUGSNAG_API_KEY }} --app-version=${GITHUB_SHA}

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,7 @@
 - [#962](https://github.com/Flank/flank/pull/962) Make table text left aligned. ([pawelpasterz](https://github.com/pawelpasterz))
 - [#965](https://github.com/Flank/flank/pull/965) Fast fail when full-junit-result and legacy-junit-result. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#970](https://github.com/Flank/flank/pull/970) Fixing Flood of snapshot  releases. ([piotradamczyk5](https://github.com/piotradamczyk5))
+- [#972](https://github.com/Flank/flank/pull/972) Fix printing release version. ([piotradamczyk5](https://github.com/piotradamczyk5))
 -
 -
 


### PR DESCRIPTION
Fixes #961

## Test Plan
> How do we know the code works?

Release version should correctly print version after run command `flank --version`

## Checklist

- [x] release_notes.md updated
