### PR TITLE
ci: Fix test artifacts url

### DIFF
--- a/test_runner/src/main/kotlin/ftl/mock/TestArtifact.kt
+++ b/test_runner/src/main/kotlin/ftl/mock/TestArtifact.kt
@@ -51,7 +51,7 @@ object TestArtifact {
     }
 
     private fun getHtml(): Document {
-        val githubUrl = "https://github.com/Flank/test_artifacts/releases/latest"
+        val githubUrl = "https://github.com/Flank/test_artifacts/releases/tag/latest"
         val maxRetries = 6
         repeat(maxRetries) { attempt ->
             try {


### PR DESCRIPTION
This is fast fix for broken test artifacts url that causes test fails on CI

## Test Plan
> How do we know the code works?

Test artifacts should be downloaded correctly on CI when [test_artifacts](https://github.com/Flank/test_artifacts) repo contains more than one release.

