### PR TITLE
fix: dockerfile fix for slack message send

### DIFF
--- a/flank-actions/Dockerfile
+++ b/flank-actions/Dockerfile
@@ -21,6 +21,4 @@ RUN chmod +x /entrypoint.sh
 
 RUN chmod +x /sendMessage
 
-RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && /test.sh"
-
 ENTRYPOINT /bin/bash /entrypoint.sh


### PR DESCRIPTION
Removed the test command from docker file

## Test Plan
Tests run fine locally however needs a production run
