### PR TITLE
build: Added options to minimize the shadowJar process

### DIFF
--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -27,9 +27,23 @@ shadowJar.apply {
     archiveClassifier.set("")
     archiveBaseName.set(artifactID)
     mergeServiceFiles()
+    minimize {
+        exclude(dependency(Libs.KOTLIN_REFLECT))
+        exclude(dependency(Libs.JACKSON_XML))
+        exclude(dependency(Libs.JACKSON_DATABIND))
+        exclude(dependency(Libs.JACKSON_KOTLIN))
+        exclude(dependency(Libs.JACKSON_YAML))
+        exclude(dependency(Libs.GSON))
+    }
     @Suppress("UnstableApiUsage")
     manifest {
         attributes(mapOf("Main-Class" to "ftl.Main"))
+    }
+    dependencies {
+        exclude(dependency(Libs.TRUTH))
+        exclude(dependency(Libs.MOCKK))
+        exclude(dependency(Libs.JUNIT))
+        exclude(dependency(Libs.DETEKT_FORMATTING))
     }
 }
 
@@ -135,8 +149,8 @@ detekt {
 
 // Kotlin dsl
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt> {
-        // Target version of the generated JVM bytecode. It is used for type resolution.
-        this.jvmTarget = "1.8"
+    // Target version of the generated JVM bytecode. It is used for type resolution.
+    this.jvmTarget = "1.8"
 }
 
 // http://www.eclemma.org/jacoco/
@@ -171,6 +185,7 @@ application {
 repositories {
     maven(url = "http://dl.bintray.com/kotlin/ktor")
     maven(url = "https://dl.bintray.com/kotlin/kotlinx")
+    google()
     jcenter()
 }
 
@@ -185,7 +200,6 @@ tasks.withType<Test> {
 
 dependencies {
     implementation(Libs.BUGSNAG)
-
     implementation(Libs.DD_PLIST)
     implementation(Libs.DEX_TEST_PARSER)
 


### PR DESCRIPTION
Fixes #1063 

## Test Plan
> How do we know the code works?
Tests passes and tested manually with bash files ./update-flank and the executable flank.
For example: `flank firebase test android run --output-style=single -c=../src/test/kotlin/ftl/fixtures/test_app_cases/flank-multiple-flaky.yml --project=flank-open-source` 

`flank-multiple-flaky.yml` needs a minor update if run from the bash folder, the pathing is incorrect. eg:
```
 app: ../src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
 test: ../src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-flaky-debug-androidTest.apk
```

The difficulty associated with minimizing a build results in possible missing classes within the shadowJar which is a difficult thing to pick up as you need integration tests rather than unit tests to achieve this. The tests were run manually and have passed. I do suggest we consider having a set of manually run external tests that can be run 
WDYT?
