### PR TITLE
fix: generation of release notes

### DIFF
--- a/.github/workflows/release_notes_generation.yml
+++ b/.github/workflows/release_notes_generation.yml
@@ -10,6 +10,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Get all git tags
+      run: |
+        git fetch --prune --unshallow --tags
+        git tag
+
     - name: Gradle Build flankScripts and add it to PATH
       run: |
         ./flank-scripts/bash/buildFlankScripts.sh


### PR DESCRIPTION

## Test Plan
> How do we know the code works?

Release notes are generated for the next release.
What is missing in the previous PR is that tags are not fetched by default on Github Actions

