### PR TITLE
feat: add versions description command for ios and android

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,7 +1,7 @@
 ## next (unreleased)
 - [#987](https://github.com/Flank/flank/pull/987) Flank Error Monitoring readme addition ([sloox](https://github.com/Sloox))
 - [#990](https://github.com/Flank/flank/pull/990) Fix: exclusion of @Suppress test. ([piotradamczyk5](https://github.com/piotradamczyk5))
-- 
+- [#988](https://github.com/Flank/flank/pull/988) Add versions description command for ios and android. ([adamfilipow92](https://github.com/adamfilipow92))
 -
 
 ## v20.08.1

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -3,6 +3,7 @@ package ftl.android
 import com.google.api.services.testing.model.AndroidDevice
 import com.google.api.services.testing.model.AndroidDeviceCatalog
 import ftl.environment.android.asPrintableTable
+import ftl.environment.android.getDescription
 import ftl.environment.asPrintableTable
 import ftl.environment.common.asPrintableTable
 import ftl.gc.GcTesting
@@ -27,7 +28,11 @@ object AndroidCatalog {
 
     fun devicesCatalogAsTable(projectId: String) = deviceCatalog(projectId).models.asPrintableTable()
 
-    fun supportedVersionsAsTable(projectId: String) = deviceCatalog(projectId).versions.asPrintableTable()
+    fun supportedVersionsAsTable(projectId: String) = getVersionsList(projectId).asPrintableTable()
+
+    fun describeSoftwareVersion(projectId: String, versionId: String) = getVersionsList(projectId).getDescription(versionId)
+
+    private fun getVersionsList(projectId: String) = deviceCatalog(projectId).versions
 
     fun supportedOrientationsAsTable(projectId: String) = deviceCatalog(projectId).runtimeConfiguration.orientations.asPrintableTable()
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsCommand.kt
@@ -11,7 +11,7 @@ import picocli.CommandLine
     optionListHeading = "%n@|bold,underline Options:|@%n",
     header = ["Information about available software versions"],
     description = ["Information about available software versions. For example prints list of available software versions"],
-    subcommands = [AndroidVersionsListCommand::class],
+    subcommands = [AndroidVersionsListCommand::class, AndroidVersionsDescribeCommand::class],
     usageHelpAutoWidth = true
 )
 class AndroidVersionsCommand : Runnable {

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsDescribeCommand.kt
@@ -1,0 +1,39 @@
+package ftl.cli.firebase.test.android.versions
+
+import ftl.android.AndroidCatalog
+import ftl.args.AndroidArgs
+import ftl.config.FtlConstants
+import ftl.util.FlankConfigurationError
+import picocli.CommandLine
+import java.nio.file.Paths
+
+@CommandLine.Command(
+    name = "describe",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["List of OS versions available to test against"],
+    description = ["Print current list of android versions available to test against"],
+    usageHelpAutoWidth = true
+)
+class AndroidVersionsDescribeCommand : Runnable {
+    override fun run() {
+        if (versionId.isBlank()) throw FlankConfigurationError("Argument VERSION_ID must be specified.")
+        println(AndroidCatalog.describeSoftwareVersion(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, versionId))
+    }
+
+    @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = FtlConstants.defaultAndroidConfig
+
+    @CommandLine.Parameters(
+        index = "0",
+        arity = "1",
+        paramLabel = "VERSION_ID",
+        defaultValue = "",
+        description = ["The version to describe, found" +
+            " using \$ gcloud firebase test android versions list."]
+    )
+    var versionId: String = ""
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsCommand.kt
@@ -4,13 +4,13 @@ import picocli.CommandLine
 
 @CommandLine.Command(
     name = "versions",
-    subcommands = [IosVersionsListCommand::class],
+    subcommands = [IosVersionsListCommand::class, IosVersionsDescribeCommand::class],
     headerHeading = "",
     synopsisHeading = "%n",
     descriptionHeading = "%n@|bold,underline Description:|@%n%n",
     parameterListHeading = "%n@|bold,underline Parameters:|@%n",
     optionListHeading = "%n@|bold,underline Options:|@%n",
-    header = ["Information about available software versions"],
+    header = ["Describe software versions"],
     description = ["Information about available software versions. For example prints list of available software versions"],
     usageHelpAutoWidth = true
 )

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsDescribeCommand.kt
@@ -1,0 +1,39 @@
+package ftl.cli.firebase.test.ios.versions
+
+import ftl.args.IosArgs
+import ftl.config.FtlConstants
+import ftl.ios.IosCatalog
+import ftl.util.FlankConfigurationError
+import picocli.CommandLine
+import java.nio.file.Paths
+
+@CommandLine.Command(
+    name = "describe",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["List of OS versions available to test against"],
+    description = ["Print current list of iOS versions available to test against"],
+    usageHelpAutoWidth = true
+)
+class IosVersionsDescribeCommand : Runnable {
+    override fun run() {
+        if (versionId.isBlank()) throw FlankConfigurationError("Argument VERSION_ID must be specified.")
+        println(IosCatalog.describeSoftwareVersion(IosArgs.loadOrDefault(Paths.get(configPath)).project, versionId))
+    }
+
+    @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = FtlConstants.defaultIosConfig
+
+    @CommandLine.Parameters(
+        index = "0",
+        arity = "1",
+        paramLabel = "VERSION_ID",
+        defaultValue = "",
+        description = ["The version to describe, found" +
+            " using \$ gcloud firebase test ios versions list."]
+    )
+    var versionId: String = ""
+}

--- a/test_runner/src/main/kotlin/ftl/environment/android/AndroidSoftwareVersionDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/android/AndroidSoftwareVersionDescription.kt
@@ -2,7 +2,7 @@ package ftl.environment.android
 
 import com.google.api.services.testing.model.AndroidVersion
 
-fun List<AndroidVersion>.getDescription(versionId: String) = findVersion(versionId)?.prepareDescription().createErrorMessage(versionId)
+fun List<AndroidVersion>.getDescription(versionId: String) = findVersion(versionId)?.prepareDescription().orErrorMessage(versionId)
 
 private fun List<AndroidVersion>.findVersion(versionId: String) = firstOrNull { it.id == versionId }
 
@@ -14,7 +14,7 @@ private fun AndroidVersion.prepareDescription() = """
       day: ${releaseDate.day}
       month: ${releaseDate.month}
       year: ${releaseDate.year}
-""".trimIndent().addDataIfExists(tags).addVersion(versionString)
+""".trimIndent().addDataIfExists(tags).addVersion(versionString).trim()
 
 private fun String.addVersion(versionString: String) = StringBuilder(this).appendln("\nversionString: $versionString").toString()
 
@@ -26,6 +26,6 @@ private fun StringBuilder.appendDataToList(data: List<String?>) = apply {
     data.filterNotNull().forEach { item -> appendln("- $item") }
 }.toString().trim()
 
-private fun String?.createErrorMessage(versionId: String) = this ?: "ERROR: '$versionId' is not a valid OS version"
+private fun String?.orErrorMessage(versionId: String) = this ?: "ERROR: '$versionId' is not a valid OS version"
 
 private const val TAGS_HEADER = "tags"

--- a/test_runner/src/main/kotlin/ftl/environment/android/AndroidSoftwareVersionDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/android/AndroidSoftwareVersionDescription.kt
@@ -1,6 +1,7 @@
 package ftl.environment.android
 
 import com.google.api.services.testing.model.AndroidVersion
+import ftl.util.FlankGeneralError
 
 fun List<AndroidVersion>.getDescription(versionId: String) = findVersion(versionId)?.prepareDescription().orErrorMessage(versionId)
 
@@ -26,6 +27,6 @@ private fun StringBuilder.appendDataToList(data: List<String?>) = apply {
     data.filterNotNull().forEach { item -> appendln("- $item") }
 }.toString().trim()
 
-private fun String?.orErrorMessage(versionId: String) = this ?: "ERROR: '$versionId' is not a valid OS version"
+private fun String?.orErrorMessage(versionId: String) = this ?: throw FlankGeneralError("ERROR: '$versionId' is not a valid OS version")
 
 private const val TAGS_HEADER = "tags"

--- a/test_runner/src/main/kotlin/ftl/environment/android/AndroidSoftwareVersionDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/android/AndroidSoftwareVersionDescription.kt
@@ -1,0 +1,31 @@
+package ftl.environment.android
+
+import com.google.api.services.testing.model.AndroidVersion
+
+fun List<AndroidVersion>.getDescription(versionId: String) = findVersion(versionId)?.prepareDescription().createErrorMessage(versionId)
+
+private fun List<AndroidVersion>.findVersion(versionId: String) = firstOrNull { it.id == versionId }
+
+private fun AndroidVersion.prepareDescription() = """
+    apiLevel: $apiLevel
+    codeName: $codeName
+    id: '$id'
+    releaseDate:
+      day: ${releaseDate.day}
+      month: ${releaseDate.month}
+      year: ${releaseDate.year}
+""".trimIndent().addDataIfExists(tags).addVersion(versionString)
+
+private fun String.addVersion(versionString: String) = StringBuilder(this).appendln("\nversionString: $versionString").toString()
+
+private fun String.addDataIfExists(data: List<String?>?) =
+    if (!data.isNullOrEmpty()) StringBuilder(this).appendln("\n$TAGS_HEADER:").appendDataToList(data)
+    else this
+
+private fun StringBuilder.appendDataToList(data: List<String?>) = apply {
+    data.filterNotNull().forEach { item -> appendln("- $item") }
+}.toString().trim()
+
+private fun String?.createErrorMessage(versionId: String) = this ?: "ERROR: '$versionId' is not a valid OS version"
+
+private const val TAGS_HEADER = "tags"

--- a/test_runner/src/main/kotlin/ftl/environment/ios/IosSoftwareVersionDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ios/IosSoftwareVersionDescription.kt
@@ -2,17 +2,15 @@ package ftl.environment.ios
 
 import com.google.api.services.testing.model.IosVersion
 
-fun List<IosVersion>.getDescription(versionId: String) = findVersion(versionId)?.prepareDescription().createErrorMessage(versionId)
+fun List<IosVersion>.getDescription(versionId: String) = findVersion(versionId)?.prepareDescription().orErrorMessage(versionId)
 
 private fun List<IosVersion>.findVersion(versionId: String) = firstOrNull { it.id == versionId }
 
 private fun IosVersion.prepareDescription() = """
     id: '$id'
-    majorVersion: ${majorVersion.onUnknown()}
-    minorVersion: ${minorVersion.onUnknown()}
+    majorVersion: $majorVersion
+    minorVersion: $minorVersion.
 """.trimIndent().addDataIfExists(SUPPORTED_VERSIONS_HEADER, supportedXcodeVersionIds).addDataIfExists(TAGS_HEADER, tags)
-
-private fun Int?.onUnknown() = this?.toString() ?: UNKNOWN
 
 private fun String.addDataIfExists(header: String, data: List<String?>?) =
     if (!data.isNullOrEmpty()) StringBuilder(this).appendln("\n$header:").appendDataToList(data)
@@ -22,8 +20,7 @@ private fun StringBuilder.appendDataToList(data: List<String?>) = apply {
     data.filterNotNull().forEach { item -> appendln("- $item") }
 }.toString().trim()
 
-private fun String?.createErrorMessage(versionId: String) = this ?: "ERROR: '$versionId' is not a valid OS version"
+private fun String?.orErrorMessage(versionId: String) = this ?: "ERROR: '$versionId' is not a valid OS version"
 
 private const val TAGS_HEADER = "tags"
 private const val SUPPORTED_VERSIONS_HEADER = "supportedXcodeVersionIds"
-private const val UNKNOWN = "[Unknown]"

--- a/test_runner/src/main/kotlin/ftl/environment/ios/IosSoftwareVersionDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ios/IosSoftwareVersionDescription.kt
@@ -1,6 +1,7 @@
 package ftl.environment.ios
 
 import com.google.api.services.testing.model.IosVersion
+import ftl.util.FlankGeneralError
 
 fun List<IosVersion>.getDescription(versionId: String) = findVersion(versionId)?.prepareDescription().orErrorMessage(versionId)
 
@@ -20,7 +21,7 @@ private fun StringBuilder.appendDataToList(data: List<String?>) = apply {
     data.filterNotNull().forEach { item -> appendln("- $item") }
 }.toString().trim()
 
-private fun String?.orErrorMessage(versionId: String) = this ?: "ERROR: '$versionId' is not a valid OS version"
+private fun String?.orErrorMessage(versionId: String) = this ?: throw FlankGeneralError("ERROR: '$versionId' is not a valid OS version")
 
 private const val TAGS_HEADER = "tags"
 private const val SUPPORTED_VERSIONS_HEADER = "supportedXcodeVersionIds"

--- a/test_runner/src/main/kotlin/ftl/environment/ios/IosSoftwareVersionDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ios/IosSoftwareVersionDescription.kt
@@ -9,7 +9,7 @@ private fun List<IosVersion>.findVersion(versionId: String) = firstOrNull { it.i
 private fun IosVersion.prepareDescription() = """
     id: '$id'
     majorVersion: $majorVersion
-    minorVersion: $minorVersion.
+    minorVersion: $minorVersion
 """.trimIndent().addDataIfExists(SUPPORTED_VERSIONS_HEADER, supportedXcodeVersionIds).addDataIfExists(TAGS_HEADER, tags)
 
 private fun String.addDataIfExists(header: String, data: List<String?>?) =

--- a/test_runner/src/main/kotlin/ftl/environment/ios/IosSoftwareVersionDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ios/IosSoftwareVersionDescription.kt
@@ -1,0 +1,29 @@
+package ftl.environment.ios
+
+import com.google.api.services.testing.model.IosVersion
+
+fun List<IosVersion>.getDescription(versionId: String) = findVersion(versionId)?.prepareDescription().createErrorMessage(versionId)
+
+private fun List<IosVersion>.findVersion(versionId: String) = firstOrNull { it.id == versionId }
+
+private fun IosVersion.prepareDescription() = """
+    id: '$id'
+    majorVersion: ${majorVersion.onUnknown()}
+    minorVersion: ${minorVersion.onUnknown()}
+""".trimIndent().addDataIfExists(SUPPORTED_VERSIONS_HEADER, supportedXcodeVersionIds).addDataIfExists(TAGS_HEADER, tags)
+
+private fun Int?.onUnknown() = this?.toString() ?: UNKNOWN
+
+private fun String.addDataIfExists(header: String, data: List<String?>?) =
+    if (!data.isNullOrEmpty()) StringBuilder(this).appendln("\n$header:").appendDataToList(data)
+    else this
+
+private fun StringBuilder.appendDataToList(data: List<String?>) = apply {
+    data.filterNotNull().forEach { item -> appendln("- $item") }
+}.toString().trim()
+
+private fun String?.createErrorMessage(versionId: String) = this ?: "ERROR: '$versionId' is not a valid OS version"
+
+private const val TAGS_HEADER = "tags"
+private const val SUPPORTED_VERSIONS_HEADER = "supportedXcodeVersionIds"
+private const val UNKNOWN = "[Unknown]"

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -5,6 +5,7 @@ import ftl.environment.android.asPrintableTable
 import ftl.environment.asPrintableTable
 import ftl.environment.common.asPrintableTable
 import ftl.environment.ios.asPrintableTable
+import ftl.environment.ios.getDescription
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
@@ -19,7 +20,11 @@ object IosCatalog {
 
     fun devicesCatalogAsTable(projectId: String) = iosDeviceCatalog(projectId).models.asPrintableTable()
 
-    fun softwareVersionsAsTable(projectId: String) = iosDeviceCatalog(projectId).versions.asPrintableTable()
+    fun softwareVersionsAsTable(projectId: String) = getVersionsList(projectId).asPrintableTable()
+
+    fun describeSoftwareVersion(projectId: String, versionId: String) = getVersionsList(projectId).getDescription(versionId)
+
+    private fun getVersionsList(projectId: String) = iosDeviceCatalog(projectId).versions
 
     fun localesAsTable(projectId: String) = iosDeviceCatalog(projectId).runtimeConfiguration.locales.asPrintableTable()
 

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -18,15 +18,15 @@ fun main() {
     withGlobalExceptionHandling {
         CommandLine(Main()).execute(
 //            "--debug",
-            "firebase", "test", "ios",
-            "versions", "describe", "11.2"
+            "firebase", "test", "android",
+            "run",
 //            "--dry",
 //            "--dump-shards",
 //            "--output-style=single",
 //            "--full-junit-result",
 //            "--legacy-junit-result",
-//            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
-//            "--project=$projectId"
+            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
+            "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"
         )
     }

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -18,15 +18,15 @@ fun main() {
     withGlobalExceptionHandling {
         CommandLine(Main()).execute(
 //            "--debug",
-            "firebase", "test", "android",
-            "run",
+            "firebase", "test", "ios",
+            "versions", "describe", "11.2"
 //            "--dry",
 //            "--dump-shards",
 //            "--output-style=single",
 //            "--full-junit-result",
 //            "--legacy-junit-result",
-            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
-            "--project=$projectId"
+//            "-c=src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
+//            "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"
         )
     }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsDescribeCommandTest.kt
@@ -1,0 +1,37 @@
+package ftl.cli.firebase.test.android.versions
+
+import ftl.android.AndroidCatalog
+import ftl.util.FlankConfigurationError
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.contrib.java.lang.system.SystemOutRule
+import picocli.CommandLine
+
+class AndroidVersionsDescribeCommandTest {
+    @get:Rule
+    val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @Test
+    fun `should execute AndroidCatalog describeSoftwareVersion when run AndroidVersionsDescribeCommand`() {
+        mockkObject(AndroidCatalog) {
+            CommandLine(AndroidVersionsDescribeCommand()).execute("21")
+            verify { AndroidCatalog.describeSoftwareVersion(any(), any()) }
+        }
+    }
+
+    @Test(expected = FlankConfigurationError::class)
+    fun `should throw if version not specified`() {
+        CommandLine(AndroidVersionsDescribeCommand()).execute()
+    }
+
+    @Test
+    fun `should return error message if version not exists`() {
+        systemOutRule.clearLog()
+        CommandLine(AndroidVersionsDescribeCommand()).execute("test")
+        val result = systemOutRule.log.trim()
+        assertEquals("ERROR: 'test' is not a valid OS version", result)
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsDescribeCommandTest.kt
@@ -1,18 +1,16 @@
 package ftl.cli.firebase.test.android.versions
 
 import ftl.android.AndroidCatalog
+import ftl.cli.firebase.test.ios.versions.IosVersionsDescribeCommand
+import ftl.test.util.TestHelper
 import ftl.util.FlankConfigurationError
 import io.mockk.mockkObject
 import io.mockk.verify
 import org.junit.Assert.assertEquals
-import org.junit.Rule
 import org.junit.Test
-import org.junit.contrib.java.lang.system.SystemOutRule
 import picocli.CommandLine
 
 class AndroidVersionsDescribeCommandTest {
-    @get:Rule
-    val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
 
     @Test
     fun `should execute AndroidCatalog describeSoftwareVersion when run AndroidVersionsDescribeCommand`() {
@@ -29,9 +27,7 @@ class AndroidVersionsDescribeCommandTest {
 
     @Test
     fun `should return error message if version not exists`() {
-        systemOutRule.clearLog()
-        CommandLine(AndroidVersionsDescribeCommand()).execute("test")
-        val result = systemOutRule.log.trim()
-        assertEquals("ERROR: 'test' is not a valid OS version", result)
+        val exception = TestHelper.getThrowable { CommandLine(IosVersionsDescribeCommand()).execute("test") }
+        assertEquals("ERROR: 'test' is not a valid OS version", exception.message)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsDescribeCommandTest.kt
@@ -1,6 +1,7 @@
 package ftl.cli.firebase.test.ios.versions
 
 import ftl.ios.IosCatalog
+import ftl.test.util.TestHelper.getThrowable
 import ftl.util.FlankConfigurationError
 import io.mockk.mockkObject
 import io.mockk.verify
@@ -29,9 +30,7 @@ class IosVersionsDescribeCommandTest {
 
     @Test
     fun `should return error message if version not exists`() {
-        systemOutRule.clearLog()
-        CommandLine(IosVersionsDescribeCommand()).execute("test")
-        val result = systemOutRule.log.trim()
-        assertEquals("ERROR: 'test' is not a valid OS version", result)
+        val exception = getThrowable { CommandLine(IosVersionsDescribeCommand()).execute("test") }
+        assertEquals("ERROR: 'test' is not a valid OS version", exception.message)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsDescribeCommandTest.kt
@@ -1,0 +1,37 @@
+package ftl.cli.firebase.test.ios.versions
+
+import ftl.ios.IosCatalog
+import ftl.util.FlankConfigurationError
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.contrib.java.lang.system.SystemOutRule
+import picocli.CommandLine
+
+class IosVersionsDescribeCommandTest {
+    @get:Rule
+    val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @Test
+    fun `should execute IosCatalog describeSoftwareVersion when run IosVersionsDescribeCommand`() {
+        mockkObject(IosCatalog) {
+            CommandLine(IosVersionsDescribeCommand()).execute("10.3")
+            verify { IosCatalog.describeSoftwareVersion(any(), any()) }
+        }
+    }
+
+    @Test(expected = FlankConfigurationError::class)
+    fun `should throw if version not specified`() {
+        CommandLine(IosVersionsDescribeCommand()).execute()
+    }
+
+    @Test
+    fun `should return error message if version not exists`() {
+        systemOutRule.clearLog()
+        CommandLine(IosVersionsDescribeCommand()).execute("test")
+        val result = systemOutRule.log.trim()
+        assertEquals("ERROR: 'test' is not a valid OS version", result)
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/environment/android/AndroidSoftwareVersionDescriptionTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/android/AndroidSoftwareVersionDescriptionTest.kt
@@ -1,0 +1,75 @@
+package ftl.environment.android
+
+import com.google.api.services.testing.model.AndroidVersion
+import com.google.api.services.testing.model.Date
+import org.junit.Assert
+import org.junit.Test
+
+class AndroidSoftwareVersionDescriptionTest {
+    @Test
+    fun `should return software version with tag if any tag exists`() {
+        val versions = listOf(AndroidVersion().apply {
+            id = "26"
+            apiLevel = 26
+            codeName = "Oreo"
+            versionString = "8.0.x"
+            releaseDate = Date().apply {
+                day = 21
+                month = 8
+                year = 2017
+            }
+            tags = listOf("default")
+        })
+
+        val localesDescription = versions.getDescription("26")
+        val expected = """
+            apiLevel: 26
+            codeName: Oreo
+            id: '26'
+            releaseDate:
+              day: 21
+              month: 8
+              year: 2017
+            tags:
+            - default
+            versionString: 8.0.x
+            """.trimIndent()
+        Assert.assertEquals(expected, localesDescription)
+    }
+    @Test
+    fun `should return software version without tag if no tags`() {
+        val versions = listOf(AndroidVersion().apply {
+            id = "23"
+            apiLevel = 23
+            codeName = "Marshmallow"
+            versionString = "6.0.x"
+            releaseDate = Date().apply {
+                day = 5
+                month = 10
+                year = 2015
+            }
+        })
+
+        val localesDescription = versions.getDescription("23")
+        val expected = """
+            apiLevel: 23
+            codeName: Marshmallow
+            id: '23'
+            releaseDate:
+              day: 5
+              month: 10
+              year: 2015
+            versionString: 6.0.x
+            """.trimIndent()
+        Assert.assertEquals(expected, localesDescription)
+    }
+
+    @Test
+    fun `should return error message if version not found`() {
+        val versions = listOf<AndroidVersion>()
+        val versionName = "test"
+        val localesDescription = versions.getDescription(versionName)
+        val expected = "ERROR: '$versionName' is not a valid OS version"
+        Assert.assertEquals(expected, localesDescription)
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/environment/android/AndroidSoftwareVersionDescriptionTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/android/AndroidSoftwareVersionDescriptionTest.kt
@@ -2,6 +2,7 @@ package ftl.environment.android
 
 import com.google.api.services.testing.model.AndroidVersion
 import com.google.api.services.testing.model.Date
+import ftl.test.util.TestHelper.getThrowable
 import org.junit.Assert
 import org.junit.Test
 
@@ -36,6 +37,7 @@ class AndroidSoftwareVersionDescriptionTest {
             """.trimIndent()
         Assert.assertEquals(expected, localesDescription)
     }
+
     @Test
     fun `should return software version without tag if no tags`() {
         val versions = listOf(AndroidVersion().apply {
@@ -68,8 +70,8 @@ class AndroidSoftwareVersionDescriptionTest {
     fun `should return error message if version not found`() {
         val versions = listOf<AndroidVersion>()
         val versionName = "test"
-        val localesDescription = versions.getDescription(versionName)
+        val localesDescription = getThrowable { versions.getDescription(versionName) }
         val expected = "ERROR: '$versionName' is not a valid OS version"
-        Assert.assertEquals(expected, localesDescription)
+        Assert.assertEquals(expected, localesDescription.message)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/environment/ios/IosSoftwareVersionDescriptionTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/ios/IosSoftwareVersionDescriptionTest.kt
@@ -1,6 +1,7 @@
 package ftl.environment.ios
 
 import com.google.api.services.testing.model.IosVersion
+import ftl.test.util.TestHelper.getThrowable
 import org.junit.Assert
 import org.junit.Test
 
@@ -65,8 +66,8 @@ class IosSoftwareVersionDescriptionTest {
     fun `should return error message if version not found`() {
         val versions = listOf<IosVersion>()
         val versionName = "test"
-        val localesDescription = versions.getDescription(versionName)
+        val localesDescription = getThrowable { versions.getDescription(versionName) }
         val expected = "ERROR: '$versionName' is not a valid OS version"
-        Assert.assertEquals(expected, localesDescription)
+        Assert.assertEquals(expected, localesDescription.message)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/environment/ios/IosSoftwareVersionDescriptionTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/ios/IosSoftwareVersionDescriptionTest.kt
@@ -1,0 +1,72 @@
+package ftl.environment.ios
+
+import com.google.api.services.testing.model.IosVersion
+import org.junit.Assert
+import org.junit.Test
+
+class IosSoftwareVersionDescriptionTest {
+    @Test
+    fun `should return software version with tag if any tag exists`() {
+        val versionId = "11.2"
+        val versions = listOf(IosVersion().apply {
+            id = versionId
+            majorVersion = 10
+            minorVersion = 3
+            tags = listOf("default")
+            supportedXcodeVersionIds = listOf("10.2.1", "10.3", "11.0", "11.1", "11.2.1", "11.3.1")
+        })
+
+        val localesDescription = versions.getDescription(versionId)
+        val expected = """
+            id: '$versionId'
+            majorVersion: 10
+            minorVersion: 3
+            supportedXcodeVersionIds:
+            - 10.2.1
+            - 10.3
+            - 11.0
+            - 11.1
+            - 11.2.1
+            - 11.3.1
+            tags:
+            - default
+            """.trimIndent()
+        Assert.assertEquals(expected, localesDescription)
+    }
+
+    @Test
+    fun `should return software version without tag not exist`() {
+        val versionId = "11.2"
+        val versions = listOf(IosVersion().apply {
+            id = versionId
+            majorVersion = 10
+            minorVersion = 3
+            tags = null
+            supportedXcodeVersionIds = listOf("10.2.1", "10.3", "11.0", "11.1", "11.2.1", "11.3.1")
+        })
+
+        val localesDescription = versions.getDescription(versionId)
+        val expected = """
+            id: '$versionId'
+            majorVersion: 10
+            minorVersion: 3
+            supportedXcodeVersionIds:
+            - 10.2.1
+            - 10.3
+            - 11.0
+            - 11.1
+            - 11.2.1
+            - 11.3.1
+            """.trimIndent()
+        Assert.assertEquals(expected, localesDescription)
+    }
+
+    @Test
+    fun `should return error message if version not found`() {
+        val versions = listOf<IosVersion>()
+        val versionName = "test"
+        val localesDescription = versions.getDescription(versionName)
+        val expected = "ERROR: '$versionName' is not a valid OS version"
+        Assert.assertEquals(expected, localesDescription)
+    }
+}


### PR DESCRIPTION
Fixes #975

## Test Plan
> How do we know the code works?

When run 

```

flank firebase test android|ios versions describe VERSION_ID

```

flank should return output like gcloud cli when execute

```

gcloud alpha firebase test android|ios versions describe VERSION_ID

```

example for ``` flank firebase test android versions describe 28 ```

```

apiLevel: 28
codeName: Pie
id: '28'
releaseDate:
  day: 6
  month: 8
  year: 2018
versionString: 9.x

```

example for ``` flank firebase test ios versions describe 11.2 ```

```

id: '11.2'
majorVersion: 11
minorVersion: 2
supportedXcodeVersionIds:
- 10.2.1
- 10.3
- 11.0
- 11.1
- 11.2.1
- 11.3.1
tags:
- default

```

example for the wrong VERSION_ID ``` flank firebase test android versions describe test ```

```

ERROR: 'test' is not a valid OS version

```

## Additional informations

Some supportedXcodeVersionIds is returned in single quotes on describe command like:

```

id: '11.2'
majorVersion: 11
minorVersion: 2
supportedXcodeVersionIds:
- 10.2.1
- '10.3'
- '11.0'
- '11.1'
- 11.2.1
- 11.3.1
tags:
- default


```

Api returns all versions without quotes so I cannot determine what version should in quotes. I asked on test-lab slack to get more info. 

## Checklist

- [X] Unit tested
- [X] release_notes.md updated
