### PR TITLE
fix: Reflect gclouds outcome for robo tests

### DIFF
--- a/test_runner/src/main/kotlin/ftl/json/OutcomeDetailsFormatter.kt
+++ b/test_runner/src/main/kotlin/ftl/json/OutcomeDetailsFormatter.kt
@@ -17,16 +17,16 @@ internal fun Outcome?.getDetails(
     testSuiteOverviewData: TestSuiteOverviewData?,
     isRoboTest: Boolean = false
 ): String = when (this?.summary) {
-    success, flaky -> if (isRoboTest) "---"
-    else testSuiteOverviewData
-        ?.getSuccessOutcomeDetails(successDetail?.otherNativeCrash ?: false)
-        ?: "Unknown outcome"
+    success, flaky -> if (isRoboTest) "---" else getSuccessOutcomeDetails(testSuiteOverviewData)
     failure -> failureDetail.getFailureOutcomeDetails(testSuiteOverviewData)
     inconclusive -> inconclusiveDetail.formatOutcomeDetails()
     skipped -> skippedDetail.formatOutcomeDetails()
     unset -> "Unset outcome"
     else -> "Unknown outcome"
 }
+
+private fun Outcome?.getSuccessOutcomeDetails(data: TestSuiteOverviewData?) =
+    data?.getSuccessOutcomeDetails(this?.successDetail?.otherNativeCrash ?: false) ?: "Unknown outcome"
 
 private fun TestSuiteOverviewData.getSuccessOutcomeDetails(
     otherNativeCrash: Boolean

--- a/test_runner/src/main/kotlin/ftl/json/OutcomeDetailsFormatter.kt
+++ b/test_runner/src/main/kotlin/ftl/json/OutcomeDetailsFormatter.kt
@@ -14,9 +14,11 @@ import ftl.util.StepOutcome.success
 import ftl.util.StepOutcome.unset
 
 internal fun Outcome?.getDetails(
-    testSuiteOverviewData: TestSuiteOverviewData?
+    testSuiteOverviewData: TestSuiteOverviewData?,
+    isRoboTest: Boolean = false
 ): String = when (this?.summary) {
-    success, flaky -> testSuiteOverviewData
+    success, flaky -> if (isRoboTest) "---"
+    else testSuiteOverviewData
         ?.getSuccessOutcomeDetails(successDetail?.otherNativeCrash ?: false)
         ?: "Unknown outcome"
     failure -> failureDetail.getFailureOutcomeDetails(testSuiteOverviewData)
@@ -43,6 +45,7 @@ internal fun FailureDetail?.getFailureOutcomeDetails(testSuiteOverviewData: Test
     crashed == true -> "Application crashed"
     timedOut == true -> "Test timed out"
     notInstalled == true -> "App failed to install"
+    failedRoboscript == true -> "Test failed to run"
     else -> testSuiteOverviewData?.buildFailureOutcomeDetailsSummary() ?: "Unknown failure"
 } + this?.takeIf { it.otherNativeCrash ?: false }?.let { NATIVE_CRASH_MESSAGE }.orEmpty()
 

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummary.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummary.kt
@@ -2,14 +2,16 @@ package ftl.reports.outcome
 
 import com.google.api.services.toolresults.model.Environment
 
-fun TestOutcomeContext.createMatrixOutcomeSummary() = Pair(
-    steps.calculateAndroidBillableMinutes(projectId, testTimeout),
+fun TestOutcomeContext.createMatrixOutcomeSummary() = billableMinutes() to outcomeSummary()
+
+private fun TestOutcomeContext.billableMinutes() = steps.calculateAndroidBillableMinutes(projectId, testTimeout)
+
+private fun TestOutcomeContext.outcomeSummary() =
     if (environments.hasOutcome())
         createMatrixOutcomeSummaryUsingEnvironments()
     else {
         if (steps.isEmpty()) println("No test results found, something went wrong. Try re-running the tests.")
         createMatrixOutcomeSummaryUsingSteps()
     }
-)
 
 private fun List<Environment>.hasOutcome() = isNotEmpty() && all { it.environmentResult?.outcome?.summary != null }

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummary.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummary.kt
@@ -2,15 +2,14 @@ package ftl.reports.outcome
 
 import com.google.api.services.toolresults.model.Environment
 
-fun TestOutcomeContext.createMatrixOutcomeSummary(): Pair<BillableMinutes, List<TestOutcome>> =
-    steps.calculateAndroidBillableMinutes(projectId, testTimeout) to
-        if (environments.hasOutcome())
-            environments.createMatrixOutcomeSummaryUsingEnvironments()
-        else {
-            if (steps.isEmpty()) println("No test results found, something went wrong. Try re-running the tests.")
-            steps.createMatrixOutcomeSummaryUsingSteps()
-        }
+fun TestOutcomeContext.createMatrixOutcomeSummary() = Pair(
+    steps.calculateAndroidBillableMinutes(projectId, testTimeout),
+    if (environments.hasOutcome())
+        createMatrixOutcomeSummaryUsingEnvironments()
+    else {
+        if (steps.isEmpty()) println("No test results found, something went wrong. Try re-running the tests.")
+        createMatrixOutcomeSummaryUsingSteps()
+    }
+)
 
-private fun List<Environment>.hasOutcome() = isNotEmpty() && any { env ->
-    env.environmentResult?.outcome?.summary == null
-}.not()
+private fun List<Environment>.hasOutcome() = isNotEmpty() && all { it.environmentResult?.outcome?.summary != null }

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/CreateTestSuiteOverviewData.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/CreateTestSuiteOverviewData.kt
@@ -23,7 +23,7 @@ internal fun List<Step>.createTestSuiteOverviewData(): TestSuiteOverviewData = t
     .groupBy(Step::axisValue)
     .values
     .map { it.mapToTestSuiteOverviews().foldTestSuiteOverviewData() }
-    .fold(TestSuiteOverviewData()) { acc, data -> acc + data } // Fixme https://github.com/Flank/flank/issues/983
+    .fold(TestSuiteOverviewData()) { acc, data -> acc + data }
 
 private fun Step.isPrimaryStep() =
     multiStep?.primaryStep?.rollUp != null || multiStep == null

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/TestOutcomeContext.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/TestOutcomeContext.kt
@@ -15,7 +15,8 @@ data class TestOutcomeContext(
     val projectId: String,
     val environments: List<Environment>,
     val steps: List<Step>,
-    val testTimeout: Long
+    val testTimeout: Long,
+    val isRoboTest: Boolean
 )
 
 fun TestMatrix.fetchTestOutcomeContext() = getToolResultsIds().let { ids ->
@@ -24,7 +25,8 @@ fun TestMatrix.fetchTestOutcomeContext() = getToolResultsIds().let { ids ->
         matrixId = testMatrixId,
         environments = GcToolResults.listAllEnvironments(ids),
         steps = GcToolResults.listAllSteps(ids),
-        testTimeout = testTimeout()
+        testTimeout = testTimeout(),
+        isRoboTest = isRoboTest()
     )
 }
 
@@ -44,3 +46,5 @@ private fun TestMatrix.testTimeout() = timeoutToSeconds(
         ?.testTimeout
         ?: "0s"
 )
+
+private fun TestMatrix.isRoboTest() = testExecutions.orEmpty().any { it?.testSpecification?.androidRoboTest != null }

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunMessage.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunMessage.kt
@@ -11,7 +11,7 @@ internal fun beforeRunMessage(args: IArgs, testShardChunks: List<Chunk>): String
     val (classesCount, testsCount) = testShardChunks.partitionedTestCases.testAndClassesCount
 
     val result = StringBuilder()
-    val testString = if (testsCount > 0) "$testsCount test${s(testsCount)}" else ""
+    val testString = if (testsCount == 0 && classesCount != 0) "" else "$testsCount test${s(testsCount)}"
     val classString = if (classesCount > 0) "$classesCount parameterized class${es(classesCount)}" else ""
 
     result.appendLine(

--- a/test_runner/src/test/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummaryKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummaryKtTest.kt
@@ -1,0 +1,126 @@
+package ftl.reports.outcome
+
+import com.google.api.services.toolresults.model.Environment
+import com.google.api.services.toolresults.model.Step
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlin.reflect.full.createInstance
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class CreateMatrixOutcomeSummaryKtTest {
+
+    @Before
+    fun setUp() {
+        mockkStatic("ftl.reports.outcome.UtilKt")
+        mockkStatic("ftl.reports.outcome.BillableMinutesKt")
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `should create TestOutcome list for success robo test - from environments`() {
+        val env: Environment = make {
+            environmentResult = make {
+                outcome = make { summary = "success" }
+            }
+        }
+        every { env.axisValue() } returns "anyDevice"
+        val context = TestOutcomeContext(
+            matrixId = "anyMatrix",
+            projectId = "anyProject",
+            testTimeout = Long.MAX_VALUE,
+            steps = emptyList(),
+            isRoboTest = true,
+            environments = listOf(env)
+        )
+
+        val (_, result) = context.createMatrixOutcomeSummary()
+
+        assertEquals("---", result[0].details)
+        assertEquals("anyDevice", result[0].device)
+        assertEquals("success", result[0].outcome)
+    }
+
+    @Test
+    fun `should create TestOutcome list for failed robo test - from environments`() {
+        val env: Environment = make {
+            environmentResult = make {
+                outcome = make {
+                    summary = "failure"
+                    failureDetail = make { failedRoboscript = true }
+                }
+            }
+        }
+        every { env.axisValue() } returns "anyDevice"
+        val context = TestOutcomeContext(
+            matrixId = "anyMatrix",
+            projectId = "anyProject",
+            testTimeout = Long.MAX_VALUE,
+            steps = emptyList(),
+            isRoboTest = true,
+            environments = listOf(env)
+        )
+
+        val (_, result) = context.createMatrixOutcomeSummary()
+
+        assertEquals("Test failed to run", result[0].details)
+        assertEquals("anyDevice", result[0].device)
+        assertEquals("failure", result[0].outcome)
+    }
+
+    @Test
+    fun `should create TestOutcome list for success robo test - from steps`() {
+        val steps: List<Step> = listOf(make {
+            outcome = make { summary = "success" }
+        })
+        every { steps[0].axisValue() } returns "anyDevice"
+        every { steps.calculateAndroidBillableMinutes(any(), any()) } returns make()
+        val context = TestOutcomeContext(
+            matrixId = "anyMatrix",
+            projectId = "anyProject",
+            testTimeout = Long.MAX_VALUE,
+            steps = steps,
+            isRoboTest = true,
+            environments = emptyList()
+        )
+
+        val (_, result) = context.createMatrixOutcomeSummary()
+
+        assertEquals("---", result[0].details)
+        assertEquals("anyDevice", result[0].device)
+        assertEquals("success", result[0].outcome)
+    }
+
+    @Test
+    fun `should create TestOutcome list for failed robo test - from steps`() {
+        val steps: List<Step> = listOf(make {
+            outcome = make {
+                summary = "failure"
+                failureDetail = make { failedRoboscript = true }
+            }
+        })
+        every { steps[0].axisValue() } returns "anyDevice"
+        every { steps.calculateAndroidBillableMinutes(any(), any()) } returns make()
+        val context = TestOutcomeContext(
+            matrixId = "anyMatrix",
+            projectId = "anyProject",
+            testTimeout = Long.MAX_VALUE,
+            steps = steps,
+            isRoboTest = true,
+            environments = emptyList()
+        )
+
+        val (_, result) = context.createMatrixOutcomeSummary()
+
+        assertEquals("Test failed to run", result[0].details)
+        assertEquals("anyDevice", result[0].device)
+        assertEquals("failure", result[0].outcome)
+    }
+}
+
+private inline fun <reified T : Any> make(block: T.() -> Unit = {}): T = T::class.createInstance().apply(block)


### PR DESCRIPTION
Fixes #1120 

## Test Plan
> How do we know the code works?

Flank should reflect gcloud's output for robo tests:
![Screenshot 2020-09-15 at 13 01 44](https://user-images.githubusercontent.com/32893017/93239482-231b7580-f783-11ea-91d0-04b7fc361482.png)
![Screenshot 2020-09-15 at 18 42 30](https://user-images.githubusercontent.com/32893017/93239602-4d6d3300-f783-11ea-97f3-3c3fe88f7b43.png)
![Screenshot 2020-09-15 at 18 42 43](https://user-images.githubusercontent.com/32893017/93239605-4e9e6000-f783-11ea-8c9c-a2c7a8135dfc.png)

Use this [SCRIPT](https://gist.github.com/pawelpasterz/cb0bdab77fc92ba8d83d3394faee3002) to simulate failing robo

All other functionalities related to running tests remain the same

## Checklist

- [x] Unit tested
