### PR TITLE
fix: Fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Get all git tags
       run: |
-        git fetch --prune --unshallow --tags
+        git fetch --prune --unshallow --tags -f
         git tag
 
     - name: Gradle Build flankScripts and add it to PATH


### PR DESCRIPTION
Fixes #1086 

Now release action not updating tags on fetch, this causes issues when we try to reuse tag like in the case with ```v20.09.0``` version. I add ```-f``` parameter to allow update tags.

## Test Plan
> How do we know the code works?

You can try run command

```

git fetch --prune  --tags

```

Git should return information like (in my case return information about other tags)

```

 ! [rejected]        v20.09.0                -> v20.09.0  (would clobber existing tag)

```

second run command with ```-f``` param

```

```

git fetch --prune  --tags -f
```

```

Git should return information about the update tags.



