### PR TITLE
fix: Avoid fast fail while creating a bucket

### DIFF
--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -157,7 +157,7 @@ object ArgsHelper {
                     .build()
             )
         } catch (e: Exception) {
-            throw FlankGeneralError("Failed to make bucket for $projectId\nCause: ${e.message}")
+            println("Warning: Failed to make bucket for $projectId\nCause: ${e.message}")
         }
 
         return bucket

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -142,7 +142,7 @@ object GcStorage {
                 progress.start("Uploading $fileName")
                 storage.create(fileBlob, fileBytes)
             } catch (e: Exception) {
-                throw FlankGeneralError(e.message.orEmpty(), e)
+                throw FlankGeneralError("Error on uploading $fileName\nCause: $e")
             } finally {
                 progress.stop()
             }


### PR DESCRIPTION
Fixes #1068 

## Test Plan
> How do we know the code works?

Flank should display a warning instead of throw exception while creating bucket fails. 
