### PR TITLE
fix: Fix cost report

### DIFF
--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -73,14 +73,16 @@ object AndroidCatalog {
     fun isVirtualDevice(modelId: String, projectId: String): Boolean {
         val form = deviceCatalog(projectId).models
             .find { it.id.equals(modelId, ignoreCase = true) }?.form
-            ?: "PHYSICAL".also { println("Unable to find device type for $modelId. PHYSICAL used as fallback in cost calculations") }
+            ?: DeviceType.PHYSICAL.name.also {
+                println("Unable to find device type for $modelId. PHYSICAL used as fallback in cost calculations")
+            }
 
-        return form.equals("VIRTUAL", ignoreCase = true)
+        return form.equals(DeviceType.VIRTUAL.name, ignoreCase = true)
     }
+}
 
-    fun deviceType(modelId: String, projectId: String) =
-        if (isVirtualDevice(modelId, projectId)) "VIRTUAL"
-        else "PHYSICAL"
+enum class DeviceType {
+    VIRTUAL, PHYSICAL
 }
 
 sealed class DeviceConfigCheck

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -71,7 +71,10 @@ object AndroidCatalog {
         ?: false
 
     fun isVirtualDevice(modelId: String, projectId: String): Boolean {
-        val form = deviceCatalog(projectId).models.find { it.id.equals(modelId, ignoreCase = true) }?.form ?: "PHYSICAL"
+        val form = deviceCatalog(projectId).models
+            .find { it.id.equals(modelId, ignoreCase = true) }?.form
+            ?: "PHYSICAL".also { println("Unable to find device type for $modelId. PHYSICAL used as fallback in cost calculations") }
+
         return form.equals("VIRTUAL", ignoreCase = true)
     }
 

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -65,12 +65,19 @@ object AndroidCatalog {
         return SupportedDeviceConfig
     }
 
-    fun isVirtualDevice(device: AndroidDevice?, projectId: String): Boolean = device?.androidModelId?.let { isVirtualDevice(it, projectId) } ?: false
+    fun isVirtualDevice(device: AndroidDevice?, projectId: String): Boolean = device
+        ?.androidModelId
+        ?.let { isVirtualDevice(it, projectId) }
+        ?: false
 
     fun isVirtualDevice(modelId: String, projectId: String): Boolean {
-        val form = deviceCatalog(projectId).models.find { it.id == modelId }?.form ?: "PHYSICAL"
-        return form == "VIRTUAL"
+        val form = deviceCatalog(projectId).models.find { it.id.equals(modelId, ignoreCase = true) }?.form ?: "PHYSICAL"
+        return form.equals("VIRTUAL", ignoreCase = true)
     }
+
+    fun deviceType(modelId: String, projectId: String) =
+        if (isVirtualDevice(modelId, projectId)) "VIRTUAL"
+        else "PHYSICAL"
 }
 
 sealed class DeviceConfigCheck

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/BillableMinutes.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/BillableMinutes.kt
@@ -2,6 +2,7 @@ package ftl.reports.outcome
 
 import com.google.api.services.toolresults.model.Step
 import ftl.android.AndroidCatalog
+import ftl.android.DeviceType
 import ftl.environment.orUnknown
 import ftl.util.billableMinutes
 import kotlin.math.min
@@ -31,10 +32,6 @@ private fun Step.getBillableSeconds(default: Long) =
     testExecutionStep?.testTiming?.testProcessDuration?.seconds?.let {
         min(it, default)
     }
-
-private enum class DeviceType {
-    VIRTUAL, PHYSICAL
-}
 
 private fun deviceType(modelId: String, projectId: String) =
     if (AndroidCatalog.isVirtualDevice(modelId, projectId)) DeviceType.VIRTUAL

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/BillableMinutes.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/BillableMinutes.kt
@@ -2,6 +2,7 @@ package ftl.reports.outcome
 
 import com.google.api.services.toolresults.model.Step
 import ftl.android.AndroidCatalog
