### PR TITLE
feat: print the matrices web link at the end of a run

### DIFF
--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -8,7 +8,6 @@ import ftl.args.ShardChunks
 import ftl.gc.GcStorage
 import ftl.json.MatrixMap
 import ftl.json.isAllSuccessful
-import ftl.json.validate
 import ftl.reports.CostReport
 import ftl.reports.FullJUnitReport
 import ftl.reports.HtmlErrorReport

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -117,7 +117,6 @@ object ReportManager {
             args.useLegacyJUnitResult -> processJunitXml(testSuite, args, testShardChunks)
             else -> processJunitXml(testSuite, args, testShardChunks)
         }
-        matrices.validate(args.ignoreFailedTests)
     }
 
     private fun IgnoredTestCases.toJunitTestsResults() = getSkippedJUnitTestSuite(map {

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -5,6 +5,7 @@ import ftl.args.IArgs
 import ftl.args.IosArgs
 import ftl.json.SavedMatrix
 import ftl.json.updateMatrixMap
+import ftl.json.validate
 import ftl.reports.util.ReportManager
 import ftl.run.common.fetchArtifacts
 import ftl.run.common.pollMatrices
@@ -24,14 +25,14 @@ suspend fun newTestRun(args: IArgs) = withTimeoutOrNull(args.parsedTimeout) {
     if (!args.async) {
         cancelTestsOnTimeout(args.project, matrixMap.map) { pollMatrices(matrixMap.map.keys, args).updateMatrixMap(matrixMap) }
         cancelTestsOnTimeout(args.project, matrixMap.map) { fetchArtifacts(matrixMap, args) }
-        runCatching {
-            ReportManager.generate(matrixMap, args, testShardChunks, ignoredTests)
-        }.apply {
-            println()
-            matrixMap.printMatricesWebLinks(args.project)
-        }.recover {
-            throw it
-        }
+
+        ReportManager.generate(matrixMap, args, testShardChunks, ignoredTests)
+
+        println()
+        matrixMap.printMatricesWebLinks(args.project)
+
+        matrixMap.validate(args.ignoreFailedTests)
+
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -3,13 +3,11 @@ package ftl.run
 import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
-import ftl.config.FtlConstants
 import ftl.json.SavedMatrix
 import ftl.json.updateMatrixMap
 import ftl.reports.util.ReportManager
 import ftl.run.common.fetchArtifacts
 import ftl.run.common.pollMatrices
-import ftl.run.exception.FlankException
 import ftl.run.exception.FlankGeneralError
 import ftl.run.exception.FlankTimeoutError
 import ftl.run.model.TestResult

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -32,7 +32,6 @@ suspend fun newTestRun(args: IArgs) = withTimeoutOrNull(args.parsedTimeout) {
         matrixMap.printMatricesWebLinks(args.project)
 
         matrixMap.validate(args.ignoreFailedTests)
-
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
@@ -16,7 +16,6 @@ import ftl.args.ShardChunks
 import ftl.json.needsUpdate
 import ftl.json.updateWithMatrix
 import ftl.json.validate
-import ftl.run.platform.common.printMatricesWebLinks
 import ftl.util.MatrixState
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers

--- a/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
@@ -15,6 +15,8 @@ import ftl.run.common.updateMatrixFile
 import ftl.args.ShardChunks
 import ftl.json.needsUpdate
 import ftl.json.updateWithMatrix
+import ftl.json.validate
+import ftl.run.platform.common.printMatricesWebLinks
 import ftl.util.MatrixState
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -33,6 +35,8 @@ suspend fun refreshLastRun(currentArgs: IArgs, testShardChunks: ShardChunks) {
 
     // Must generate reports *after* fetching xml artifacts since reports require xml
     ReportManager.generate(matrixMap, lastArgs, testShardChunks)
+
+    matrixMap.validate(lastArgs.ignoreFailedTests)
 }
 
 /** Refresh all in progress matrices in parallel **/

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/AfterRunTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/AfterRunTests.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.nio.file.Files
 import java.nio.file.Paths
 

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/AfterRunTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/AfterRunTests.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -49,7 +50,7 @@ private fun saveConfigFile(matrixMap: MatrixMap, args: IArgs) {
     Files.write(configFilePath, args.data.toByteArray())
 }
 
-private suspend inline fun MatrixMap.printMatricesWebLinks(project: String) = coroutineScope {
+internal suspend inline fun MatrixMap.printMatricesWebLinks(project: String) = coroutineScope {
     println("Matrices webLink")
     map.values.map {
         launch(Dispatchers.IO) {

--- a/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
@@ -3,6 +3,7 @@ package ftl.reports.utils
 import com.google.common.truth.Truth.assertThat
 import ftl.args.AndroidArgs
 import ftl.gc.GcStorage
+import ftl.json.validate
 import ftl.reports.CostReport
 import ftl.reports.FullJUnitReport
 import ftl.reports.JUnitReport
@@ -52,6 +53,7 @@ class ReportManagerTest {
         every { mockArgs.smartFlankGcsPath } returns ""
         every { mockArgs.useLegacyJUnitResult } returns true
         ReportManager.generate(matrix, mockArgs, emptyList())
+        matrix.validate()
     }
 
     @Test


### PR DESCRIPTION
Fixes #1094

## Test Plan
> How do we know the code works?

On the end of the output Flank should reprint matrices webLinks like:

```

MatrixResultsReport
  1 / 1 (100.00%)
┌─────────┬──────────────────────┬────────────────────────────┬──────────────────────┐
│ OUTCOME │      MATRIX ID       │      TEST AXIS VALUE       │     TEST DETAILS     │
├─────────┼──────────────────────┼────────────────────────────┼──────────────────────┤
│ success │ matrix-a6sbyeuihlwta │ NexusLowRes-28-en-portrait │ 20 test cases passed │
└─────────┴──────────────────────┴────────────────────────────┴──────────────────────┘
  Uploading MatrixResultsReport.txt .
  Uploading JUnitReport.xml .

Matrices webLink
  matrix-a6sbyeuihlwta https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/9050578927670125735


Process finished with exit code 0


```
