### PR TITLE
fix: master not compiling

### DIFF
--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -106,12 +106,18 @@ formatting:
   active: true
   android: false
   autoCorrect: true
+  AnnotationOnSeparateLine:
+    active: false
+    autoCorrect: true
   ChainWrapping:
     active: true
     autoCorrect: true
   CommentSpacing:
     active: true
     autoCorrect: true
+  EnumEntryNameCase: 
+    active: true
+    autoCorrect: false
   Filename:
     active: false
   FinalNewline:
@@ -121,10 +127,10 @@ formatting:
   # see https://github.com/pinterest/ktlint/issues/527
   ImportOrdering:
     active: false
-    autoCorrect: true
+    autoCorrect: false
   Indentation:
     active: false
-    autoCorrect: true
+    autoCorrect: false
     indentSize: 4
     continuationIndentSize: 4
   MaximumLineLength:

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -106,18 +106,12 @@ formatting:
   active: true
   android: false
   autoCorrect: true
-  AnnotationOnSeparateLine:
-    active: true
-    autoCorrect: true
   ChainWrapping:
     active: true
     autoCorrect: true
   CommentSpacing:
     active: true
     autoCorrect: true
-  EnumEntryNameCase: 
-    active: true
-    autoCorrect: false
   Filename:
     active: false
   FinalNewline:
@@ -127,7 +121,7 @@ formatting:
   # see https://github.com/pinterest/ktlint/issues/527
   ImportOrdering:
     active: false
-    autoCorrect: false
+    autoCorrect: true
   Indentation:
     active: false
     autoCorrect: true
@@ -135,7 +129,6 @@ formatting:
     continuationIndentSize: 4
   MaximumLineLength:
     active: false
-    autoCorrect: false
   ModifierOrdering:
     active: true
     autoCorrect: true


### PR DESCRIPTION
Fixes master not compiling due to flank-scripts formatting error

Unfortunately Flanks-scripts was not checked with the new detekt modifications and is causing master to fail to compile
