### PR TITLE
fix: Flank finding and running duplicate tests

### DIFF
--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
@@ -64,11 +64,11 @@ private fun InstrumentationTestContext.getFlankTestMethods(
 ): List<FlankTestMethod> =
     getParametrizedClasses().let { parameterizedClasses: List<String> ->
         DexParser.findTestMethods(test.local).asSequence()
-            .distinct()
-            .filter(testFilter.shouldRun)
-            .filterNot(parameterizedClasses::belong)
-            .map(TestMethod::toFlankTestMethod).toList()
-            .plus(parameterizedClasses.map(String::toFlankTestMethod))
+                .distinctBy { it.testName }
+                .filter(testFilter.shouldRun)
+                .filterNot(parameterizedClasses::belong)
+                .map(TestMethod::toFlankTestMethod).toList()
+                .plus(parameterizedClasses.map(String::toFlankTestMethod))
     }
 
 private fun List<String>.belong(method: TestMethod) = any { className -> method.testName.startsWith(className) }


### PR DESCRIPTION
## The Problem

Flank is detecting more tests than there are in my test suit (there should be about 2,000 give or take, but it’s running 12,000). When I look at the junit test report in each matrix, I see that some tests are being ran once as expected, but some are being ran 5 times and some even 40+ times. Each test only appears once in my source code, num-test-runs is set to 1, and num-flaky-test-attempts is set to 0.

Flank version: v20.08.3
Example of android_shards.json with duplicated tests: https://gist.github.com/MatthewTPage/99dcf8a1876716f815b802c0bc2a5d41
(note that I obfuscated the class and method names, but the important information of "the tests are duplicated" is there).
Flank configuration that produced the above (with some bucket and apk names obfuscated): https://gist.github.com/MatthewTPage/ecd0c40fb4e089b6b6db028c716cb7f0

## The Solution

It seems that the distinct function call I changed in this PR wasn't working as intended - possibly it was distincting objects simply by the object reference rather than information about the actual test? So I made it distinct by the test name. Seems to work all fine and dandy.

## Verification

I ran this on my test suit and it came back with what seems like the right number of tests, and I don't see any duplicated.

## Unit Test Coverage

Seems a little excessive to figure out how to mock the dex parser, unless if someone would be strongly opinionated about me doing so and would have a suggestion.