### PR TITLE
style: Improve kotlin code formatting

### DIFF
--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -132,7 +132,7 @@ formatting:
     active: false
     autoCorrect: true
     indentSize: 4
-    continuationIndentSize: 8
+    continuationIndentSize: 4
   MaximumLineLength:
     active: false
     autoCorrect: false

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -106,10 +106,16 @@ formatting:
   active: true
   android: false
   autoCorrect: true
+  AnnotationOnSeparateLine:
+    active: true
+    autoCorrect: true
   ChainWrapping:
     active: true
     autoCorrect: true
   CommentSpacing:
+    active: true
+    autoCorrect: true
+  EnumEntryNameCase: 
     active: true
     autoCorrect: true
   Filename:
@@ -120,13 +126,13 @@ formatting:
   # Conflicts with IntelliJ import ordering. Disabled for now.
   # see https://github.com/pinterest/ktlint/issues/527
   ImportOrdering:
-    active: false
+    active: true
     autoCorrect: true
   Indentation:
-    active: false
+    active: true
     autoCorrect: true
     indentSize: 4
-    continuationIndentSize: 4
+    continuationIndentSize: 8
   MaximumLineLength:
     active: false
   ModifierOrdering:

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -117,7 +117,7 @@ formatting:
     autoCorrect: true
   EnumEntryNameCase: 
     active: true
-    autoCorrect: true
+    autoCorrect: false
   Filename:
     active: false
   FinalNewline:
@@ -126,15 +126,16 @@ formatting:
   # Conflicts with IntelliJ import ordering. Disabled for now.
   # see https://github.com/pinterest/ktlint/issues/527
   ImportOrdering:
-    active: true
-    autoCorrect: true
+    active: false
+    autoCorrect: false
   Indentation:
-    active: true
+    active: false
     autoCorrect: true
     indentSize: 4
     continuationIndentSize: 8
   MaximumLineLength:
     active: false
+    autoCorrect: false
   ModifierOrdering:
     active: true
     autoCorrect: true

