### PR TITLE
feat: Make release notes more organized

### DIFF
--- a/flank-scripts/src/main/kotlin/flank/scripts/ci/releasenotes/AppendReleaseNotes.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/ci/releasenotes/AppendReleaseNotes.kt
@@ -1,24 +1,17 @@
 package flank.scripts.ci.releasenotes
 
-import flank.scripts.utils.markdownH2
 import java.io.File
 
-fun File.appendReleaseNotes(messages: List<String>, releaseTag: String) {
+fun File.appendReleaseNotes(releaseNotesWithType: ReleaseNotesWithType, releaseTag: String) {
     appendToReleaseNotes(
-        messages = messages,
+        releaseNotesWithType = releaseNotesWithType,
         releaseTag = releaseTag
     )
 }
 
-private fun File.appendToReleaseNotes(messages: List<String>, releaseTag: String) {
-    val currentFileLines = readLines()
-    val newLines = mutableListOf<String>().apply {
-        add(releaseTag.markdownH2())
-        addAll(messages)
-        add("")
-    }
-
-    writeText((newLines + currentFileLines).joinToString(System.lineSeparator()).withNewLineAtTheEnd())
+private fun File.appendToReleaseNotes(releaseNotesWithType: ReleaseNotesWithType, releaseTag: String) {
+    writeText(releaseNotesWithType.asString(releaseTag).withNewLineAtTheEnd() +
+        readLines().joinToString(System.lineSeparator()).withNewLineAtTheEnd())
 }
 
 private fun String.withNewLineAtTheEnd() = plus(System.lineSeparator())

--- a/flank-scripts/src/main/kotlin/flank/scripts/ci/releasenotes/ConventionalCommitFormatter.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/ci/releasenotes/ConventionalCommitFormatter.kt
@@ -1,14 +1,14 @@
 package flank.scripts.ci.releasenotes
 
-import flank.scripts.utils.markdownBold
-
-fun String.mapPrTitle() = when {
-    startsWith("feat") -> replaceFirst("feat", "New feature".markdownBold())
-    startsWith("fix") -> replaceFirst("fix", "Fix".markdownBold())
-    startsWith("docs") -> replaceFirst("docs", "Documentation".markdownBold())
-    startsWith("refactor") -> replaceFirst("refactor", "Refactor".markdownBold())
-    startsWith("ci") -> replaceFirst("ci", "CI changes".markdownBold())
-    startsWith("test") -> replaceFirst("test", "Tests update".markdownBold())
-    startsWith("perf") -> replaceFirst("perf", "Performance upgrade".markdownBold())
+fun String.mapPrTitleWithType() = when {
+    startsWith("feat") -> "Features" to skipConventionalCommitPrefix().capitalize()
+    startsWith("fix") -> "Bug Fixes" to skipConventionalCommitPrefix().capitalize()
+    startsWith("docs") -> "Documentation" to skipConventionalCommitPrefix().capitalize()
+    startsWith("refactor") -> "Refactor" to skipConventionalCommitPrefix().capitalize()
+    startsWith("ci") -> "CI Changes" to skipConventionalCommitPrefix().capitalize()
+    startsWith("test") -> "Tests update" to skipConventionalCommitPrefix().capitalize()
+    startsWith("perf") -> "Performance upgrade" to skipConventionalCommitPrefix().capitalize()
     else -> null // we do not accept other prefix to have update in release notes
 }
+
+private fun String.skipConventionalCommitPrefix() = substring(indexOf(':') + 2)

--- a/flank-scripts/src/main/kotlin/flank/scripts/ci/releasenotes/ReleaseNotesWithType.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/ci/releasenotes/ReleaseNotesWithType.kt
@@ -1,0 +1,18 @@
+package flank.scripts.ci.releasenotes
+
+import flank.scripts.utils.markdownH2
+import flank.scripts.utils.markdownH3
+import java.lang.StringBuilder
+
+typealias ReleaseNotesWithType = Map<String, List<String>>
+
+fun ReleaseNotesWithType.asString(headerTag: String) =
+    StringBuilder(headerTag.markdownH2())
+        .appendln()
+        .apply {
+            this@asString.forEach { (type, messages) ->
+                appendln(type.markdownH3())
+                messages.forEach { appendln(it) }
+            }
+        }
+        .toString()

--- a/flank-scripts/src/main/kotlin/flank/scripts/release/hub/ReleaseFlank.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/release/hub/ReleaseFlank.kt
@@ -1,5 +1,6 @@
 package flank.scripts.release.hub
 
+import flank.scripts.ci.releasenotes.ReleaseNotesWithType
 import flank.scripts.ci.releasenotes.generateReleaseNotes
 import flank.scripts.utils.markdownH2
 import flank.scripts.utils.runCommand
@@ -38,7 +39,7 @@ private fun hubStableReleaseCommand(path: String, gitTag: String, token: String)
         gitTag
     )
 
-private fun List<String>.asReleaseBody(tag: String) =
+private fun ReleaseNotesWithType.asReleaseBody(tag: String) =
     StringBuilder(tag.markdownH2())
         .appendln()
         .apply { this@asReleaseBody.forEach { appendln(it) } }

--- a/flank-scripts/src/main/kotlin/flank/scripts/utils/MarkdownFormatter.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/utils/MarkdownFormatter.kt
@@ -5,3 +5,5 @@ fun String.markdownBold() = "**$this**"
 fun markdownLink(description: String, url: String) = "[$description]($url)"
 
 fun String.markdownH2() = "## $this"
+
+fun String.markdownH3() = "### $this"

--- a/flank-scripts/src/test/kotlin/flank/scripts/ci/releasenotes/AppendReleaseNotesTest.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/ci/releasenotes/AppendReleaseNotesTest.kt
@@ -2,6 +2,7 @@ package flank.scripts.ci.releasenotes
 
 import com.google.common.truth.Truth.assertThat
 import flank.scripts.utils.markdownH2
+import flank.scripts.utils.markdownH3
 import java.io.File
 import org.junit.Test
 
@@ -13,12 +14,26 @@ class AppendReleaseNotesTest {
         val testFile = File.createTempFile("empty", ".md")
         val tag = "v20.08.0"
         val expectedHeader = tag.markdownH2()
-        val messages = listOf(
-            "- [#11](https://github.com/Flank/flank/pull/11) **New feature**: Tests ([test_of](https://github.com/test_of))",
-            "- [#12](https://github.com/Flank/flank/pull/12) **New feature**: Tests2 ([test_of](https://github.com/test_of))",
-            "- [#13](https://github.com/Flank/flank/pull/13) **New feature**: Tests3 ([test_of](https://github.com/test_of))"
+        val messages = mapOf(
+            "Features" to listOf(
+                "- [#1](https://github.com/Flank/flank/pull/1) Tests1 ([test_of](https://github.com/test_of))",
+                "- [#2](https://github.com/Flank/flank/pull/2) Tests2 ([test_of](https://github.com/test_of))",
+                "- [#3](https://github.com/Flank/flank/pull/3) Tests3 ([test_of](https://github.com/test_of))"
+            ),
+            "Bug fixes" to listOf(
+                "- [#11](https://github.com/Flank/flank/pull/11) Tests11 ([test_of](https://github.com/test_of))",
+                "- [#12](https://github.com/Flank/flank/pull/12) Tests12 ([test_of](https://github.com/test_of))",
+                "- [#13](https://github.com/Flank/flank/pull/13) Tests13 ([test_of](https://github.com/test_of))"
+            ),
+            "Documentation" to listOf(
+                "- [#21](https://github.com/Flank/flank/pull/21) Tests21 ([test_of](https://github.com/test_of))",
+                "- [#22](https://github.com/Flank/flank/pull/22) Tests22 ([test_of](https://github.com/test_of))",
+                "- [#23](https://github.com/Flank/flank/pull/23) Tests33 ([test_of](https://github.com/test_of))"
+            )
         )
-        val expectedLinesCount = testFile.readLines().size + messages.size + 2 // header + newline
+        val expectedLinesCount = testFile.readLines().size +
+            12 + // values to append
+            3 // header + newline + end newline
 
         // when
         testFile.appendReleaseNotes(messages, tag)
@@ -26,8 +41,12 @@ class AppendReleaseNotesTest {
         // verify
         val lines = testFile.readLines()
         assertThat(lines.first()).isEqualTo(expectedHeader)
-        messages.forEachIndexed { index, text ->
-            assertThat(lines[index + 1]).isEqualTo(text)
+        var currentLine = 1
+        messages.keys.forEach { type ->
+            assertThat(lines[currentLine++]).isEqualTo(type.markdownH3())
+            messages[type]?.forEach { line ->
+                assertThat(lines[currentLine++]).isEqualTo(line)
+            }
         }
         assertThat(lines.last()).isEmpty()
         assertThat(lines.size).isEqualTo(expectedLinesCount)

--- a/flank-scripts/src/test/kotlin/flank/scripts/ci/releasenotes/ConventionalCommitFormatterTest.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/ci/releasenotes/ConventionalCommitFormatterTest.kt
@@ -6,37 +6,40 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
-class ConventionalCommitFormatterTest(private val mapFrom: String, private val expected: String?) {
+class ConventionalCommitFormatterTest(
+    private val mapFrom: String,
+    private val expectedType: String?,
+    private val expectedTitle: String?
+) {
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "{0} to {1}")
         fun data() = listOf(
-            arrayOf("feat: Sample", "New feature"),
-            arrayOf("fix: Bug", "Fix"),
-            arrayOf("docs: New", "Documentation"),
-            arrayOf("refactor: Eveerything", "Refactor"),
-            arrayOf("ci(cd): actions", "CI changes"),
-            arrayOf("test(ios): update", "Tests update"),
-            arrayOf("perf!: 10%", "Performance upgrade"),
-            arrayOf("style: dd", null),
-            arrayOf("build: passed", null),
-            arrayOf("chore: release", null),
-            arrayOf("nope: nbd", null)
+            arrayOf("feat: Sample", "Features", "Sample"),
+            arrayOf("fix: Bug", "Bug Fixes", "Bug"),
+            arrayOf("docs: New", "Documentation", "New"),
+            arrayOf("refactor: Eveerything", "Refactor", "Eveerything"),
+            arrayOf("ci(cd): actions", "CI Changes", "Actions"),
+            arrayOf("test(ios): update", "Tests update", "Update"),
+            arrayOf("perf!: 10%", "Performance upgrade", "10%"),
+            arrayOf("style: dd", null, null),
+            arrayOf("build: passed", null, null),
+            arrayOf("chore: release", null, null),
+            arrayOf("nope: nbd", null, null)
         )
     }
 
     @Test
     fun `Should properly map`() {
-        // given
-        val expected = expected?.let { "**$it**" }
-
         // when
-        val actual = mapFrom.mapPrTitle()
+        val actual = mapFrom.mapPrTitleWithType()
 
         // then
-        if (expected != null) {
-            assertThat(actual).startsWith(expected)
+        if (expectedType != null) {
+            val (type, title) = actual!!
+            assertThat(type).isEqualTo(expectedType)
+            assertThat(title).startsWith(expectedTitle)
         } else {
             assertThat(actual).isNull()
         }

--- a/flank-scripts/src/test/kotlin/flank/scripts/ci/releasenotes/ReleaseNotesWithTypeTest.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/ci/releasenotes/ReleaseNotesWithTypeTest.kt
@@ -1,0 +1,52 @@
+package flank.scripts.ci.releasenotes
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReleaseNotesWithTypeTest {
+
+    @Test
+    fun `Should properly format release notes with type`() {
+        // given
+        val testTag = "TAG"
+        val expected = """
+            ## TAG
+            ### Features
+            - [#1](https://github.com/Flank/flank/pull/1) Tests1 ([test_of](https://github.com/test_of))
+            - [#2](https://github.com/Flank/flank/pull/2) Tests2 ([test_of](https://github.com/test_of))
+            - [#3](https://github.com/Flank/flank/pull/3) Tests3 ([test_of](https://github.com/test_of))
+            ### Bug fixes
+            - [#11](https://github.com/Flank/flank/pull/11) Tests11 ([test_of](https://github.com/test_of))
+            - [#12](https://github.com/Flank/flank/pull/12) Tests12 ([test_of](https://github.com/test_of))
+            - [#13](https://github.com/Flank/flank/pull/13) Tests13 ([test_of](https://github.com/test_of))
+            ### Documentation
+            - [#21](https://github.com/Flank/flank/pull/21) Tests21 ([test_of](https://github.com/test_of))
+            - [#22](https://github.com/Flank/flank/pull/22) Tests22 ([test_of](https://github.com/test_of))
+            - [#23](https://github.com/Flank/flank/pull/23) Tests33 ([test_of](https://github.com/test_of))
+
+        """.trimIndent()
+        val releaseNotesWithType = mapOf(
+            "Features" to listOf(
+                "- [#1](https://github.com/Flank/flank/pull/1) Tests1 ([test_of](https://github.com/test_of))",
+                "- [#2](https://github.com/Flank/flank/pull/2) Tests2 ([test_of](https://github.com/test_of))",
+                "- [#3](https://github.com/Flank/flank/pull/3) Tests3 ([test_of](https://github.com/test_of))"
+            ),
+            "Bug fixes" to listOf(
+                "- [#11](https://github.com/Flank/flank/pull/11) Tests11 ([test_of](https://github.com/test_of))",
+                "- [#12](https://github.com/Flank/flank/pull/12) Tests12 ([test_of](https://github.com/test_of))",
+                "- [#13](https://github.com/Flank/flank/pull/13) Tests13 ([test_of](https://github.com/test_of))"
+            ),
+            "Documentation" to listOf(
+                "- [#21](https://github.com/Flank/flank/pull/21) Tests21 ([test_of](https://github.com/test_of))",
+                "- [#22](https://github.com/Flank/flank/pull/22) Tests22 ([test_of](https://github.com/test_of))",
+                "- [#23](https://github.com/Flank/flank/pull/23) Tests33 ([test_of](https://github.com/test_of))"
+            )
+        )
+
+        // when
+        val actual = releaseNotesWithType.asString(testTag)
+
+        // then
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
Fixes #1019

## Test Plan
> How do we know the code works?

Release notes are better organized in categories:
`flankScripts ci generateReleaseNotes --token=<PAT> --release-notes-file=<PATH TO FILE>`

<details>
<summary>example output:</summary>

## v20.08.2
### Bug Fixes
- [#919](https://github.com/Flank/flank/pull/919) Rate limit exceeded ([pawelpasterz](https://github.com/pawelpasterz), [jan-gogo](https://github.com/jan-gogo))
- [#1005](https://github.com/Flank/flank/pull/1005) Generation of release notes ([piotradamczyk5](https://github.com/piotradamczyk5))
- [#1007](https://github.com/Flank/flank/pull/1007) Failing tests ([piotradamczyk5](https://github.com/piotradamczyk5))
- [#990](https://github.com/Flank/flank/pull/990) Exclusion of @Suppress test ([piotradamczyk5](https://github.com/piotradamczyk5))
### CI Changes
- [#1015](https://github.com/Flank/flank/pull/1015) Update mergify configuration ([piotradamczyk5](https://github.com/piotradamczyk5))
- [#1011](https://github.com/Flank/flank/pull/1011) Generate release notes for Github release description ([piotradamczyk5](https://github.com/piotradamczyk5))
- [#989](https://github.com/Flank/flank/pull/989) Check if valid title is used in PR ([piotradamczyk5](https://github.com/piotradamczyk5))
### Features
- [#1013](https://github.com/Flank/flank/pull/1013) Generating docs before release ([piotradamczyk5](https://github.com/piotradamczyk5))
- [#1012](https://github.com/Flank/flank/pull/1012) Add ip-blocks command to test-environment command ([pawelpasterz](https://github.com/pawelpasterz))
- [#999](https://github.com/Flank/flank/pull/999) Implement ip-blocks list command ([pawelpasterz](https://github.com/pawelpasterz))
- [#996](https://github.com/Flank/flank/pull/996) Auto generate release notes for next release ([piotradamczyk5](https://github.com/piotradamczyk5))
- [#995](https://github.com/Flank/flank/pull/995) Implement command `models describe` for ios/android ([adamfilipow92](https://github.com/adamfilipow92))
- [#991](https://github.com/Flank/flank/pull/991) Validate orientation and fail fast ([Sloox](https://github.com/Sloox))
- [#969](https://github.com/Flank/flank/pull/969) Add locales description command for ios and android ([adamfilipow92](https://github.com/adamfilipow92))
- [#992](https://github.com/Flank/flank/pull/992) Update google api ([jan-gogo](https://github.com/jan-gogo))
- [#988](https://github.com/Flank/flank/pull/988) Add versions description command for ios and android ([adamfilipow92](https://github.com/adamfilipow92))
### Documentation
- [#987](https://github.com/Flank/flank/pull/987) Analytics addition to readme ([Sloox](https://github.com/Sloox))

</details>

## Checklist

- [x] Unit tested