+import ftl.environment.orUnknown
 import ftl.util.billableMinutes
 import kotlin.math.min
 
@@ -16,25 +17,24 @@ fun List<Step>.calculateAndroidBillableMinutes(
 ): BillableMinutes =
     groupByDeviceType(projectId).run {
         BillableMinutes(
-            virtual = get(true)?.sumBillableMinutes(timeoutValue) ?: 0,
-            physical = get(false)?.sumBillableMinutes(timeoutValue) ?: 0
+            virtual = get("VIRTUAL")?.sumBillableMinutes(timeoutValue) ?: 0,
+            physical = get("PHYSICAL")?.sumBillableMinutes(timeoutValue) ?: 0
         )
     }
+private fun Step.deviceModel() = dimensionValue.find { it.key.equals("Model", ignoreCase = true) }?.value.orUnknown()
 
 private fun List<Step>.groupByDeviceType(projectId: String) =
     groupBy {
-        AndroidCatalog.isVirtualDevice(
-            it.axisValue(),
+        AndroidCatalog.deviceType(
+            it.deviceModel(),
             projectId
         )
     }
 
-private fun List<Step>.sumBillableMinutes(timeout: Long) =
-    mapNotNull { step ->
-        step.getBillableSeconds(default = timeout)
-    }.map {
-        billableMinutes(it)
-    }.sum()
+private fun List<Step>.sumBillableMinutes(timeout: Long) = this
+    .mapNotNull { it.getBillableSeconds(default = timeout) }
+    .map { billableMinutes(it) }
+    .sum()
 
 private fun Step.getBillableSeconds(default: Long) =
     testExecutionStep?.testTiming?.testProcessDuration?.seconds?.let {

--- a/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
@@ -2,6 +2,7 @@ package ftl.reports.outcome
 
 import com.google.api.services.testing.model.AndroidModel
 import com.google.api.services.toolresults.model.Step
+import ftl.android.DeviceType
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 import io.mockk.every
@@ -21,10 +22,10 @@ class BillableMinutesTest {
     val output: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
 
     private val androidModels = listOf<AndroidModel>(
-        make { id = "NexusLowRes"; form = "VIRTUAL" },
-        make { id = "Nexus5"; form = "VIRTUAL" },
-        make { id = "g3"; form = "PHYSICAL" },
-        make { id = "sailfish"; form = "PHYSICAL" }
+        make { id = "NexusLowRes"; form = DeviceType.VIRTUAL.name },
+        make { id = "Nexus5"; form = DeviceType.VIRTUAL.name },
+        make { id = "g3"; form = DeviceType.PHYSICAL.name },
+        make { id = "sailfish"; form = DeviceType.PHYSICAL.name }
     )
 
     @Before

--- a/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
@@ -1,0 +1,116 @@
+package ftl.reports.outcome
+
+import com.google.api.services.testing.model.AndroidModel
+import com.google.api.services.toolresults.model.Step
+import ftl.gc.GcTesting
+import ftl.http.executeWithRetry
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class BillableMinutesTest {
+
+    private val androidModels = listOf<AndroidModel>(
+        make { id = "NexusLowRes"; form = "VIRTUAL" },
+        make { id = "Nexus5"; form = "VIRTUAL" },
+        make { id = "g3"; form = "PHYSICAL" },
+        make { id = "sailfish"; form = "PHYSICAL" }
+    )
+
+    @Before
+    fun setUp() {
+        mockkObject(GcTesting)
+        every {
+            GcTesting
+                .get
+                .testEnvironmentCatalog()
+                .get(any())
+                .setProjectId(any())
+                .executeWithRetry()
+        } returns make {
+            androidDeviceCatalog = make { models = androidModels }
+        }
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `should return billing for virtual device only`() {
+        val expected = 1L
+        val step: Step = makeStep()
+
+        val minutes = listOf(step).calculateAndroidBillableMinutes(projectId = "anyId", timeoutValue = 1000L)
+
+        verifyBilling(minutes, expectedVirtual = expected)
+    }
+
+    @Test
+    fun `should return billing for physical devices only`() {
+        val expected = 1L
+        val step: Step = makeStep(model = "g3")
+
+        val minutes = listOf(step).calculateAndroidBillableMinutes(projectId = "anyId", timeoutValue = 1000L)
+
+        verifyBilling(minutes, expectedPhysical = expected)
+    }
+
+    @Test
+    fun `should return mixed billing`() {
+        val expectedVirtual = 3L
+        val expectedPhysical = 5L
+        val step1: Step = makeStep(model = "nexuslowres", duration = 123)
+        val step2: Step = makeStep(model = "SaIlFisH", duration = 245)
+
+        val minutes = listOf(step1, step2).calculateAndroidBillableMinutes(projectId = "anyId", timeoutValue = 1000L)
+
+        verifyBilling(minutes, expectedVirtual, expectedPhysical)
+    }
+
+    @Test
+    fun `should return multiple mixed billing`() {
+        val expectedVirtual = 9L
+        val expectedPhysical = 16L
+        val step1: Step = makeStep(model = "Nexus5", duration = 123)
+        val step2: Step = makeStep(model = "SaIlFisH", duration = 245)
+        val step3: Step = makeStep(model = "NEXUSLOWRES", duration = 352)
+        val step4: Step = makeStep(model = "G3", duration = 657)
+
+        val minutes = listOf(step1, step2, step3, step4).calculateAndroidBillableMinutes(projectId = "anyId", timeoutValue = 1000L)
+
+        verifyBilling(minutes, expectedVirtual, expectedPhysical)
+    }
+
+    @Test
+    fun `should return multiple mixed billing - timeouted`() {
+        val timeout = 120L
+        val expectedVirtual = 3L
+        val expectedPhysical = 4L
+        val step1: Step = makeStep(model = "Nexus5", duration = 23)
+        val step2: Step = makeStep(model = "SaIlFisH", duration = 245)
+        val step3: Step = makeStep(model = "NEXUSLOWRES", duration = 352)
+        val step4: Step = makeStep(model = "G3", duration = 657)
+
+        val minutes = listOf(step1, step2, step3, step4).calculateAndroidBillableMinutes(projectId = "anyId", timeoutValue = timeout)
+
+        verifyBilling(minutes, expectedVirtual, expectedPhysical)
+    }
+}
+
+private fun makeStep(model: String = "NexusLowRes", duration: Long = 15L): Step = make {
+    dimensionValue = listOf(make { key = "Model"; value = model })
+    testExecutionStep = make {
+        testTiming = make {
+            testProcessDuration = make { seconds = duration }
+        }
+    }
+}
+
+private fun verifyBilling(billing: BillableMinutes, expectedVirtual: Long = 0, expectedPhysical: Long = 0) {
+    assertEquals("Physical devices minutes should be $expectedPhysical", expectedPhysical, billing.physical)
+    assertEquals("Virtual devices minutes should be $expectedVirtual", expectedVirtual, billing.virtual)
+}

--- a/test_runner/src/test/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummaryKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummaryKtTest.kt
@@ -123,4 +123,4 @@ class CreateMatrixOutcomeSummaryKtTest {
     }
 }
 
-private inline fun <reified T : Any> make(block: T.() -> Unit = {}): T = T::class.createInstance().apply(block)
+internal inline fun <reified T : Any> make(block: T.() -> Unit = {}): T = T::class.createInstance().apply(block)


### PR DESCRIPTION
Fixes #1135 
Due to an incorrect device model check, all android models were considered as physical ones.

## Test Plan
> How do we know the code works?

1) Start test run for any virtual device, observe cost report calculated for virtual device
2) Start test run for both, virtual and physical device, observe cost report consists of a section for physical and virtual devices

## Checklist

- [x] Unit tested