--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -123,7 +123,7 @@ detekt {
     failFast = true // fail build on any finding
     input = files("src/main/kotlin", "src/test/kotlin")
     config = files("../config/detekt.yml")
-
+    autoCorrect = true //auto format for detekt via klint
     buildUponDefaultConfig = true // preconfigure defaults
 
     reports {
@@ -131,6 +131,12 @@ detekt {
         xml.enabled = true // checkstyle like format mainly for integrations like Jenkins
         txt.enabled = true // similar to the console output, contains issue signature to manually edit baseline files
     }
+}
+
+// Kotlin dsl
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt> {
+        // Target version of the generated JVM bytecode. It is used for type resolution.
+        this.jvmTarget = "1.8"
 }
 
 // http://www.eclemma.org/jacoco/

--- a/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
@@ -1,3 +1,5 @@
+@file:Suppress("EnumEntryNameCase")
+
 package ftl.args.yml
 
 import com.fasterxml.jackson.databind.JsonNode
@@ -15,8 +17,8 @@ import java.nio.file.Path
 
 object YamlDeprecated {
 
-    @Suppress("EnumEntryName", "EnumNaming")
-    enum class Parent { gcloud, flank }
+    @Suppress("EnumEntryNameCase", "EnumEntryName", "EnumNaming")
+    enum class Parent { gcloud, flank } // ktlint-disable
 
     enum class Level { Warning, Error }
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidDoctorCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidDoctorCommand.kt
@@ -4,9 +4,9 @@ import ftl.args.AndroidArgs
 import ftl.cli.firebase.test.processValidation
 import ftl.config.FtlConstants
 import ftl.doctor.validateYaml
-import java.nio.file.Paths
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
+import java.nio.file.Paths
 
 @Command(
     name = "doctor",

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
@@ -1,14 +1,14 @@
 package ftl.cli.firebase.test.android
 
 import ftl.android.AndroidCatalog.devicesCatalogAsTable
-import ftl.android.AndroidCatalog.supportedOrientationsAsTable
 import ftl.android.AndroidCatalog.localesAsTable
+import ftl.android.AndroidCatalog.supportedOrientationsAsTable
 import ftl.android.AndroidCatalog.supportedVersionsAsTable
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
 import ftl.environment.ipBlocksListAsTable
-import ftl.environment.providedSoftwareAsTable
 import ftl.environment.networkConfigurationAsTable
+import ftl.environment.providedSoftwareAsTable
 import picocli.CommandLine
 import java.nio.file.Paths
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosDoctorCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosDoctorCommand.kt
@@ -4,9 +4,9 @@ import ftl.args.IosArgs
 import ftl.cli.firebase.test.processValidation
 import ftl.config.FtlConstants
 import ftl.doctor.validateYaml
-import java.nio.file.Paths
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
+import java.nio.file.Paths
 
 @Command(
     name = "doctor",

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
@@ -3,8 +3,8 @@ package ftl.cli.firebase.test.ios
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.environment.ipBlocksListAsTable
-import ftl.environment.providedSoftwareAsTable
 import ftl.environment.networkConfigurationAsTable
+import ftl.environment.providedSoftwareAsTable
 import ftl.ios.IosCatalog.devicesCatalogAsTable
 import ftl.ios.IosCatalog.localesAsTable
 import ftl.ios.IosCatalog.softwareVersionsAsTable

--- a/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
+++ b/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
@@ -13,9 +13,9 @@ import com.google.auth.oauth2.ServiceAccountCredentials
 import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
-import ftl.util.BugsnagInitHelper.initBugsnag
 import ftl.gc.UserAuth
 import ftl.http.HttpTimeoutIncrease
+import ftl.util.BugsnagInitHelper.initBugsnag
 import ftl.util.FlankConfigurationError
 import ftl.util.FlankGeneralError
 import ftl.util.readRevision

--- a/test_runner/src/main/kotlin/ftl/config/Load.kt
+++ b/test_runner/src/main/kotlin/ftl/config/Load.kt
@@ -1,4 +1,5 @@
 @file:Suppress("UnusedPrivateClass")
+
 package ftl.config
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties

--- a/test_runner/src/main/kotlin/ftl/config/android/AndroidFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/android/AndroidFlankConfig.kt
@@ -3,9 +3,9 @@ package ftl.config.android
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
-import ftl.config.Config
 import ftl.args.yml.AppTestPair
 import ftl.args.yml.IYmlKeys
+import ftl.config.Config
 import picocli.CommandLine
 
 /** Flank specific parameters for Android */

--- a/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import ftl.args.ArgsHelper
-import ftl.config.Config
 import ftl.args.yml.IYmlKeys
+import ftl.config.Config
 import ftl.config.FtlConstants
 import picocli.CommandLine
 

--- a/test_runner/src/main/kotlin/ftl/config/ios/IosGcloudConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/ios/IosGcloudConfig.kt
@@ -3,8 +3,8 @@ package ftl.config.ios
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
-import ftl.config.Config
 import ftl.args.yml.IYmlKeys
+import ftl.config.Config
 import picocli.CommandLine
 
 /**

--- a/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
@@ -5,7 +5,6 @@ import com.google.api.services.testing.model.Account
 import com.google.api.services.testing.model.AndroidDeviceList
 import com.google.api.services.testing.model.ClientInfo
 import com.google.api.services.testing.model.EnvironmentMatrix
-import ftl.gc.android.setEnvironmentVariables
 import com.google.api.services.testing.model.GoogleAuto
 import com.google.api.services.testing.model.GoogleCloudStorage
 import com.google.api.services.testing.model.ResultStorage
@@ -16,6 +15,7 @@ import com.google.api.services.testing.model.ToolResultsHistory
 import ftl.args.AndroidArgs
 import ftl.gc.android.mapGcsPathsToApks
 import ftl.gc.android.mapToDeviceFiles
+import ftl.gc.android.setEnvironmentVariables
 import ftl.gc.android.setupAndroidTest
 import ftl.run.platform.android.AndroidTestConfig
 import ftl.util.FlankGeneralError

--- a/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
@@ -19,8 +19,8 @@ import ftl.config.FtlConstants.applicationName
 import ftl.config.FtlConstants.httpCredential
 import ftl.config.FtlConstants.httpTransport
 import ftl.http.executeWithRetry
-import ftl.util.FlankGeneralError
 import ftl.util.FTLProjectError
+import ftl.util.FlankGeneralError
 import ftl.util.PermissionDenied
 import ftl.util.ProjectNotFound
 

--- a/test_runner/src/main/kotlin/ftl/gc/UserAuth.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/UserAuth.kt
@@ -11,6 +11,8 @@ import io.ktor.routing.get
 import io.ktor.routing.routing
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.ObjectInputStream
@@ -18,8 +20,6 @@ import java.io.ObjectOutputStream
 import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 
 class UserAuth {
 

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -3,9 +3,9 @@ package ftl.ios
 import com.google.api.services.testing.model.IosDeviceCatalog
 import ftl.environment.asPrintableTable
 import ftl.environment.common.asPrintableTable
+import ftl.environment.getLocaleDescription
 import ftl.environment.ios.asPrintableTable
 import ftl.environment.ios.getDescription
-import ftl.environment.getLocaleDescription
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 

--- a/test_runner/src/main/kotlin/ftl/mock/TestArtifact.kt
+++ b/test_runner/src/main/kotlin/ftl/mock/TestArtifact.kt
@@ -1,6 +1,12 @@
 package ftl.mock
 
 import ftl.util.FlankGeneralError
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.ResponseBody
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 import java.io.File
 import java.net.InetAddress
 import java.net.InetSocketAddress
@@ -8,14 +14,8 @@ import java.net.Socket
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
-import kotlin.math.pow
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.ResponseBody
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
 import java.util.zip.ZipFile
+import kotlin.math.pow
 
 object TestArtifact {
     const val fixturesPath = "./src/test/kotlin/ftl/fixtures/tmp"

--- a/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
@@ -1,9 +1,9 @@
 package ftl.reports.xml
 
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.model.JUnitTestSuite
 import ftl.reports.xml.preprocesor.fixHtmlCodes

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -6,9 +6,9 @@ import ftl.args.IosArgs
 import ftl.json.SavedMatrix
 import ftl.json.update
 import ftl.reports.util.ReportManager
-import ftl.run.model.TestResult
 import ftl.run.common.fetchArtifacts
 import ftl.run.common.pollMatrices
+import ftl.run.model.TestResult
 import ftl.run.platform.runAndroidTests
 import ftl.run.platform.runIosTests
 import ftl.util.FlankGeneralError

--- a/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
@@ -2,7 +2,6 @@ package ftl.run
 
 import com.google.api.services.testing.model.TestMatrix
 import ftl.args.IArgs
-import ftl.args.ShardChunks
 import ftl.config.FtlConstants
 import ftl.gc.GcTestMatrix
 import ftl.json.MatrixMap
@@ -15,7 +14,6 @@ import ftl.run.common.pollMatrices
 import ftl.run.common.updateMatrixFile
 import ftl.args.ShardChunks
 import ftl.json.needsUpdate
-import ftl.json.update
 import ftl.json.updateWithMatrix
 import ftl.util.MatrixState
 import kotlinx.coroutines.Deferred

--- a/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
@@ -2,17 +2,17 @@ package ftl.run
 
 import com.google.api.services.testing.model.TestMatrix
 import ftl.args.IArgs
+import ftl.args.ShardChunks
 import ftl.config.FtlConstants
 import ftl.gc.GcTestMatrix
 import ftl.json.MatrixMap
+import ftl.json.update
 import ftl.reports.util.ReportManager
 import ftl.run.common.fetchArtifacts
 import ftl.run.common.getLastArgs
 import ftl.run.common.getLastMatrices
 import ftl.run.common.pollMatrices
 import ftl.run.common.updateMatrixFile
-import ftl.args.ShardChunks
-import ftl.json.update
 import ftl.util.MatrixState
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers

--- a/test_runner/src/main/kotlin/ftl/run/common/FetchArtifacts.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/FetchArtifacts.kt
@@ -3,17 +3,17 @@ package ftl.run.common
 import com.google.cloud.storage.Storage
 import ftl.args.IArgs
 import ftl.config.FtlConstants
-import ftl.json.MatrixMap
 import ftl.gc.GcStorage
+import ftl.json.MatrixMap
 import ftl.util.Artifacts
 import ftl.util.MatrixState
-import java.nio.file.Path
-import java.nio.file.Paths
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import java.nio.file.Path
+import java.nio.file.Paths
 
 // TODO needs refactor
 internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = coroutineScope {

--- a/test_runner/src/main/kotlin/ftl/run/model/TestResult.kt
+++ b/test_runner/src/main/kotlin/ftl/run/model/TestResult.kt
@@ -1,8 +1,8 @@
 package ftl.run.model
 
 import ftl.args.IgnoredTestCases
-import ftl.json.MatrixMap
 import ftl.args.ShardChunks
+import ftl.json.MatrixMap
 
 data class TestResult(
     val matrixMap: MatrixMap,

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
@@ -1,7 +1,7 @@
 package ftl.run.platform.android
 
-import ftl.args.ShardChunks
 import ftl.args.FlankRoboDirective
+import ftl.args.ShardChunks
 
 sealed class AndroidTestConfig {
 

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -20,8 +20,8 @@ import ftl.test.util.TestHelper.absolutePath
 import ftl.test.util.TestHelper.assert
 import ftl.test.util.TestHelper.getPath
 import ftl.test.util.assertThrowsWithMessage
-import ftl.util.FlankGeneralError
 import ftl.util.FlankConfigurationError
+import ftl.util.FlankGeneralError
 import ftl.util.IncompatibleTestDimensionError
 import ftl.util.asFileReference
 import io.mockk.every
@@ -29,10 +29,10 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.fail
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import picocli.CommandLine

--- a/test_runner/src/test/kotlin/ftl/args/ArgsHelperFilePathTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ArgsHelperFilePathTest.kt
@@ -6,11 +6,11 @@ import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.absolutePath
 import ftl.util.FlankGeneralError
 import org.junit.Assume.assumeFalse
-import java.io.File
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.runner.RunWith
+import java.io.File
 
 @RunWith(FlankTestRunner::class)
 class ArgsHelperFilePathTest {

--- a/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
@@ -16,19 +16,19 @@ import ftl.shard.stringShards
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.absolutePath
 import ftl.test.util.assertThrowsWithMessage
-import ftl.util.FlankGeneralError
 import ftl.util.FlankConfigurationError
+import ftl.util.FlankGeneralError
 import io.mockk.every
 import io.mockk.spyk
 import io.mockk.unmockkAll
 import org.junit.After
 import org.junit.Assume
-import java.io.File
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.SystemErrRule
 import org.junit.runner.RunWith
+import java.io.File
 
 @RunWith(FlankTestRunner::class)
 class ArgsHelperTest {

--- a/test_runner/src/test/kotlin/ftl/args/yml/FileLoaderTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/yml/FileLoaderTest.kt
@@ -1,8 +1,8 @@
 package ftl.args.yml
 
-import ftl.util.loadFile
 import ftl.test.util.TestHelper.getThrowable
 import ftl.util.FlankGeneralError
+import ftl.util.loadFile
 import org.junit.Assert
 import org.junit.Test
 import java.nio.file.Paths

--- a/test_runner/src/test/kotlin/ftl/cli/AuthCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/AuthCommandTest.kt
@@ -2,11 +2,11 @@ package ftl.cli
 
 import com.google.common.truth.Truth.assertThat
 import ftl.test.util.FlankTestRunner
+import ftl.test.util.TestHelper.normalizeLineEnding
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
-import ftl.test.util.TestHelper.normalizeLineEnding
 
 @RunWith(FlankTestRunner::class)
 class AuthCommandTest {

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/RefreshCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/RefreshCommandTest.kt
@@ -2,15 +2,15 @@ package ftl.cli.firebase
 
 import com.google.common.truth.Truth.assertThat
 import ftl.test.util.FlankTestRunner
-import java.io.File
-import java.nio.file.Files
-import java.nio.file.Paths
+import ftl.test.util.TestHelper.normalizeLineEnding
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
 import picocli.CommandLine
-import ftl.test.util.TestHelper.normalizeLineEnding
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
 
 @RunWith(FlankTestRunner::class)
 class RefreshCommandTest {

--- a/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
@@ -3,8 +3,8 @@ package ftl.gc
 import com.google.api.services.testing.model.AndroidDeviceList
 import com.google.api.services.testing.model.TestSetup
 import ftl.args.AndroidArgs
-import ftl.gc.android.setEnvironmentVariables
 import ftl.gc.GcToolResults.createToolResultsHistory
+import ftl.gc.android.setEnvironmentVariables
 import ftl.run.platform.android.AndroidTestConfig
 import ftl.test.util.FlankTestRunner
 import io.mockk.every

--- a/test_runner/src/test/kotlin/ftl/ios/XctestrunTest.kt
+++ b/test_runner/src/test/kotlin/ftl/ios/XctestrunTest.kt
@@ -5,13 +5,13 @@ import com.google.common.truth.Truth.assertThat
 import ftl.config.FtlConstants.isWindows
 import ftl.mock.TestArtifact.fixturesPath
 import ftl.test.util.FlankTestRunner
-import org.junit.Assume.assumeFalse
-import java.nio.file.Files
-import java.nio.file.Paths
-import org.junit.Test
-import org.junit.runner.RunWith
 import ftl.test.util.TestHelper.normalizeLineEnding
 import ftl.util.FlankGeneralError
+import org.junit.Assume.assumeFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.nio.file.Files
+import java.nio.file.Paths
 
 @RunWith(FlankTestRunner::class)
 class XctestrunTest {

--- a/test_runner/src/test/kotlin/ftl/reports/api/PrepareForJUnitResultKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/api/PrepareForJUnitResultKtTest.kt
@@ -7,10 +7,10 @@ import com.google.api.services.toolresults.model.Step
 import com.google.api.services.toolresults.model.TestCase
 import com.google.api.services.toolresults.model.Timestamp
 import ftl.reports.api.data.TestExecutionData
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Assert.assertArrayEquals
 import org.junit.Test
 
 class PrepareForJUnitResultKtTest {

--- a/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
@@ -4,8 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import ftl.test.util.TestHelper.normalizeLineEnding
 import ftl.util.FlankGeneralError
 import org.junit.Assert
-import java.nio.file.Paths
 import org.junit.Test
+import java.nio.file.Paths
 
 class JUnitXmlTest {
 

--- a/test_runner/src/test/kotlin/ftl/run/GenericTestRunnerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/GenericTestRunnerTest.kt
@@ -4,14 +4,14 @@ import ftl.args.IArgs
 import ftl.run.platform.common.beforeRunMessage
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.assert
-import org.junit.Test
-import org.junit.runner.RunWith
 import ftl.test.util.TestHelper.normalizeLineEnding
 import ftl.util.trimStartLine
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
 
 @RunWith(FlankTestRunner::class)
 class GenericTestRunnerTest {

--- a/test_runner/src/test/kotlin/ftl/run/TestRunnerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/TestRunnerTest.kt
@@ -17,7 +17,6 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
-import java.nio.file.Paths
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertFalse
@@ -27,6 +26,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
+import java.nio.file.Paths
 
 private const val OBJECT_NAME = "2019-03-22_15-30-02.189000_frjt"
 private const val FILE_NAME = "StandardOutputAndStandardError.txt"

--- a/test_runner/src/test/kotlin/ftl/test/util/LocalGcs.kt
+++ b/test_runner/src/test/kotlin/ftl/test/util/LocalGcs.kt
@@ -3,10 +3,10 @@ package ftl.test.util
 import com.google.cloud.storage.BlobInfo
 import ftl.gc.GcStorage
 import ftl.util.FlankGeneralError
+import org.junit.Assert
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import org.junit.Assert
 
 object LocalGcs {
 

--- a/test_runner/src/test/kotlin/ftl/util/BillingTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/BillingTest.kt
@@ -2,8 +2,8 @@ package ftl.util
 
 import com.google.common.truth.Truth.assertThat
 import ftl.test.util.defaultTestTimeout
-import kotlin.math.min
 import org.junit.Test
+import kotlin.math.min
 
 private val timeoutSeconds = timeoutToSeconds(defaultTestTimeout)
 


### PR DESCRIPTION
Fixes #851 
Improve kotlin code formatting by enforcing all the rules by detekt & its wrapper over Klint
