### PR TITLE
ci: Disable publishing snapshot to Github Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
 
     - name: Gradle Upload to GitHub packages
       uses: eskatos/gradle-command-action@v1
+      if: startsWith(github.ref, 'refs/tags/v')
       with:
         gradle-executable: "./test_runner/gradlew"
         arguments: "-p test_runner publish -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Because GitHub packages [does not allow to delete public packages](https://docs.github.com/en/packages/publishing-and-managing-packages/deleting-a-package), we should publish flank to it only on stable releases:

```
About public package deletion
To avoid breaking projects that may depend on your packages, you cannot delete an entire public package or specific versions of a public package.

Under special circumstances, such as for legal reasons or to conform with GDPR standards, you can ask GitHub Support to delete a public package for you, using our contact form.
```

## Test Plan
> How do we know the code works?

Only stable releases are published to GitHub Packages( with unique version number)
