### PR TITLE
build: update info to build with Java 11

### DIFF
--- a/.github/workflows/macos_workflow.yml
+++ b/.github/workflows/macos_workflow.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 14
+        java-version: 11
     - uses: actions/cache@v2
       with:
         path: ~/.gradle/caches

--- a/.github/workflows/macos_workflow.yml
+++ b/.github/workflows/macos_workflow.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 14
     - uses: actions/cache@v2
       with:
         path: ~/.gradle/caches

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ See [docs/error_monitoring.md](./docs/error_monitoring.md) to disable Bugsnag er
 
 ### Contributing
 
-- Install JDK:
-  - [Oracle](https://www.oracle.com/java/technologies/javase-downloads.html)
-  - [OpenJDK](https://openjdk.java.net/)
+- Install JDK 11:
+  - [Oracle](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
+  - [OpenJDK](https://jdk.java.net/11/)
 - Use [JetBrains Toolbox](https://www.jetbrains.com/toolbox/app/) to install `IntelliJ IDEA Community`
 - Clone the repo `git clone --recursive https://github.com/Flank/flank.git`
   - `git submodule update --init --recursive` updates the submodules

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [docs/error_monitoring.md](./docs/error_monitoring.md) to disable Bugsnag er
 
 ### Contributing
 
-- Install JDK 11:
+- Install JDK 11 (it works also correctly on previous version, newer version are not guaranteed to works properly):
   - [Oracle](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
   - [OpenJDK](https://jdk.java.net/11/)
 - Use [JetBrains Toolbox](https://www.jetbrains.com/toolbox/app/) to install `IntelliJ IDEA Community`

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ See [docs/error_monitoring.md](./docs/error_monitoring.md) to disable Bugsnag er
 
 ### Contributing
 
-- Install [Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-  - JDK 9 or later will not work
+- Install JDK:
+  - [Oracle](https://www.oracle.com/java/technologies/javase-downloads.html)
+  - [OpenJDK](https://openjdk.java.net/)
 - Use [JetBrains Toolbox](https://www.jetbrains.com/toolbox/app/) to install `IntelliJ IDEA Community`
 - Clone the repo `git clone --recursive https://github.com/Flank/flank.git`
   - `git submodule update --init --recursive` updates the submodules
@@ -729,11 +730,7 @@ and flank's example [gradle-export-api](https://github.com/Flank/flank/tree/mast
 
     With the [update_flank.sh](https://github.com/Flank/flank/blob/master/test_runner/bash/update_flank.sh) shell script, you can rebuild `flank.jar`.
 
-3)  > Symbol is declared in module 'java.xml' which does not export package 'com.sun.org.apache.xerces.internal.dom'
-
-    Make sure you're using JDK 8 to compile Flank.
-
-4)  > Test run failed to complete. Expected 786 tests, received 660
+3)  > Test run failed to complete. Expected 786 tests, received 660
 
     Try setting `use-orchestrator: false`. Parameterized tests [are not compatible with orchestrator](https://stackoverflow.com/questions/48735268/unable-to-run-parameterized-tests-with-android-test-orchestrator). Flank uses [orchestrator by default on Android.](https://developer.android.com/training/testing/junit-runner)
 


### PR DESCRIPTION
Fixes #296

## Test Plan
> How do we know the code works?

Flank compiles with the JDK 11.

## Checklist

- [x] Documented
