### PR TITLE
feat: Allow Flank using different environment variables between test-apks

### DIFF
--- a/docs/using_different_environment_variables_in_different_matrices.md
+++ b/docs/using_different_environment_variables_in_different_matrices.md
@@ -1,0 +1,59 @@
+# Using different environment variables per test apk
+
+## The problem
+
+Environment variables are used to configure test coverage. When you configure this in the global scope (gcloud:environment-variables) all of the matrices have the same test coverage file name.
+Example:
+
+```yml
+
+gcloud:
+  app: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
+  test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-success-debug-androidTest.apk
+  environment-variables:
+    coverage: true
+    coverageFile: /sdcard/coverage.ec
+    clearPackageData: true
+  directories-to-pull:
+    - /sdcard/
+  use-orchestrator: false
+
+```
+
+In the case where you have configured additional test apks, all of the matrices have a coverage file named ```coverage.ec```
+
+## Solution
+
+You can override environment variables by configuring it in ```additional-app-test-apks```
+
+Example:
+
+```yml
+
+gcloud:
+  app: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
+  test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-success-debug-androidTest.apk
+  environment-variables:
+    coverage: true
+    coverageFile: /sdcard/main.ec
+    clearPackageData: true
+  directories-to-pull:
+    - /sdcard/
+  use-orchestrator: false
+
+flank:
+  disable-sharding: false
+  max-test-shards: 2
+  files-to-download:
+    - .*/sdcard/[^/]+\.ec$
+  additional-app-test-apks:
+    - test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-success-debug-androidTest.apk
+      environmentVariables:
+        coverageFile: /sdcard/module_1.ec
+    - test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-success-debug-androidTest.apk
+      environmentVariables:
+        coverageFile: /sdcard/module_2.ec
+
+```
+
+Now Flank override ```coverageFile``` in matrices and you can identify what matrix run what test

