### PR TITLE
fix: Bad validation of `local-result-dir` by Doctor

### DIFF
--- a/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
@@ -177,7 +177,8 @@ data class CommonFlankConfig @JsonIgnore constructor(
             "keep-file-path",
             "output-style",
             "disable-results-upload",
-            "full-junit-result"
+            "full-junit-result",
+            "local-result-dir"
         )
 
         const val defaultLocalResultsDir = "results"

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidDoctorCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidDoctorCommandTest.kt
@@ -4,9 +4,9 @@ import com.google.common.truth.Truth.assertThat
 import ftl.cli.firebase.test.INVALID_YML_PATH
 import ftl.cli.firebase.test.SUCCESS_VALIDATION_MESSAGE
 import ftl.config.FtlConstants
+import ftl.run.exception.YmlValidationError
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.normalizeLineEnding
-import ftl.run.exception.YmlValidationError
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemOutRule
@@ -75,5 +75,12 @@ class AndroidDoctorCommandTest {
             configPath = INVALID_YML_PATH
             run()
         }
+    }
+
+    @Test
+    fun `android doctor should not fail on local-result-dir`() {
+        AndroidDoctorCommand().apply {
+            configPath = "./src/test/kotlin/ftl/fixtures/test_app_cases/flank-with_local_result_dir.yml"
+        }.run()
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosDoctorCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosDoctorCommandTest.kt
@@ -3,7 +3,6 @@ package ftl.cli.firebase.test.ios
 import com.google.common.truth.Truth.assertThat
 import ftl.cli.firebase.test.INVALID_YML_PATH
 import ftl.cli.firebase.test.SUCCESS_VALIDATION_MESSAGE
-import ftl.cli.firebase.test.android.AndroidDoctorCommand
 import ftl.config.FtlConstants
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.normalizeLineEnding
@@ -71,9 +70,16 @@ class IosDoctorCommandTest {
 
     @Test(expected = YmlValidationError::class)
     fun `should terminate with exit code 1 when yml validation fails`() {
-        AndroidDoctorCommand().run {
+        IosDoctorCommand().run {
             configPath = INVALID_YML_PATH
             run()
         }
+    }
+
+    @Test
+    fun `ios doctor should not fail on local-result-dir`() {
+        IosDoctorCommand().apply {
+            configPath = FtlConstants.defaultIosConfig
+        }.run()
     }
 }

--- a/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-with_local_result_dir.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-with_local_result_dir.yml
@@ -1,0 +1,6 @@
+gcloud:
+  app: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
+  test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk
+  results-dir: test_dir_2
+flank:
+  local-result-dir: flank


### PR DESCRIPTION
Fixes #1065 

## Test Plan
> How do we know the code works?

Doctor command does not fail when `local-result-dir` is present

## Checklist

- [x] Unit tested
