### PR TITLE
build: Disable IT for iOS

### DIFF
--- a/integration_tests/src/test/kotlin/IntegrationTests.kt
+++ b/integration_tests/src/test/kotlin/IntegrationTests.kt
@@ -1,5 +1,6 @@
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import utils.toStringMap
 
@@ -25,6 +26,7 @@ class IntegrationTests {
         )
     }
 
+    @Ignore("iOS has only physical devices, whit current configuration flank's project hits quota limit extremely fast")
     @Test
     fun shouldMatchIosSuccessExitCodeAndPattern() {
         val testParameters = System.getProperties().toStringMap().toIosParameters()


### PR DESCRIPTION
Currently, iOS has only physical devices. Integration tests are launched at every commit for PR and both combined causes the` flank-open-source` project hits the quota limit extremely fast.
With quota limit exceeded PR automerge is blocked (IT tests are failing - quota limit)
This PR disables IT for iOS.
