### PR TITLE
Firebaseopensource.com addition

### DIFF
--- a/.opensource/project.json
+++ b/.opensource/project.json
@@ -1,0 +1,7 @@
+{
+    "name": "flank",
+    "platforms": ["Android", "iOS"],
+    "content": "README.md",
+    "pages" : ["faq.md", "contributing.md", "release_notes.md"],
+    "related": []
+  }

--- a/.opensource/project.json
+++ b/.opensource/project.json
@@ -5,3 +5,4 @@
     "pages" : ["faq.md", "contributing.md", "release_notes.md"],
     "related": []
   }
+  

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,5 @@
 ## next (unreleased)
+- [#978](https://github.com/Flank/flank/pull/978) Firebaseopensource.com addition ([sloox](https://github.com/Sloox))
 - [#952](https://github.com/Flank/flank/pull/952) Fix version printing on Flank release
 - [#950](https://github.com/Flank/flank/pull/950) Fix crash when --legacy-junit-result set. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#948](https://github.com/Flank/flank/pull/948) Increment retry tries and change sync tag for jfrogSync. ([piotradamczyk5](https://github.com/piotradamczyk5))


### PR DESCRIPTION
Added .opensource for firebaseopensource
There is still a requirement for the description to be updated with an issue attached to the firebaseopensource github.
Fixes #860 

## Test Plan
> How do we know the code works?
It will appear on the firebaseopensource.com website
.

## Checklist

- [x] Documented
- [x] release_notes.md updated
