### PR TITLE
fix: exclusion of @Suppress test

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,7 @@
 ## next (unreleased)
 - [#987](https://github.com/Flank/flank/pull/987) Flank Error Monitoring readme addition ([sloox](https://github.com/Sloox))
+- [#990](https://github.com/Flank/flank/pull/990) Fix: exclusion of @Suppress test. ([piotradamczyk5](https://github.com/piotradamczyk5))
+- 
 -
 
 ## v20.08.1

--- a/test_projects/android/app/src/androidTestMultiple/java/com.example.test_app/InstrumentedTest.kt
+++ b/test_projects/android/app/src/androidTestMultiple/java/com.example.test_app/InstrumentedTest.kt
@@ -1,6 +1,7 @@
 package com.example.test_app
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.Suppress
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,9 +23,9 @@ class InstrumentedTest : BaseInstrumentedTest() {
 
     @Test
     @Ignore("For testing purpose: https://github.com/Flank/flank/issues/852")
-    fun ignoredTest1() = testMethod()
+    fun ignoredTestWithIgnore() = testMethod()
 
     @Test
-    @Ignore("For testing purpose: https://github.com/Flank/flank/issues/852")
-    fun ignoredTest2() = testMethod()
+    @Suppress
+    fun ignoredTestWitSuppress() = testMethod()
 }

--- a/test_projects/android/app/src/androidTestSingle/java/com.example.test_app/InstrumentedTest.kt
+++ b/test_projects/android/app/src/androidTestSingle/java/com.example.test_app/InstrumentedTest.kt
@@ -2,6 +2,7 @@ package com.example.test_app
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Ignore
+import androidx.test.filters.Suppress
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -13,9 +14,9 @@ class InstrumentedTest : BaseInstrumentedTest() {
 
     @Test
     @Ignore("For testing purpose: https://github.com/Flank/flank/issues/852")
-    fun ignoredTest() = testMethod()
+    fun ignoredTestWithIgnore() = testMethod()
 
     @Test
-    @Ignore("For testing purpose: https://github.com/Flank/flank/issues/852")
-    fun ignoredTest2() = testMethod()
+    @Suppress
+    fun ignoredTestWithSuppress() = testMethod()
 }

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
@@ -73,7 +73,16 @@ private fun InstrumentationTestContext.getFlankTestMethods(
 
 private fun List<String>.belong(method: TestMethod) = any { className -> method.testName.startsWith(className) }
 
-private fun TestMethod.toFlankTestMethod() = FlankTestMethod("class $testName", ignored = annotations.any { it.name == "org.junit.Ignore" })
+private fun TestMethod.toFlankTestMethod() = FlankTestMethod(
+    testName = "class $testName",
+    ignored = annotations.any { it.name in ignoredAnnotations }
+)
+
+private val ignoredAnnotations = listOf(
+    "org.junit.Ignore",
+    "androidx.test.filters.Suppress",
+    "android.support.test.filters.Suppress"
+)
 
 private fun String.toFlankTestMethod() = FlankTestMethod("class $this", ignored = false)
 

--- a/test_runner/src/test/kotlin/ftl/run/DumpShardsKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/DumpShardsKtTest.kt
@@ -28,8 +28,8 @@ class DumpShardsKtTest {
       ]
     },
     "junit-ignored": [
-      "class com.example.test_app.InstrumentedTest#ignoredTest",
-      "class com.example.test_app.InstrumentedTest#ignoredTest2"
+      "class com.example.test_app.InstrumentedTest#ignoredTestWithIgnore",
+      "class com.example.test_app.InstrumentedTest#ignoredTestWithSuppress"
     ]
   },
   "matrix-1": {
@@ -84,8 +84,8 @@ class DumpShardsKtTest {
       ]
     },
     "junit-ignored": [
-      "class com.example.test_app.InstrumentedTest#ignoredTest",
-      "class com.example.test_app.InstrumentedTest#ignoredTest2"
+      "class com.example.test_app.InstrumentedTest#ignoredTestWithIgnore",
+      "class com.example.test_app.InstrumentedTest#ignoredTestWithSuppress"
     ]
   },
   "matrix-1": {
@@ -107,8 +107,8 @@ class DumpShardsKtTest {
       ]
     },
     "junit-ignored": [
-      "class com.example.test_app.InstrumentedTest#ignoredTest1",
-      "class com.example.test_app.InstrumentedTest#ignoredTest2",
+      "class com.example.test_app.InstrumentedTest#ignoredTestWithIgnore",
+      "class com.example.test_app.InstrumentedTest#ignoredTestWithSuppress",
       "class com.example.test_app.bar.BarInstrumentedTest#ignoredTestBar",
       "class com.example.test_app.foo.FooInstrumentedTest#ignoredTestFoo"
     ]

--- a/test_runner/src/test/kotlin/ftl/run/platform/android/IgnoreTestsAnnotationTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/android/IgnoreTestsAnnotationTest.kt
@@ -11,8 +11,7 @@ class IgnoreTestsAnnotationTest {
     private val singleSuccessYaml = TestHelper.getPath("src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-success.yml")
 
     @Test
-    fun `InstrumentationContext with @Ignore annotation should have items in ignoredTestCases`() {
-
+    fun `InstrumentationContext with @Ignore or @Suppress annotation should have items in ignoredTestCases`() {
         val testContext = runBlocking {
             AndroidArgs.load(singleSuccessYaml).createAndroidTestContexts()
         }.single() as InstrumentationTestContext
@@ -21,12 +20,21 @@ class IgnoreTestsAnnotationTest {
     }
 
     @Test
-    fun `InstrumentationContext with @Ignore annotation should't have ignoredTestCases in shards`() {
+    fun `InstrumentationContext with @Ignore annotation shouldn't have ignoredTestCases in shards`() {
+        val testContext = runBlocking {
+            AndroidArgs.load(singleSuccessYaml).createAndroidTestContexts()
+        }.single() as InstrumentationTestContext
+
+        Assert.assertFalse(testContext.shards.flatten().any { it.contains("#ignoredTestWithIgnore") })
+    }
+
+    @Test
+    fun `InstrumentationContext with @Supress annotation shouldn't have ignoredTestCases in shards`() {
 
         val testContext = runBlocking {
             AndroidArgs.load(singleSuccessYaml).createAndroidTestContexts()
         }.single() as InstrumentationTestContext
 
-        Assert.assertFalse(testContext.shards.flatten().any { it.contains("#ignoredTest") })
+        Assert.assertFalse(testContext.shards.flatten().any { it.contains("#ignoredTestWithSuppress") })
     }
 }


### PR DESCRIPTION
Fixes #984

## Test Plan
> How do we know the code works?

Tests marked with annotation  `androidx.test.filters.Suppress` or  `android.support.test.filters.Suppress` are treated like `org.junit.Ignore`.
If you run tests with this annotation you could see that these tests are ignored.
You could also run with `--dump-shards` option to check if the required test is included in `junit-ignored` section

## Checklist

- [x] Documented
- [x] Unit tested
- [x] release_notes.md updated
