### PR TITLE
feat: Implement command `models describe` for ios/android

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,8 @@
 - [#988](https://github.com/Flank/flank/pull/988) Add versions description command for ios and android. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#969](https://github.com/Flank/flank/pull/969) Add locales description command for ios and android. ([adamfilipow92](https://github.com/adamfilipow92))
 - [#989](https://github.com/Flank/flank/pull/989) CI changes: Check if valid title is used in PR. ([piotradamczyk5](https://github.com/piotradamczyk5))
--
+- [#995](https://github.com/Flank/flank/pull/995) Implement command `models describe` for ios/android. ([adamfilipow92](https://github.com/adamfilipow92))
+- 
 
 ## v20.08.1
 - [#978](https://github.com/Flank/flank/pull/978) Firebaseopensource.com addition ([sloox](https://github.com/Sloox))

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -27,7 +27,11 @@ object AndroidCatalog {
             .androidDeviceCatalog
     }
 
-    fun devicesCatalogAsTable(projectId: String) = deviceCatalog(projectId).models.asPrintableTable()
+    fun devicesCatalogAsTable(projectId: String) = getModels(projectId).asPrintableTable()
+
+    fun describeModel(projectId: String, modelId: String) = getModels(projectId).getDescription(modelId)
+
+    private fun getModels(projectId: String) = deviceCatalog(projectId).models
 
     fun supportedVersionsAsTable(projectId: String) = getVersionsList(projectId).asPrintableTable()
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelDescribeCommand.kt
@@ -1,0 +1,41 @@
+package ftl.cli.firebase.test.android.models
+
+import ftl.android.AndroidCatalog
+import ftl.args.AndroidArgs
+import ftl.config.FtlConstants
+import ftl.util.FlankConfigurationError
+import picocli.CommandLine
+import java.nio.file.Paths
+
+@CommandLine.Command(
+    name = "describe",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["Describe android model "],
+    usageHelpAutoWidth = true
+)
+class AndroidModelDescribeCommand : Runnable {
+    override fun run() {
+        if (modelId.isBlank()) throw FlankConfigurationError("Argument MODEL_ID must be specified.")
+        println(AndroidCatalog.describeModel(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
+    }
+
+    @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = FtlConstants.defaultAndroidConfig
+
+    @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["Prints this help message"])
+    var usageHelpRequested: Boolean = false
+
+    @CommandLine.Parameters(
+        index = "0",
+        arity = "1",
+        paramLabel = "MODEL_ID",
+        defaultValue = "",
+        description = ["The models to describe, found" +
+            " using \$ gcloud firebase test android models list."]
+    )
+    var modelId: String = ""
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelsCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelsCommand.kt
@@ -11,7 +11,7 @@ import picocli.CommandLine
     optionListHeading = "%n@|bold,underline Options:|@%n",
     header = ["Information about available models"],
     description = ["Information about available models. For example prints list of available models to test against"],
-    subcommands = [AndroidModelsListCommand::class],
+    subcommands = [AndroidModelsListCommand::class, AndroidModelDescribeCommand::class],
     usageHelpAutoWidth = true
 )
 class AndroidModelsCommand : Runnable {

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelDescribeCommand.kt
@@ -1,0 +1,41 @@
+package ftl.cli.firebase.test.ios.models
+
+import ftl.args.IosArgs
+import ftl.config.FtlConstants
+import ftl.ios.IosCatalog
+import ftl.util.FlankConfigurationError
+import picocli.CommandLine
+import java.nio.file.Paths
+
+@CommandLine.Command(
+    name = "describe",
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["Describe iOS model "],
+    usageHelpAutoWidth = true
+)
+class IosModelDescribeCommand : Runnable {
+    override fun run() {
+        if (modelId.isBlank()) throw FlankConfigurationError("Argument MODEL_ID must be specified.")
+        println(IosCatalog.describeModel(IosArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
+    }
+
+    @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = FtlConstants.defaultIosConfig
+
+    @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["Prints this help message"])
+    var usageHelpRequested: Boolean = false
+
+    @CommandLine.Parameters(
+        index = "0",
+        arity = "1",
+        paramLabel = "MODEL_ID",
+        defaultValue = "",
+        description = ["The models to describe, found" +
+            " using \$ gcloud firebase test ios models list."]
+    )
+    var modelId: String = ""
+}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelsCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelsCommand.kt
@@ -11,7 +11,7 @@ import picocli.CommandLine
     optionListHeading = "%n@|bold,underline Options:|@%n",
     header = ["Information about available models"],
     description = ["Information about available models. For example prints list of available models to test against"],
-    subcommands = [IosModelsListCommand::class],
+    subcommands = [IosModelsListCommand::class, IosModelDescribeCommand::class],
     usageHelpAutoWidth = true
 )
 class IosModelsCommand : Runnable {

--- a/test_runner/src/main/kotlin/ftl/environment/android/AndroidModelDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/android/AndroidModelDescription.kt
@@ -1,7 +1,6 @@
 package ftl.environment.android
 
 import com.google.api.services.testing.model.AndroidModel
-import com.google.api.services.testing.model.IosModel
 import ftl.util.FlankGeneralError
 
 fun List<AndroidModel>.getDescription(modelId: String) = findModel(modelId)?.prepareDescription().orErrorMessage(modelId)

--- a/test_runner/src/main/kotlin/ftl/environment/android/AndroidModelDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/android/AndroidModelDescription.kt
@@ -1,0 +1,45 @@
+package ftl.environment.android
+
+import com.google.api.services.testing.model.AndroidModel
+import com.google.api.services.testing.model.IosModel
+import ftl.util.FlankGeneralError
+
+fun List<AndroidModel>.getDescription(modelId: String) = findModel(modelId)?.prepareDescription().orErrorMessage(modelId)
+
+private fun List<AndroidModel>.findModel(modelId: String) = firstOrNull { it.id == modelId }
+
+private fun AndroidModel.prepareDescription() = """
+    brand: $brand
+    codename: $codename
+    form: $form
+    formFactor: $formFactor
+    id: $id
+    manufacturer: $manufacturer
+    name: $name
+    screenDensity: $screenDensity
+    screenX: $screenX
+    screenY: $screenY
+""".trimIndent()
+    .appendList(SUPPORTED_ABIS_HEADER, supportedAbis)
+    .appendList(SUPPORTED_VERSIONS_HEADER, supportedVersionIds)
+    .appendList(TAGS_HEADER, tags)
+    .appendThumbnail(thumbnailUrl).trim()
+
+private fun String.appendList(header: String, items: List<String>?) =
+    if (!items.isNullOrEmpty()) StringBuilder(this).appendln().appendln(header).appendItems(items).toString().trim()
+    else this
+
+private fun StringBuilder.appendItems(items: List<String>) = apply {
+    items.forEach { this.appendln("- $it") }
+}
+
+private fun String.appendThumbnail(thumbnailUrl: String?) =
+    if (!thumbnailUrl.isNullOrBlank()) StringBuilder(this).appendln("\n$THUBNAIL_URL_HEADER $thumbnailUrl").toString()
+    else this
+
+private fun String?.orErrorMessage(modelId: String) = this ?: throw FlankGeneralError("ERROR: '$modelId' is not a valid model")
+
+private const val SUPPORTED_ABIS_HEADER = "supportedAbis:"
+private const val SUPPORTED_VERSIONS_HEADER = "supportedVersionIds:"
+private const val TAGS_HEADER = "tags:"
+private const val THUBNAIL_URL_HEADER = "thumbnailUrl:"

--- a/test_runner/src/main/kotlin/ftl/environment/android/AndroidModelDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/android/AndroidModelDescription.kt
@@ -29,7 +29,7 @@ private fun String.appendList(header: String, items: List<String>?) =
     else this
 
 private fun StringBuilder.appendItems(items: List<String>) = apply {
-    items.forEach { this.appendln("- $it") }
+    items.forEach { appendln("- $it") }
 }
 
 private fun String.appendThumbnail(thumbnailUrl: String?) =

--- a/test_runner/src/main/kotlin/ftl/environment/ios/IosModelDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ios/IosModelDescription.kt
@@ -1,0 +1,36 @@
+package ftl.environment.ios
+
+import com.google.api.services.testing.model.IosModel
+import ftl.util.FlankGeneralError
+
+fun List<IosModel>.getDescription(modelId: String) = findModel(modelId)?.prepareDescription().orErrorMessage(modelId)
+
+private fun List<IosModel>.findModel(modelId: String) = firstOrNull { it.id == modelId }
+
+private fun IosModel.prepareDescription() = "".appendList(DEVICE_CAPABILITIES_HEADER, deviceCapabilities)
+    .appendModelBasicData(this).appendList(SUPPORTED_VERSIONS_HEADER, supportedVersionIds).appendList(TAGS_HEADER, tags).trim()
+
+private fun String.appendList(header: String, items: List<String>?) =
+    if (!items.isNullOrEmpty()) StringBuilder(this).appendln(header).appendItems(items).toString()
+    else this
+
+private fun StringBuilder.appendItems(items: List<String>) = apply {
+    items.forEach { appendln("- $it") }
+}
+
+private fun String.appendModelBasicData(model: IosModel) = StringBuilder(this).appendln(
+    """
+    formFactor: ${model.formFactor}
+    id: ${model.id}
+    name: ${model.name}
+    screenDensity: ${model.screenDensity}
+    screenX: ${model.screenX}
+    screenY: ${model.screenY}
+""".trimIndent()
+).toString()
+
+private fun String?.orErrorMessage(modelId: String) = this ?: throw FlankGeneralError("ERROR: '$modelId' is not a valid model")
+
+private const val DEVICE_CAPABILITIES_HEADER = "deviceCapabilities:"
+private const val SUPPORTED_VERSIONS_HEADER = "supportedVersionIds:"
+private const val TAGS_HEADER = "tags:"

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -1,9 +1,6 @@
 package ftl.ios
 
 import com.google.api.services.testing.model.IosDeviceCatalog
-import ftl.android.AndroidCatalog
-import ftl.environment.android.asPrintableTable
-import ftl.environment.android.getDescription
 import ftl.environment.asPrintableTable
 import ftl.environment.common.asPrintableTable
 import ftl.environment.ios.asPrintableTable

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -1,6 +1,9 @@
 package ftl.ios
 
 import com.google.api.services.testing.model.IosDeviceCatalog
+import ftl.android.AndroidCatalog
+import ftl.environment.android.asPrintableTable
+import ftl.environment.android.getDescription
 import ftl.environment.asPrintableTable
 import ftl.environment.common.asPrintableTable
 import ftl.environment.ios.asPrintableTable
@@ -18,7 +21,11 @@ object IosCatalog {
     private val catalogMap: MutableMap<String, IosDeviceCatalog> = mutableMapOf()
     private val xcodeMap: MutableMap<String, List<String>> = mutableMapOf()
 
-    fun devicesCatalogAsTable(projectId: String) = iosDeviceCatalog(projectId).models.asPrintableTable()
+    fun devicesCatalogAsTable(projectId: String) = getModels(projectId).asPrintableTable()
+
+    fun describeModel(projectId: String, modelId: String) = getModels(projectId).getDescription(modelId)
+
+    private fun getModels(projectId: String) = iosDeviceCatalog(projectId).models
 
     fun softwareVersionsAsTable(projectId: String) = getVersionsList(projectId).asPrintableTable()
 

--- a/test_runner/src/test/kotlin/ftl/environment/android/AndroidModelDescriptionTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/android/AndroidModelDescriptionTest.kt
@@ -1,8 +1,6 @@
 package ftl.environment.android
 
 import com.google.api.services.testing.model.AndroidModel
-import com.google.api.services.testing.model.AndroidVersion
-import com.google.api.services.testing.model.Date
 import ftl.test.util.TestHelper.getThrowable
 import ftl.util.FlankGeneralError
 import org.junit.Assert

--- a/test_runner/src/test/kotlin/ftl/environment/android/AndroidModelDescriptionTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/android/AndroidModelDescriptionTest.kt
@@ -1,0 +1,110 @@
+package ftl.environment.android
+
+import com.google.api.services.testing.model.AndroidModel
+import com.google.api.services.testing.model.AndroidVersion
+import com.google.api.services.testing.model.Date
+import ftl.test.util.TestHelper.getThrowable
+import ftl.util.FlankGeneralError
+import org.junit.Assert
+import org.junit.Test
+
+class AndroidModelDescriptionTest {
+    @Test
+    fun `should return model with tag if any tag exists`() {
+        val models = listOf(AndroidModel().apply {
+            id = "walleye"
+            codename = "walleye"
+            brand = "Google"
+            form = "PHYSICAL"
+            formFactor = "PHONE"
+            manufacturer = "Google"
+            name = "Pixel 2"
+            screenDensity = 420
+            screenX = 1080
+            screenY = 1920
+            supportedAbis = listOf("arm64-v8a", "armeabi-v7a", "armeabi")
+            supportedVersionIds = listOf("26", "27", "28")
+            tags = listOf("default")
+            thumbnailUrl = "https://lh3.googleusercontent.com/j4urvb3lXTaFGZI6IzHmAjum2HQVID1OHPhDB7dOzRvXb2WscSX2RFwEEFFSYhajqRO5Yu0e6FYQ"
+        })
+
+        val modelDescription = models.getDescription("walleye")
+        val expected = """
+        brand: Google
+        codename: walleye
+        form: PHYSICAL
+        formFactor: PHONE
+        id: walleye
+        manufacturer: Google
+        name: Pixel 2
+        screenDensity: 420
+        screenX: 1080
+        screenY: 1920
+        supportedAbis:
+        - arm64-v8a
+        - armeabi-v7a
+        - armeabi
+        supportedVersionIds:
+        - 26
+        - 27
+        - 28
+        tags:
+        - default
+        thumbnailUrl: https://lh3.googleusercontent.com/j4urvb3lXTaFGZI6IzHmAjum2HQVID1OHPhDB7dOzRvXb2WscSX2RFwEEFFSYhajqRO5Yu0e6FYQ
+""".trimIndent()
+        Assert.assertEquals(expected, modelDescription)
+    }
+
+    @Test
+    fun `should return model without tag if no tags`() {
+        val models = listOf(AndroidModel().apply {
+            id = "walleye"
+            codename = "walleye"
+            brand = "Google"
+            form = "PHYSICAL"
+            formFactor = "PHONE"
+            manufacturer = "Google"
+            name = "Pixel 2"
+            screenDensity = 420
+            screenX = 1080
+            screenY = 1920
+            supportedAbis = listOf("arm64-v8a", "armeabi-v7a", "armeabi")
+            supportedVersionIds = listOf("26", "27", "28")
+            thumbnailUrl = "https://lh3.googleusercontent.com/j4urvb3lXTaFGZI6IzHmAjum2HQVID1OHPhDB7dOzRvXb2WscSX2RFwEEFFSYhajqRO5Yu0e6FYQ"
+        })
+
+        val modelDescription = models.getDescription("walleye")
+        val expected = """
+        brand: Google
+        codename: walleye
+        form: PHYSICAL
+        formFactor: PHONE
+        id: walleye
+        manufacturer: Google
+        name: Pixel 2
+        screenDensity: 420
+        screenX: 1080
+        screenY: 1920
+        supportedAbis:
+        - arm64-v8a
+        - armeabi-v7a
+        - armeabi
+        supportedVersionIds:
+        - 26
+        - 27
+        - 28
+        thumbnailUrl: https://lh3.googleusercontent.com/j4urvb3lXTaFGZI6IzHmAjum2HQVID1OHPhDB7dOzRvXb2WscSX2RFwEEFFSYhajqRO5Yu0e6FYQ
+""".trimIndent()
+        Assert.assertEquals(expected, modelDescription)
+    }
+
+    @Test(expected = FlankGeneralError::class)
+    fun `should return error message if model not found and throw FlankGeneralError`() {
+        val versions = listOf<AndroidModel>()
+        val versionName = "test"
+        val localesDescription = getThrowable { versions.getDescription(versionName) }
+        val expected = "ERROR: '$versionName' is not a valid model"
+        Assert.assertEquals(expected, localesDescription.message)
+        throw localesDescription
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/environment/ios/IosModelDescriptionTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/ios/IosModelDescriptionTest.kt
@@ -1,0 +1,85 @@
+package ftl.environment.ios
+
+import com.google.api.services.testing.model.IosModel
+import ftl.test.util.TestHelper.getThrowable
+import ftl.util.FlankGeneralError
+import org.junit.Assert
+import org.junit.Test
+
+class IosModelDescriptionTest {
+    @Test
+    fun `should return model with tag if any tag exists`() {
+        val models = listOf(IosModel().apply {
+            deviceCapabilities = listOf("accelerometer", "arm64")
+            formFactor = "PHONE"
+            id = "iphone6s"
+            name = "iPhone 6s"
+            screenDensity = 326
+            screenX = 750
+            screenY = 1334
+            supportedVersionIds = listOf("10.3", "11.2")
+            tags = listOf("deprecated=10.3", "deprecated=11.2")
+        })
+
+        val modelDescription = models.getDescription("iphone6s")
+        val expected = """
+        deviceCapabilities:
+        - accelerometer
+        - arm64
+        formFactor: PHONE
+        id: iphone6s
+        name: iPhone 6s
+        screenDensity: 326
+        screenX: 750
+        screenY: 1334
+        supportedVersionIds:
+        - 10.3
+        - 11.2
+        tags:
+        - deprecated=10.3
+        - deprecated=11.2
+""".trimIndent()
+        Assert.assertEquals(expected, modelDescription)
+    }
+
+    @Test
+    fun `should return model without tag if no tags`() {
+        val models = listOf(IosModel().apply {
+            deviceCapabilities = listOf("accelerometer", "arm64")
+            formFactor = "PHONE"
+            id = "iphone6s"
+            name = "iPhone 6s"
+            screenDensity = 326
+            screenX = 750
+            screenY = 1334
+            supportedVersionIds = listOf("10.3", "11.2")
+        })
+
+        val modelDescription = models.getDescription("iphone6s")
+        val expected = """
+        deviceCapabilities:
+        - accelerometer
+        - arm64
+        formFactor: PHONE
+        id: iphone6s
+        name: iPhone 6s
+        screenDensity: 326
+        screenX: 750
+        screenY: 1334
+        supportedVersionIds:
+        - 10.3
+        - 11.2
+""".trimIndent()
+        Assert.assertEquals(expected, modelDescription)
+    }
+
+    @Test(expected = FlankGeneralError::class)
+    fun `should return error message if model not found and throw FlankGeneralError`() {
+        val versions = listOf<IosModel>()
+        val versionName = "test"
+        val localesDescription = getThrowable { versions.getDescription(versionName) }
+        val expected = "ERROR: '$versionName' is not a valid model"
+        Assert.assertEquals(expected, localesDescription.message)
+        throw localesDescription
+    }
+}


### PR DESCRIPTION
Fixes #976 

## Test Plan
> How do we know the code works?

When run 

```

flank firebase test android|ios models describe MODEL_ID

```

flank should return output like gcloud cli when execute

```

gcloud alpha firebase test android|ios models describe MODEL_ID

```

example for ``` flank firebase test android  models describe walleye ```

```

brand: Google
codename: walleye
form: PHYSICAL
formFactor: PHONE
id: walleye
manufacturer: Google
name: Pixel 2
screenDensity: 420
screenX: 1080
screenY: 1920
supportedAbis:
- arm64-v8a
- armeabi-v7a
- armeabi
supportedVersionIds:
- 26
- 27
- 28
tags:
- default
thumbnailUrl: https://lh3.googleusercontent.com/j4urvb3lXTaFGZI6IzHmAjum2HQVID1OHPhDB7dOzRvXb2WscSX2RFwEEFFSYhajqRO5Yu0e6FYQ

```

example for ``` flank firebase test ios  models describe iphone6s ```

```

deviceCapabilities:
- accelerometer
- arm64
- armv6
- armv7
- auto-focus-camera
- bluetooth-le
- front-facing-camera
- gamekit
- gyroscope
- location-services
- magnetometer
- metal
- microphone
- opengles-1
- opengles-2
- opengles-3
- peer-peer
- still-camera
- video-camera
- wifi
- arkit
- camera-flash
- gps
- healthkit
- sms
- telephony
formFactor: PHONE
id: iphone6s
name: iPhone 6s
screenDensity: 326
screenX: 750
screenY: 1334
supportedVersionIds:
- 10.3
- 11.2
- 11.4
- 12.0
tags:
- deprecated=10.3
- deprecated=11.2

```

example for the wrong VERSION_ID ``` flank firebase test android models describe test ```

```

ERROR: 'test' is not a valid model

```

## Checklist

- [X] Unit tested
- [X] release_notes.md updated
