### PR TITLE
fix: otherNativeCrash NPE

### DIFF
--- a/test_runner/src/main/kotlin/ftl/json/OutcomeDetailsFormatter.kt
+++ b/test_runner/src/main/kotlin/ftl/json/OutcomeDetailsFormatter.kt
@@ -4,6 +4,7 @@ import com.google.api.services.toolresults.model.FailureDetail
 import com.google.api.services.toolresults.model.InconclusiveDetail
 import com.google.api.services.toolresults.model.Outcome
 import com.google.api.services.toolresults.model.SkippedDetail
+import com.google.common.annotations.VisibleForTesting
 import ftl.reports.api.data.TestSuiteOverviewData
 import ftl.util.StepOutcome.failure
 import ftl.util.StepOutcome.flaky
@@ -34,13 +35,14 @@ private fun TestSuiteOverviewData.getSuccessOutcomeDetails(
 private val TestSuiteOverviewData.successCount
     get() = total - errors - failures - skipped - flakes
 
-private fun FailureDetail?.getFailureOutcomeDetails(testSuiteOverviewData: TestSuiteOverviewData?) = when {
+@VisibleForTesting
+internal fun FailureDetail?.getFailureOutcomeDetails(testSuiteOverviewData: TestSuiteOverviewData?) = when {
     this == null -> testSuiteOverviewData?.buildFailureOutcomeDetailsSummary() ?: "Unknown failure"
     crashed == true -> "Application crashed"
     timedOut == true -> "Test timed out"
     notInstalled == true -> "App failed to install"
     else -> testSuiteOverviewData?.buildFailureOutcomeDetailsSummary() ?: "Unknown failure"
-} + this?.takeIf { it.otherNativeCrash }?.let { NATIVE_CRASH_MESSAGE }.orEmpty()
+} + this?.takeIf { it.otherNativeCrash ?: false }?.let { NATIVE_CRASH_MESSAGE }.orEmpty()
 
 private fun TestSuiteOverviewData.buildFailureOutcomeDetailsSummary() =
     StringBuilder("$failures test cases failed").apply {

--- a/test_runner/src/test/kotlin/ftl/json/OutcomeDetailsFormatterTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/OutcomeDetailsFormatterTest.kt
@@ -1,5 +1,6 @@
 package ftl.json
 
+import com.google.api.services.toolresults.model.FailureDetail
 import com.google.api.services.toolresults.model.Outcome
 import ftl.reports.api.data.TestSuiteOverviewData
 import ftl.util.StepOutcome
@@ -20,8 +21,8 @@ internal class OutcomeDetailsFormatterTest {
         val testSuiteOverviewData = TestSuiteOverviewData(12, 0, 0, 3, 2, 0.0, 0.0)
         val successCount = with(testSuiteOverviewData) { total - errors - failures - flakes - skipped }
         val expectedMessage = "$successCount test cases passed, " +
-                "${testSuiteOverviewData.skipped} skipped, " +
-                "${testSuiteOverviewData.flakes} flaky"
+            "${testSuiteOverviewData.skipped} skipped, " +
+            "${testSuiteOverviewData.flakes} flaky"
 
         // when
         val result = mockedOutcome.getDetails(testSuiteOverviewData)
@@ -40,9 +41,9 @@ internal class OutcomeDetailsFormatterTest {
         val testSuiteOverviewData = TestSuiteOverviewData(12, 0, 0, 3, 2, 0.0, 0.0)
         val successCount = with(testSuiteOverviewData) { total - errors - failures - flakes - skipped }
         val expectedMessage = "$successCount test cases passed, " +
-                "${testSuiteOverviewData.skipped} skipped, " +
-                "${testSuiteOverviewData.flakes} flaky" +
-                " (Native crash)"
+            "${testSuiteOverviewData.skipped} skipped, " +
+            "${testSuiteOverviewData.flakes} flaky" +
+            " (Native crash)"
 
         // when
         val result = mockedOutcome.getDetails(testSuiteOverviewData)
@@ -65,10 +66,10 @@ internal class OutcomeDetailsFormatterTest {
         }
         val testSuiteOverviewData = TestSuiteOverviewData(12, 3, 3, 3, 2, 0.0, 0.0)
         val expectedMessage = "${testSuiteOverviewData.failures} test cases failed, " +
-                "${testSuiteOverviewData.errors} errors, " +
-                "1 passed, " +
-                "${testSuiteOverviewData.skipped} skipped, " +
-                "${testSuiteOverviewData.flakes} flaky"
+            "${testSuiteOverviewData.errors} errors, " +
+            "1 passed, " +
+            "${testSuiteOverviewData.skipped} skipped, " +
+            "${testSuiteOverviewData.flakes} flaky"
 
         // when
         val result = mockedOutcome.getDetails(testSuiteOverviewData)
@@ -345,5 +346,12 @@ internal class OutcomeDetailsFormatterTest {
 
         // then
         assertEquals(expectedMessage, result)
+    }
+
+    @Test // https://github.com/flank/flank/issues/1026
+    fun `should not throw when otherNativeCrash is null`() {
+        FailureDetail().apply {
+            otherNativeCrash = null
+        }.getFailureOutcomeDetails(null)
     }
 }


### PR DESCRIPTION
Fixes #1026 

## Test Plan
> How do we know the code works?
Flank not throwing an NPE when otherNativeCrash is null. 
The unit test passes.

## Checklist

- [x] Unit tested
