### PR TITLE
docs: Update documentation related with test-targets-always-run feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out/
 .gradle/
 test_runner/flank/
 local.properties
+results

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ flank:
   # disable-sharding: false
 
   ## always run - these tests are inserted at the beginning of every shard
-  ## Execution order is not guaranteed by Flank. Users are responsible for configuring their on device test runner logic.
+  ## Execution order is not guaranteed by Flank. Users are responsible for configuring their own device test runner logic.
   # test-targets-always-run:
   #   - className/testName
 
@@ -404,7 +404,7 @@ flank:
   # disable-sharding: false
 
   ## always run - these tests are inserted at the beginning of every shard
-  ## Execution order is not guaranteed by Flank. Users are responsible for configuring their on device test runner logic.
+  ## Execution order is not guaranteed by Flank. Users are responsible for configuring their own device test runner logic.
   # test-targets-always-run:
   #   - class com.example.app.ExampleUiTest#testPasses
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ flank:
   # disable-sharding: false
 
   ## always run - these tests are inserted at the beginning of every shard
-  ## However flank doesn't guarantee tests execution order. It is specific for user's config and FTL internal implementation
+  ## Execution order is not guaranteed by Flank. Users are responsible for configuring their on device test runner logic.
   # test-targets-always-run:
   #   - className/testName
 
@@ -404,7 +404,7 @@ flank:
   # disable-sharding: false
 
   ## always run - these tests are inserted at the beginning of every shard
-    ## However flank doesn't guarantee tests execution order. It is specific for user's config and FTL internal implementation
+  ## Execution order is not guaranteed by Flank. Users are responsible for configuring their on device test runner logic.
   # test-targets-always-run:
   #   - class com.example.app.ExampleUiTest#testPasses
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [docs/error_monitoring.md](./docs/error_monitoring.md) to disable Bugsnag er
 
 ### Contributing
 
-- Install JDK 11 (it works also correctly on previous version, newer version are not guaranteed to works properly):
+- Install JDK 11 (it works also correctly on the previous version, a newer version is not guaranteed to work properly):
   - [Oracle](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
   - [OpenJDK](https://jdk.java.net/11/)
 - Use [JetBrains Toolbox](https://www.jetbrains.com/toolbox/app/) to install `IntelliJ IDEA Community`
@@ -181,7 +181,7 @@ flank:
   # disable-sharding: false
 
   ## always run - these tests are inserted at the beginning of every shard
-  ## useful if you need to grant permissions or login before other tests run
+  ## However flank doesn't guarantee tests execution order. It is specific for user's config and FTL internal implementation
   # test-targets-always-run:
   #   - className/testName
 
@@ -404,7 +404,7 @@ flank:
   # disable-sharding: false
 
   ## always run - these tests are inserted at the beginning of every shard
-  ## useful if you need to grant permissions or login before other tests run
+    ## However flank doesn't guarantee tests execution order. It is specific for user's config and FTL internal implementation
   # test-targets-always-run:
   #   - class com.example.app.ExampleUiTest#testPasses
 

--- a/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
@@ -63,8 +63,8 @@ data class CommonFlankConfig @JsonIgnore constructor(
     @set:CommandLine.Option(
         names = ["--test-targets-always-run"],
         split = ",",
-        description = [
-            "A list of one or more test methods to always run first in every shard."]
+        description = ["A list of one or more test methods to be added at the top of every shard. " +
+            "Flank doesn't ensure execution order of added tests."]
     )
     @set:JsonProperty("test-targets-always-run")
     var testTargetsAlwaysRun: List<String>? by data
@@ -73,9 +73,9 @@ data class CommonFlankConfig @JsonIgnore constructor(
         names = ["--files-to-download"],
         split = ",",
         description = ["A list of paths that will be downloaded from the resulting bucket " +
-                "to the local results folder after the test is complete. These must be absolute paths " +
-                "(for example, --files-to-download /images/tempDir1,/data/local/tmp/tempDir2). " +
-                "Path names are restricted to the characters a-zA-Z0-9_-./+."]
+            "to the local results folder after the test is complete. These must be absolute paths " +
+            "(for example, --files-to-download /images/tempDir1,/data/local/tmp/tempDir2). " +
+            "Path names are restricted to the characters a-zA-Z0-9_-./+."]
     )
     @set:JsonProperty("files-to-download")
     var filesToDownload: List<String>? by data
@@ -83,7 +83,7 @@ data class CommonFlankConfig @JsonIgnore constructor(
     @set:CommandLine.Option(
         names = ["--project"],
         description = ["The Google Cloud Platform project name to use for this invocation. " +
-                "If omitted, then the project from the service account credential is used"]
+            "If omitted, then the project from the service account credential is used"]
     )
     var project: String? by data
 
@@ -111,8 +111,8 @@ data class CommonFlankConfig @JsonIgnore constructor(
     @set:CommandLine.Option(
         names = ["--ignore-failed-tests"],
         description = ["Terminate with exit code 0 when there are failed tests. " +
-                "Useful for Fladle and other gradle plugins that don't expect the process to have a non-zero exit code. " +
-                "The JUnit XML is used to determine failure. (default: false)"]
+            "Useful for Fladle and other gradle plugins that don't expect the process to have a non-zero exit code. " +
+            "The JUnit XML is used to determine failure. (default: false)"]
     )
     @set:JsonProperty("ignore-failed-tests")
     var ignoreFailedTests: Boolean? by data
@@ -120,7 +120,7 @@ data class CommonFlankConfig @JsonIgnore constructor(
     @set:CommandLine.Option(
         names = ["--keep-file-path"],
         description = ["Keeps the full path of downloaded files. " +
-                "Required when file names are not unique."]
+            "Required when file names are not unique."]
     )
     @set:JsonProperty("keep-file-path")
     var keepFilePath: Boolean? by data
@@ -128,9 +128,9 @@ data class CommonFlankConfig @JsonIgnore constructor(
     @set:CommandLine.Option(
         names = ["--output-style"],
         description = ["Output style of execution status. May be one of [verbose, multi, single]. " +
-                "For runs with only one test execution the default value is 'verbose', in other cases " +
-                "'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles " +
-                "which don't support ansi codes, to avoid corrupted output use `single` or `verbose`."]
+            "For runs with only one test execution the default value is 'verbose', in other cases " +
+            "'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles " +
+            "which don't support ansi codes, to avoid corrupted output use `single` or `verbose`."]
     )
     @set:JsonProperty("output-style")
     var outputStyle: String? by data


### PR DESCRIPTION
Fixes #1106 

This PR updates documentation for `test-targets-always-run` feature - test execution order is not guaranteed by flank.
