### PR TITLE
ci: Post slack message about releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
 
     - name: Post Message of Flank Release TEST ONLY
       uses: archive/github-actions-slack@master
+      if: startsWith(github.ref, 'refs/tags/v')
       with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: flank_test_channel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,3 +107,16 @@ jobs:
       with:
         gradle-executable: "./test_runner/gradlew"
         arguments: "-p test_runner publish -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
+
+    - name: Get Latest Release notes and set as variables
+      run: |
+        testVar=$(awk '!NF{exit}1' release_notes.md)
+        echo "::set-env name=RELEASE_NOTES::$(echo $testVar)";
+
+    - name: Post Message of Flank Release TEST ONLY
+      uses: archive/github-actions-slack@master
+      with:
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: flank_test_channel
+          slack-optional-icon_emoji: ":fire:"  
+          slack-text: <http://https://github.com/Flank/flank/releases/tag/${{ $RELEASE_TAG }}|Flank "${{ $RELEASE_TAG }}" > is released \n ${{ $(echo $RELEASE_NOTES) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,8 +110,8 @@ jobs:
 
     - name: Get Latest Release notes and set as variables
       run: |
-        testVar=$(awk '!NF{exit}1' release_notes.md)
-        echo "::set-env name=RELEASE_NOTES::$(echo $testVar)";
+        notes=$(awk '!NF{exit}1' release_notes.md)
+        echo "::set-env name=RELEASE_NOTES::$(echo $notes)";
 
     - name: Post Message of Flank Release TEST ONLY
       uses: archive/github-actions-slack@master
@@ -119,4 +119,4 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: flank_test_channel
           slack-optional-icon_emoji: ":fire:"  
-          slack-text: <http://https://github.com/Flank/flank/releases/tag/${{ $RELEASE_TAG }}|Flank "${{ $RELEASE_TAG }}" > is released \n ${{ $(echo $RELEASE_NOTES) }}
+          slack-text: <http://github.com/Flank/flank/releases/tag/${{ $RELEASE_TAG }}|Flank "${{ $RELEASE_TAG }}" > is released \n ${{ $(echo $RELEASE_NOTES) }}


### PR DESCRIPTION
Fixes potential 1033 but for now in test. Will update accordingly

## Test Plan
> How do we know the code works?
Want to test it on our GOGO apps first as we must wait for the permission to post to firebase.

An app (Flank Release Test Bot) is created and installed on GoGoApps slack and pointing towards a test_channel. This will be triggered for releases.

Firebase community has had the official Flank Release Bot permission requested to be installed and we are waiting for the result.

To update for firebase simply changing the oauthkey in the GitHub secrets and pointing to the correct channel will work. 