--- a/test_runner/src/main/kotlin/ftl/args/CreateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateAndroidArgs.kt
@@ -29,10 +29,11 @@ fun createAndroidArgs(
     roboScript = gcloud.roboScript?.normalizeFilePath(),
 
     // flank
-    additionalAppTestApks = flank.additionalAppTestApks?.map { (app, test) ->
+    additionalAppTestApks = flank.additionalAppTestApks?.map { (app, test, env) ->
         AppTestPair(
             app = app?.normalizeFilePath(),
-            test = test.normalizeFilePath()
+            test = test.normalizeFilePath(),
+            environmentVariables = env
         )
     } ?: emptyList(),
     useLegacyJUnitResult = flank.useLegacyJUnitResult!!

--- a/test_runner/src/main/kotlin/ftl/args/yml/AppTestPair.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/AppTestPair.kt
@@ -1,7 +1,12 @@
 package ftl.args.yml
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class AppTestPair(
     val app: String?,
     val test: String,
+    @JsonProperty("environment-variables")
     val environmentVariables: Map<String, String> = emptyMap()
 )

--- a/test_runner/src/main/kotlin/ftl/args/yml/AppTestPair.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/AppTestPair.kt
@@ -2,5 +2,6 @@ package ftl.args.yml
 
 data class AppTestPair(
     val app: String?,
-    val test: String
+    val test: String,
+    val environmentVariables: Map<String, String> = emptyMap()
 )

--- a/test_runner/src/main/kotlin/ftl/gc/android/SetupEnvironmentVariables.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/android/SetupEnvironmentVariables.kt
@@ -7,9 +7,10 @@ import ftl.args.AndroidArgs
 import ftl.run.platform.android.AndroidTestConfig
 
 @VisibleForTesting
-internal fun TestSetup.setEnvironmentVariables(args: AndroidArgs, testConfig: AndroidTestConfig) = this.apply {
+internal fun TestSetup.setEnvironmentVariables(args: AndroidArgs, testConfig: AndroidTestConfig) = apply {
     environmentVariables = when (testConfig) {
-        is AndroidTestConfig.Instrumentation -> args.environmentVariables.map { it.toEnvironmentVariable() }
+        is AndroidTestConfig.Instrumentation ->
+            args.environmentVariables.map { it.toEnvironmentVariable() } + testConfig.env.map { it.toEnvironmentVariable() }
         is AndroidTestConfig.Robo -> emptyList()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/android/SetupEnvironmentVariables.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/android/SetupEnvironmentVariables.kt
@@ -10,9 +10,9 @@ import ftl.run.platform.android.AndroidTestConfig
 internal fun TestSetup.setEnvironmentVariables(args: AndroidArgs, testConfig: AndroidTestConfig) = apply {
     environmentVariables = when (testConfig) {
         is AndroidTestConfig.Instrumentation ->
-            args.environmentVariables.map { it.toEnvironmentVariable() } + testConfig.env.map { it.toEnvironmentVariable() }
+            testConfig.environmentVariables.map { it.toEnvironmentVariable() } + args.environmentVariables.map { it.toEnvironmentVariable() }
         is AndroidTestConfig.Robo -> emptyList()
-    }
+    }.distinctBy { it.key }
 }
 
 private fun Map.Entry<String, String>.toEnvironmentVariable() = EnvironmentVariable().apply {

--- a/test_runner/src/main/kotlin/ftl/run/model/AndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/model/AndroidTestContext.kt
@@ -11,7 +11,7 @@ data class InstrumentationTestContext(
     val test: FileReference,
     val shards: List<Chunk> = emptyList(),
     val ignoredTestCases: IgnoredTestCases = emptyList(),
-    val env: Map<String, String> = emptyMap()
+    val environmentVariables: Map<String, String> = emptyMap()
 ) : AndroidTestContext()
 
 data class RoboTestContext(

--- a/test_runner/src/main/kotlin/ftl/run/model/AndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/model/AndroidTestContext.kt
@@ -10,7 +10,8 @@ data class InstrumentationTestContext(
     val app: FileReference,
     val test: FileReference,
     val shards: List<Chunk> = emptyList(),
-    val ignoredTestCases: IgnoredTestCases = emptyList()
+    val ignoredTestCases: IgnoredTestCases = emptyList(),
+    val env: Map<String, String> = emptyMap()
 ) : AndroidTestContext()
 
 data class RoboTestContext(

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
@@ -4,7 +4,6 @@ import ftl.args.FlankRoboDirective
 import ftl.args.ShardChunks
 
 sealed class AndroidTestConfig {
-
     data class Instrumentation(
         val appApkGcsPath: String,
         val testApkGcsPath: String,
@@ -14,7 +13,8 @@ sealed class AndroidTestConfig {
         val disableSharding: Boolean,
         val testShards: ShardChunks,
         val numUniformShards: Int?,
-        val keepTestTargetsEmpty: Boolean
+        val keepTestTargetsEmpty: Boolean,
+        val env: Map<String, String> = emptyMap()
     ) : AndroidTestConfig()
 
     data class Robo(
@@ -22,4 +22,5 @@ sealed class AndroidTestConfig {
         val flankRoboDirectives: List<FlankRoboDirective>?,
         val roboScriptGcsPath: String?
     ) : AndroidTestConfig()
+
 }

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
@@ -14,7 +14,7 @@ sealed class AndroidTestConfig {
         val testShards: ShardChunks,
         val numUniformShards: Int?,
         val keepTestTargetsEmpty: Boolean,
-        val env: Map<String, String> = emptyMap()
+        val environmentVariables: Map<String, String> = emptyMap()
     ) : AndroidTestConfig()
 
     data class Robo(

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
@@ -22,5 +22,4 @@ sealed class AndroidTestConfig {
         val flankRoboDirectives: List<FlankRoboDirective>?,
         val roboScriptGcsPath: String?
     ) : AndroidTestConfig()
-
 }

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
@@ -5,21 +5,21 @@ import ftl.args.ShardChunks
 
 sealed class AndroidTestConfig {
     data class Instrumentation(
-        val appApkGcsPath: String,
-        val testApkGcsPath: String,
-        val testRunnerClass: String?,
-        val orchestratorOption: String?,
-        // sharding
-        val disableSharding: Boolean,
-        val testShards: ShardChunks,
-        val numUniformShards: Int?,
-        val keepTestTargetsEmpty: Boolean,
-        val environmentVariables: Map<String, String> = emptyMap()
+            val appApkGcsPath: String,
+            val testApkGcsPath: String,
+            val testRunnerClass: String?,
+            val orchestratorOption: String?,
+            // sharding
+            val disableSharding: Boolean,
+            val testShards: ShardChunks,
+            val numUniformShards: Int?,
+            val keepTestTargetsEmpty: Boolean,
+            val environmentVariables: Map<String, String> = emptyMap()
     ) : AndroidTestConfig()
 
     data class Robo(
-        val appApkGcsPath: String,
-        val flankRoboDirectives: List<FlankRoboDirective>?,
-        val roboScriptGcsPath: String?
+            val appApkGcsPath: String,
+            val flankRoboDirectives: List<FlankRoboDirective>?,
+            val roboScriptGcsPath: String?
     ) : AndroidTestConfig()
 }

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
@@ -9,7 +9,7 @@ sealed class AndroidTestConfig {
         val testApkGcsPath: String,
         val testRunnerClass: String?,
         val orchestratorOption: String?,
-            // sharding
+        // sharding
         val disableSharding: Boolean,
         val testShards: ShardChunks,
         val numUniformShards: Int?,

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/AndroidTestConfig.kt
@@ -5,21 +5,21 @@ import ftl.args.ShardChunks
 
 sealed class AndroidTestConfig {
     data class Instrumentation(
-            val appApkGcsPath: String,
-            val testApkGcsPath: String,
-            val testRunnerClass: String?,
-            val orchestratorOption: String?,
+        val appApkGcsPath: String,
+        val testApkGcsPath: String,
+        val testRunnerClass: String?,
+        val orchestratorOption: String?,
             // sharding
-            val disableSharding: Boolean,
-            val testShards: ShardChunks,
-            val numUniformShards: Int?,
-            val keepTestTargetsEmpty: Boolean,
-            val environmentVariables: Map<String, String> = emptyMap()
+        val disableSharding: Boolean,
+        val testShards: ShardChunks,
+        val numUniformShards: Int?,
+        val keepTestTargetsEmpty: Boolean,
+        val environmentVariables: Map<String, String> = emptyMap()
     ) : AndroidTestConfig()
 
     data class Robo(
-            val appApkGcsPath: String,
-            val flankRoboDirectives: List<FlankRoboDirective>?,
-            val roboScriptGcsPath: String?
+        val appApkGcsPath: String,
+        val flankRoboDirectives: List<FlankRoboDirective>?,
+        val roboScriptGcsPath: String?
     ) : AndroidTestConfig()
 }

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateInstrumentationConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateInstrumentationConfig.kt
@@ -14,5 +14,6 @@ internal fun AndroidArgs.createInstrumentationConfig(
     disableSharding = disableSharding,
     numUniformShards = numUniformShards,
     testShards = testApk.shards.testCases,
-    keepTestTargetsEmpty = disableSharding && testTargets.isEmpty()
+    keepTestTargetsEmpty = disableSharding && testTargets.isEmpty(),
+    env = testApk.env
 )

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateInstrumentationConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateInstrumentationConfig.kt
@@ -15,5 +15,5 @@ internal fun AndroidArgs.createInstrumentationConfig(
     numUniformShards = numUniformShards,
     testShards = testApk.shards.testCases,
     keepTestTargetsEmpty = disableSharding && testTargets.isEmpty(),
-    env = testApk.env
+    environmentVariables = testApk.environmentVariables
 )

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
@@ -19,7 +19,7 @@ internal fun AndroidArgs.resolveApks(): List<AndroidTestContext> = listOfNotNull
 
 private fun AndroidArgs.mainApkContext() = appApk?.let { appApk ->
     when {
-        testApk != null -> InstrumentationTestContext(app = appApk.asFileReference(), test = testApk.asFileReference())
+        testApk != null -> InstrumentationTestContext(app = appApk.asFileReference(), test = testApk.asFileReference(), env = emptyMap())
         roboScript != null -> RoboTestContext(app = appApk.asFileReference(), roboScript = roboScript.asFileReference())
         isSanityRobo -> SanityRoboTestContext(app = appApk.asFileReference())
         else -> null
@@ -31,6 +31,6 @@ private fun AndroidArgs.additionalApksContexts() = additionalAppTestApks.map {
         app = (it.app ?: appApk)
             ?.asFileReference()
             ?: throw FlankGeneralError("Cannot create app-test apks pair for instrumentation tests, missing app apk for test ${it.test}"),
-        test = it.test.asFileReference()
+        test = it.test.asFileReference(), env = it.environmentVariables
     )
 }.toTypedArray()

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
@@ -19,7 +19,7 @@ internal fun AndroidArgs.resolveApks(): List<AndroidTestContext> = listOfNotNull
 
 private fun AndroidArgs.mainApkContext() = appApk?.let { appApk ->
     when {
-        testApk != null -> InstrumentationTestContext(app = appApk.asFileReference(), test = testApk.asFileReference(), env = emptyMap())
+        testApk != null -> InstrumentationTestContext(app = appApk.asFileReference(), test = testApk.asFileReference(), environmentVariables = emptyMap())
         roboScript != null -> RoboTestContext(app = appApk.asFileReference(), roboScript = roboScript.asFileReference())
         isSanityRobo -> SanityRoboTestContext(app = appApk.asFileReference())
         else -> null
@@ -31,6 +31,6 @@ private fun AndroidArgs.additionalApksContexts() = additionalAppTestApks.map {
         app = (it.app ?: appApk)
             ?.asFileReference()
             ?: throw FlankGeneralError("Cannot create app-test apks pair for instrumentation tests, missing app apk for test ${it.test}"),
-        test = it.test.asFileReference(), env = it.environmentVariables
+        test = it.test.asFileReference(), environmentVariables = it.environmentVariables
     )
 }.toTypedArray()

--- a/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
@@ -158,4 +158,62 @@ class GcAndroidTestMatrixTest {
         )
         assertTrue(testSetup.environmentVariables.isNotEmpty())
     }
+
+    @Test
+    fun `should set env variables with values from test config`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          environment-variables:
+            coverage: true
+            coverageFilePath: /sdcard/
+            clearPackageData: true
+        """.trimIndent()
+        val androidArgs = AndroidArgs.load(StringReader(yaml), null)
+
+        val testSetup = TestSetup().setEnvironmentVariables(
+            androidArgs, AndroidTestConfig.Instrumentation(
+                appApkGcsPath = "",
+                testApkGcsPath = "",
+                testShards = emptyList(),
+                orchestratorOption = null,
+                numUniformShards = null,
+                disableSharding = false,
+                testRunnerClass = "",
+                keepTestTargetsEmpty = false,
+                environmentVariables = mapOf(Pair("coverageFile", "/sdcard/test.ec"))
+            )
+        )
+        assertTrue(testSetup.environmentVariables.any { it.key == "coverageFile" && it.value == "/sdcard/test.ec" })
+    }
+
+    @Test
+    fun `should set env variables and override androidArgs env variables by value from TestConfig variables`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          environment-variables:
+            coverage: true
+            coverageFile: /sdcard/test.ec
+            clearPackageData: true
+        """.trimIndent()
+        val androidArgs = AndroidArgs.load(StringReader(yaml), null)
+
+        val testSetup = TestSetup().setEnvironmentVariables(
+            androidArgs, AndroidTestConfig.Instrumentation(
+                appApkGcsPath = "",
+                testApkGcsPath = "",
+                testShards = emptyList(),
+                orchestratorOption = null,
+                numUniformShards = null,
+                disableSharding = false,
+                testRunnerClass = "",
+                keepTestTargetsEmpty = false,
+                environmentVariables = mapOf(Pair("coverageFile", "/sdcard/test_module1.ec"))
+            )
+        )
+        assertTrue(testSetup.environmentVariables.any { it.key == "coverageFile" && it.value == "/sdcard/test_module1.ec" })
+    }
 }

--- a/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
@@ -11,6 +11,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -215,5 +216,34 @@ class GcAndroidTestMatrixTest {
             )
         )
         assertTrue(testSetup.environmentVariables.any { it.key == "coverageFile" && it.value == "/sdcard/test_module1.ec" })
+    }
+
+    @Test
+    fun `should override env variable value instead of add second with same key`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          environment-variables:
+            coverage: true
+            coverageFile: /sdcard/test.ec
+            clearPackageData: true
+        """.trimIndent()
+        val androidArgs = AndroidArgs.load(StringReader(yaml), null)
+
+        val testSetup = TestSetup().setEnvironmentVariables(
+            androidArgs, AndroidTestConfig.Instrumentation(
+                appApkGcsPath = "",
+                testApkGcsPath = "",
+                testShards = emptyList(),
+                orchestratorOption = null,
+                numUniformShards = null,
+                disableSharding = false,
+                testRunnerClass = "",
+                keepTestTargetsEmpty = false,
+                environmentVariables = mapOf(Pair("coverageFile", "/sdcard/test_module1.ec"))
+            )
+        )
+        assertEquals(1, testSetup.environmentVariables.count { it.key == "coverageFile" })
     }
 }


### PR DESCRIPTION
Fixes #1090 

Doc can be found [here](docs/using_different_environment_variables_in_different_matrices.md)

## Test Plan
> How do we know the code works?

1. Configure test apks with enabled coverage
2. Prepare yaml config for flank like

```
gcloud:
  app: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
  test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-success-debug-androidTest.apk
  environment-variables:
    coverage: true
    coverageFile: /sdcard/main.ec
    clearPackageData: true
  directories-to-pull:
    - /sdcard/
  use-orchestrator: false

flank:
  disable-sharding: false
  max-test-shards: 2
  files-to-download:
    - .*/sdcard/[^/]+\.ec$
  additional-app-test-apks:
    - test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-success-debug-androidTest.apk
      environmentVariables:
        coverageFile: /sdcard/module_1.ec
    - test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-success-debug-androidTest.apk
      environmentVariables:
        coverageFile: /sdcard/module_2.ec
      
```

3. Run flank
4. When flank finished, you should see on the bucket coverages files with different names.

## Checklist

- [X] Documented
- [X] Unit tested
