### PR TITLE
Added leading V to version name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Store version variables to file
       run: |
           echo "$GITHUB_SHA" > ./test_runner/src/main/resources/revision.txt
-          echo "$MVN_VERSION" > ./test_runner/src/main/resources/version.txt
+          echo "$RELEASE_TAG" > ./test_runner/src/main/resources/version.txt
     
     - name: Update bugsnag
       run: flankScripts release updateBugsnag --bugsnag-api-key=${{ secrets.BUGSNAG_API_KEY }} --app-version=${GITHUB_SHA}


### PR DESCRIPTION
Refix for #961 

## Test Plan
> How do we know the code works?

Release version is printed with leading `v`

