### PR TITLE
feat: Add ip-blocks command to test-environment command

### DIFF
--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
@@ -6,6 +6,7 @@ import ftl.android.AndroidCatalog.localesAsTable
 import ftl.android.AndroidCatalog.supportedVersionsAsTable
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
+import ftl.environment.ipBlocksListAsTable
 import ftl.environment.providedSoftwareAsTable
 import ftl.environment.networkConfigurationAsTable
 import picocli.CommandLine
@@ -18,8 +19,10 @@ import java.nio.file.Paths
     descriptionHeading = "%n@|bold,underline Description:|@%n%n",
     parameterListHeading = "%n@|bold,underline Parameters:|@%n",
     optionListHeading = "%n@|bold,underline Options:|@%n",
-    header = ["Print available devices, OS versions, locales, provided software list and network configuration to test against"],
-    description = ["Print available Android devices, Android OS versions list, locales, provided software and network configuration to test against"],
+    header = ["Print available Android devices, Android OS versions list, locales, provided software, network " +
+        "configuration, orientation and IP blocks to test against"],
+    description = ["Print available Android devices, Android OS versions list, locales, provided software, network " +
+        "configuration, orientation and IP blocks to test against"],
     usageHelpAutoWidth = true
 )
 class AndroidTestEnvironmentCommand : Runnable {
@@ -31,6 +34,7 @@ class AndroidTestEnvironmentCommand : Runnable {
         println(providedSoftwareAsTable())
         println(networkConfigurationAsTable())
         println(supportedOrientationsAsTable(projectId))
+        println(ipBlocksListAsTable())
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
@@ -2,6 +2,7 @@ package ftl.cli.firebase.test.ios
 
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
+import ftl.environment.ipBlocksListAsTable
 import ftl.environment.providedSoftwareAsTable
 import ftl.environment.networkConfigurationAsTable
 import ftl.ios.IosCatalog.devicesCatalogAsTable
@@ -18,8 +19,10 @@ import java.nio.file.Paths
     descriptionHeading = "%n@|bold,underline Description:|@%n%n",
     parameterListHeading = "%n@|bold,underline Parameters:|@%n",
     optionListHeading = "%n@|bold,underline Options:|@%n",
-    header = ["Print available devices, OS versions, locales, provided software list and network configuration to test against"],
-    description = ["Print available iOS devices, iOS OS versions list, locales, provided software and network configuration to test against"],
+    header = ["Print available iOS devices, OS versions list, locales, provided software, network configuration, " +
+        "orientation and IP blocks to test against"],
+    description = ["Print available iOS devices, OS versions list, locales, provided software, network configuration, " +
+        "orientation and IP blocks to test against"],
     usageHelpAutoWidth = true
 )
 class IosTestEnvironmentCommand : Runnable {
@@ -31,6 +34,7 @@ class IosTestEnvironmentCommand : Runnable {
         println(providedSoftwareAsTable())
         println(networkConfigurationAsTable())
         println(supportedOrientationsAsTable(projectId))
+        println(ipBlocksListAsTable())
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])


### PR DESCRIPTION
Fixes #1001 

## Test Plan
> How do we know the code works?

Run `flank android test-environment` and `flank ios test-environment` and see a table with IPs printed at the bottom
