### PR TITLE
feat: Improve error message on matrix failures

### DIFF
--- a/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
+++ b/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
@@ -1,7 +1,12 @@
 package ftl.json
 
 import com.google.api.services.testing.model.TestMatrix
-import ftl.run.exception.*
+import ftl.run.exception.FTLError
+import ftl.run.exception.FailedMatrixError
+import ftl.run.exception.IncompatibleTestDimensionError
+import ftl.run.exception.InfrastructureError
+import ftl.run.exception.MatrixCanceledError
+import ftl.run.exception.MatrixValidationError
 import ftl.util.MatrixState
 
 data class MatrixMap(val map: Map<String, SavedMatrix>, val runPath: String) {

--- a/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
+++ b/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
@@ -3,7 +3,6 @@ package ftl.json
 import com.google.api.services.testing.model.TestMatrix
 import ftl.run.exception.*
 import ftl.util.MatrixState
-import ftl.util.MatrixState.INVALID
 
 data class MatrixMap(val map: Map<String, SavedMatrix>, val runPath: String) {
     private val mutableMap
@@ -46,10 +45,10 @@ fun Iterable<TestMatrix>.updateMatrixMap(matrixMap: MatrixMap) = forEach { matri
 
 fun MatrixMap.validate(shouldIgnore: Boolean = false) {
     map.values.run {
-        firstOrNull { it.canceledByUser() }?.run { throw MatrixCanceledError(errorMessage()) }
-        firstOrNull { it.infrastructureFail() }?.run { throw InfrastructureError(errorMessage()) }
-        firstOrNull { it.incompatibleFail() }?.run { throw IncompatibleTestDimensionError(errorMessage()) }
-        firstOrNull { it.invalid() }?.run { throw ValidationError(errorMessage()) }
+        firstOrNull { it.canceledByUser() }?.run { throw MatrixCanceledError(outcomeDetails) }
+        firstOrNull { it.infrastructureFail() }?.run { throw InfrastructureError(outcomeDetails) }
+        firstOrNull { it.incompatibleFail() }?.run { throw IncompatibleTestDimensionError(outcomeDetails) }
+        firstOrNull { it.invalid() }?.run { throw MatrixValidationError(errorMessage()) }
         firstOrNull { it.state != MatrixState.FINISHED }?.let { throw FTLError(it) }
         filter { it.isFailed() }.let {
             if (it.isNotEmpty()) throw FailedMatrixError(

--- a/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
+++ b/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
@@ -1,6 +1,9 @@
 package ftl.json
 
 import com.google.api.services.testing.model.TestMatrix
+import com.google.common.annotations.VisibleForTesting
+import ftl.environment.orUnknown
+import ftl.reports.outcome.getOutcomeMessageByKey
 import ftl.run.exception.FTLError
 import ftl.run.exception.FailedMatrixError
 import ftl.run.exception.IncompatibleTestDimensionError
@@ -65,3 +68,6 @@ fun MatrixMap.validate(shouldIgnore: Boolean = false) {
 }
 
 private val SavedMatrix.outcomeDetails get() = testAxises.firstOrNull()?.details.orEmpty()
+
+@VisibleForTesting
+internal fun SavedMatrix.errorMessage() = "Matrix: [$matrixId] failed: ".plus(getOutcomeMessageByKey(testAxises.firstOrNull()?.details.orUnknown()))

--- a/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
+++ b/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
@@ -1,7 +1,6 @@
 package ftl.json
 
 import com.google.api.services.testing.model.TestMatrix
-import com.google.common.annotations.VisibleForTesting
 import ftl.environment.orUnknown
 import ftl.reports.outcome.getOutcomeMessageByKey
 import ftl.run.exception.FTLError
@@ -69,5 +68,4 @@ fun MatrixMap.validate(shouldIgnore: Boolean = false) {
 
 private val SavedMatrix.outcomeDetails get() = testAxises.firstOrNull()?.details.orEmpty()
 
-@VisibleForTesting
-internal fun SavedMatrix.errorMessage() = "Matrix: [$matrixId] failed: ".plus(getOutcomeMessageByKey(testAxises.firstOrNull()?.details.orUnknown()))
+private fun SavedMatrix.errorMessage() = "Matrix: [$matrixId] failed: ".plus(getOutcomeMessageByKey(testAxises.firstOrNull()?.details.orUnknown()))

--- a/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
@@ -6,7 +6,6 @@ import ftl.reports.outcome.BillableMinutes
 import ftl.reports.outcome.TestOutcome
 import ftl.reports.outcome.createMatrixOutcomeSummary
 import ftl.reports.outcome.fetchTestOutcomeContext
-import ftl.reports.outcome.getOutcomeMessageByKey
 import ftl.util.MatrixState.FINISHED
 import ftl.util.MatrixState.INVALID
 import ftl.util.StepOutcome
@@ -113,5 +112,3 @@ private fun TestMatrix.invalidTestOutcome() = TestOutcome(
     outcome = INVALID,
     details = invalidMatrixDetails.orUnknown()
 )
-
-fun SavedMatrix.errorMessage() = "Matrix: [$matrixId] failed: ".plus(getOutcomeMessageByKey(testAxises.firstOrNull()?.details.orUnknown()))

--- a/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
@@ -1,6 +1,7 @@
 package ftl.json
 
 import com.google.api.services.testing.model.TestMatrix
+import ftl.environment.orUnknown
 import ftl.reports.outcome.*
 import ftl.util.MatrixState.FINISHED
 import ftl.util.MatrixState.INVALID
@@ -106,8 +107,7 @@ private fun SavedMatrix.updateOutcome(outcome: List<TestOutcome>) = copy(
 
 private fun TestMatrix.invalidTestOutcome() = TestOutcome(
     outcome = INVALID,
-//    details = "Matrix: $testMatrixId failed, reason: ${invalidMatrixDetails.orEmpty()}"
-    details = invalidMatrixDetails.orEmpty()
+    details = invalidMatrixDetails.orUnknown()
 )
 
-fun SavedMatrix.errorMessage() = getOutcomeMessageByKey(testAxises.firstOrNull()?.details.orEmpty())
+fun SavedMatrix.errorMessage() = "Matrix: [$matrixId] failed: ".plus(getOutcomeMessageByKey(testAxises.firstOrNull()?.details.orUnknown()))

--- a/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
@@ -2,7 +2,11 @@ package ftl.json
 
 import com.google.api.services.testing.model.TestMatrix
 import ftl.environment.orUnknown
-import ftl.reports.outcome.*
+import ftl.reports.outcome.BillableMinutes
+import ftl.reports.outcome.TestOutcome
+import ftl.reports.outcome.createMatrixOutcomeSummary
+import ftl.reports.outcome.fetchTestOutcomeContext
+import ftl.reports.outcome.getOutcomeMessageByKey
 import ftl.util.MatrixState.FINISHED
 import ftl.util.MatrixState.INVALID
 import ftl.util.StepOutcome

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/OutcomeMessageEnum.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/OutcomeMessageEnum.kt
@@ -5,40 +5,53 @@ enum class OutcomeMessageEnum(val message: String) {
     MALFORMED_TEST_APK("The test APK is not a valid Android instrumentation test"),
     NO_MANIFEST("The app APK is missing the manifest file"),
     NO_PACKAGE_NAME("The APK manifest file is missing the package name"),
-    NO_SIGNATURE("The test APK has the same package name as the app APK"),
-    INSTRUMENTATION_ORCHESTRATOR_INCOMPATIBLE("The test APK declares no instrumentation tags in the manifest"),
-    NO_TEST_RUNNER_CLASS("The test APK does not contain the test runner class specified by " +
+    TEST_SAME_AS_APP("The test APK has the same package name as the app APK"),
+    NO_INSTRUMENTATION("The test APK declares no instrumentation tags in the manifest"),
+    NO_SIGNATURE("At least one supplied APK file has a missing or invalid signature"),
+    INSTRUMENTATION_ORCHESTRATOR_INCOMPATIBLE(
+        "The test runner class specified by the user or the test APK's " +
+            "manifest file is not compatible with Android Test Orchestrator. " +
+            "Please use AndroidJUnitRunner version 1.0 or higher"),
+    NO_TEST_RUNNER_CLASS
+    ("The test APK does not contain the test runner class specified by " +
         "the user or the manifest file. The test runner class name may be " +
         "incorrect, or the class may be mislocated in the app APK."),
-    NO_LAUNCHER_ACTIVITY(
-        "The app APK does not specify a main launcher activity"
-    ),
+    NO_LAUNCHER_ACTIVITY("The app APK does not specify a main launcher activity"),
     FORBIDDEN_PERMISSIONS("The app declares one or more permissions that are not allowed"),
     INVALID_ROBO_DIRECTIVES("Cannot have multiple robo-directives with the same resource name"),
     INVALID_DIRECTIVE_ACTION("Robo Directive includes at least one invalid action definition."),
-    INVALID_RESOURCE_NAME(" 'Robo Directive resource name contains invalid characters: ' (colon) or \" (space)',"),
+    INVALID_RESOURCE_NAME("Robo Directive resource name contains invalid characters( ' (colon), or \" \" (space)"),
     TEST_LOOP_INTENT_FILTER_NOT_FOUND("The app does not have a correctly formatted game-loop intent filter"),
     SCENARIO_LABEL_NOT_DECLARED("A scenario-label was not declared in the manifest file"),
     SCENARIO_LABEL_MALFORMED("A scenario-label in the manifest includes invalid numbers or ranges"),
     SCENARIO_NOT_DECLARED("A scenario-number was not declared in the manifest file"),
     DEVICE_ADMIN_RECEIVER("Device administrator applications are not allowed"),
-    MALFORMED_XC_TEST_ZIP("The XCTest zip file was malformed. The zip did not contain a single .xctestrun file and the contents of the DerivedData/Build/Products directory."),
+    MALFORMED_XC_TEST_ZIP(
+        "The XCTest zip file was malformed. The zip did not contain a single " +
+            ".xctestrun file and the contents of the DerivedData/Build/Products " +
+            "directory."),
     BUILT_FOR_IOS_SIMULATOR("The provided XCTest was built for the iOS simulator rather than for a physical device"),
     NO_TESTS_IN_XC_TEST_ZIP("The .xctestrun file did not specify any test targets to run"),
-    USE_DESTINATION_ARTIFACTS("'One or more of the test targets defined in the .xctestrun file specifies \"UseDestinationArtifacts\", which is not allowed"),
-    TEST_NOT_APP_HOSTED("'One or more of the test targets defined in the .xctestrun file does not have a host binary to run on the physical iOS device, which may cause errors when running xcodebuild"),
+    USE_DESTINATION_ARTIFACTS(
+        "One or more of the test targets defined in the .xctestrun file " +
+            "specifies \"UseDestinationArtifacts\"), which is not allowed"),
+    TEST_NOT_APP_HOSTED(
+        "One or more of the test targets defined in the .xctestrun file " +
+            "does not have a host binary to run on the physical iOS device), " +
+            "which may cause errors when running xcodebuild"),
     NO_CODE_APK("\"hasCode\" is false in the Manifest. Tested APKs must contain code"),
     INVALID_INPUT_APK("Either the provided input APK path was malformed, the APK file does not exist, or the user does not have permission to access the file"),
     INVALID_APK_PREVIEW_SDK("Your app targets a preview version of the Android SDK that's incompatible with the selected devices."),
     PLIST_CANNOT_BE_PARSED("One or more of the Info.plist files in the zip could not be parsed"),
-    INVALID_PACKAGE_NAME("The APK application ID (aka package name) is invalid. See also https://developer.android.com/studio/build/application-id"),
+    INVALID_PACKAGE_NAME("The APK application ID (aka package name), is invalid. See also https(//developer.android.com/studio/build/application-id"),
     MALFORMED_IPA("The app IPA is not a valid iOS application"),
     MISSING_URL_SCHEME("The iOS game loop application does not register the custom URL scheme"),
-    MALFORMED_APP_BUNDLE("The iOS application bundle (.app) is invalid")
+    MALFORMED_APP_BUNDLE("The iOS application bundle (.app), is invalid"),
+    UNKNOWN("Unknown error")
 }
 
 fun getOutcomeMessageByKey(key: String) = try {
     OutcomeMessageEnum.valueOf(key).message
-}catch (error: IllegalArgumentException){
+} catch (error: IllegalArgumentException) {
     "UNKNOWN"
 }

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/OutcomeMessageEnum.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/OutcomeMessageEnum.kt
@@ -1,0 +1,44 @@
+package ftl.reports.outcome
+
+enum class OutcomeMessageEnum(val message: String) {
+    MALFORMED_APK("The app APK is not a valid Android application"),
+    MALFORMED_TEST_APK("The test APK is not a valid Android instrumentation test"),
+    NO_MANIFEST("The app APK is missing the manifest file"),
+    NO_PACKAGE_NAME("The APK manifest file is missing the package name"),
+    NO_SIGNATURE("The test APK has the same package name as the app APK"),
+    INSTRUMENTATION_ORCHESTRATOR_INCOMPATIBLE("The test APK declares no instrumentation tags in the manifest"),
+    NO_TEST_RUNNER_CLASS("The test APK does not contain the test runner class specified by " +
+        "the user or the manifest file. The test runner class name may be " +
+        "incorrect, or the class may be mislocated in the app APK."),
+    NO_LAUNCHER_ACTIVITY(
+        "The app APK does not specify a main launcher activity"
+    ),
+    FORBIDDEN_PERMISSIONS("The app declares one or more permissions that are not allowed"),
+    INVALID_ROBO_DIRECTIVES("Cannot have multiple robo-directives with the same resource name"),
+    INVALID_DIRECTIVE_ACTION("Robo Directive includes at least one invalid action definition."),
+    INVALID_RESOURCE_NAME(" 'Robo Directive resource name contains invalid characters: ' (colon) or \" (space)',"),
+    TEST_LOOP_INTENT_FILTER_NOT_FOUND("The app does not have a correctly formatted game-loop intent filter"),
+    SCENARIO_LABEL_NOT_DECLARED("A scenario-label was not declared in the manifest file"),
+    SCENARIO_LABEL_MALFORMED("A scenario-label in the manifest includes invalid numbers or ranges"),
+    SCENARIO_NOT_DECLARED("A scenario-number was not declared in the manifest file"),
+    DEVICE_ADMIN_RECEIVER("Device administrator applications are not allowed"),
+    MALFORMED_XC_TEST_ZIP("The XCTest zip file was malformed. The zip did not contain a single .xctestrun file and the contents of the DerivedData/Build/Products directory."),
+    BUILT_FOR_IOS_SIMULATOR("The provided XCTest was built for the iOS simulator rather than for a physical device"),
+    NO_TESTS_IN_XC_TEST_ZIP("The .xctestrun file did not specify any test targets to run"),
+    USE_DESTINATION_ARTIFACTS("'One or more of the test targets defined in the .xctestrun file specifies \"UseDestinationArtifacts\", which is not allowed"),
+    TEST_NOT_APP_HOSTED("'One or more of the test targets defined in the .xctestrun file does not have a host binary to run on the physical iOS device, which may cause errors when running xcodebuild"),
+    NO_CODE_APK("\"hasCode\" is false in the Manifest. Tested APKs must contain code"),
+    INVALID_INPUT_APK("Either the provided input APK path was malformed, the APK file does not exist, or the user does not have permission to access the file"),
+    INVALID_APK_PREVIEW_SDK("Your app targets a preview version of the Android SDK that's incompatible with the selected devices."),
+    PLIST_CANNOT_BE_PARSED("One or more of the Info.plist files in the zip could not be parsed"),
+    INVALID_PACKAGE_NAME("The APK application ID (aka package name) is invalid. See also https://developer.android.com/studio/build/application-id"),
+    MALFORMED_IPA("The app IPA is not a valid iOS application"),
+    MISSING_URL_SCHEME("The iOS game loop application does not register the custom URL scheme"),
+    MALFORMED_APP_BUNDLE("The iOS application bundle (.app) is invalid")
+}
+
+fun getOutcomeMessageByKey(key: String) = try {
+    OutcomeMessageEnum.valueOf(key).message
+}catch (error: IllegalArgumentException){
+    "UNKNOWN"
+}

--- a/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
+++ b/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
@@ -53,6 +53,7 @@ fun withGlobalExceptionHandling(block: () -> Int) {
                 exitProcess(UNEXPECTED_ERROR)
             }
 
+            is MatrixValidationError,
             is YmlValidationError,
             is FlankConfigurationError -> {
                 printError(t.message)

--- a/test_runner/src/main/kotlin/ftl/run/exception/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/run/exception/FlankException.kt
@@ -90,6 +90,16 @@ class ProjectNotFound(exc: IOException) : FTLProjectError(exc)
  */
 class IncompatibleTestDimensionError(message: String) : FlankException(message)
 
+
+/**
+ * The test environment for this test execution is not supported because of incompatible test dimensions. This error might occur if the selected Android API level is not supported by the selected device type.
+ *
+ * Exit code: 18
+ *
+ * @param message [String] message to be printed to [System.err]
+ */
+class ValidationError(message: String) : FlankException(message)
+
 /**
  * The test matrix was canceled by the user.
  *

--- a/test_runner/src/main/kotlin/ftl/run/exception/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/run/exception/FlankException.kt
@@ -90,7 +90,6 @@ class ProjectNotFound(exc: IOException) : FTLProjectError(exc)
  */
 class IncompatibleTestDimensionError(message: String) : FlankException(message)
 
-
 /**
  * The test environment for this test execution is not supported because of incompatible test dimensions. This error might occur if the selected Android API level is not supported by the selected device type.
  *

--- a/test_runner/src/main/kotlin/ftl/run/exception/FlankException.kt
+++ b/test_runner/src/main/kotlin/ftl/run/exception/FlankException.kt
@@ -98,7 +98,7 @@ class IncompatibleTestDimensionError(message: String) : FlankException(message)
  *
  * @param message [String] message to be printed to [System.err]
  */
-class ValidationError(message: String) : FlankException(message)
+class MatrixValidationError(message: String) : FlankException(message)
 
 /**
  * The test matrix was canceled by the user.

--- a/test_runner/src/test/kotlin/ftl/json/MatrixMapTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/MatrixMapTest.kt
@@ -4,7 +4,9 @@ import com.google.common.truth.Truth.assertThat
 import ftl.json.SavedMatrixTest.Companion.createResultsStorage
 import ftl.json.SavedMatrixTest.Companion.createStepExecution
 import ftl.json.SavedMatrixTest.Companion.testMatrix
+import ftl.run.exception.MatrixValidationError
 import ftl.test.util.FlankTestRunner
+import ftl.test.util.assertThrowsWithMessage
 import ftl.util.MatrixState
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,5 +48,19 @@ class MatrixMapTest {
         val matrixMap = MatrixMap(mutableMapOf("a" to failureMatrix, "b" to successMatrix), "")
 
         assertThat(matrixMap.isAllSuccessful()).isFalse()
+    }
+
+    @Test
+    fun `invalid matrix should contains specyfic error message`() {
+        val testMatrix = testMatrix()
+        testMatrix.testMatrixId = "123"
+        testMatrix.state = MatrixState.INVALID
+
+        val savedMatrix = createSavedMatrix(testMatrix)
+
+        val expectedErrorMessage = "Matrix: [${testMatrix.testMatrixId}] failed: Unknown error"
+        assertThrowsWithMessage(MatrixValidationError::class, expectedErrorMessage) {
+            MatrixMap(mapOf(savedMatrix.matrixId to savedMatrix), "").validate()
+        }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
@@ -10,9 +10,7 @@ import com.google.api.services.testing.model.ToolResultsStep
 import com.google.common.truth.Truth.assertThat
 import ftl.config.Device
 import ftl.gc.GcAndroidDevice
-import ftl.run.exception.MatrixValidationError
 import ftl.test.util.FlankTestRunner
-import ftl.test.util.assertThrowsWithMessage
 import ftl.util.MatrixState.FINISHED
 import ftl.util.MatrixState.INVALID
 import ftl.util.MatrixState.PENDING

--- a/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
@@ -183,8 +183,8 @@ class SavedMatrixTest {
 
     @Test
     fun `savedMatrix should have outcome and outcome details properly filled when state is INVALID`() {
-        val expectedOutcome = "---"
-        val expectedOutcomeDetails = "Matrix is invalid"
+        val expectedOutcome = "INVALID"
+        val expectedOutcomeDetails = "UNKNOWN"
         val testMatrix = testMatrix()
         testMatrix.testMatrixId = "123"
         testMatrix.state = PENDING

--- a/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
@@ -197,6 +197,7 @@ class SavedMatrixTest {
         assertEquals(expectedOutcome, savedMatrix.outcome)
         assertEquals(expectedOutcomeDetails, savedMatrix.testAxises.first().details)
         assertEquals(INVALID, savedMatrix.state)
+        assertEquals("Matrix: [${testMatrix.testMatrixId}] failed: Unknown error", savedMatrix.errorMessage())
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
@@ -10,7 +10,9 @@ import com.google.api.services.testing.model.ToolResultsStep
 import com.google.common.truth.Truth.assertThat
 import ftl.config.Device
 import ftl.gc.GcAndroidDevice
+import ftl.run.exception.MatrixValidationError
 import ftl.test.util.FlankTestRunner
+import ftl.test.util.assertThrowsWithMessage
 import ftl.util.MatrixState.FINISHED
 import ftl.util.MatrixState.INVALID
 import ftl.util.MatrixState.PENDING
@@ -197,7 +199,6 @@ class SavedMatrixTest {
         assertEquals(expectedOutcome, savedMatrix.outcome)
         assertEquals(expectedOutcomeDetails, savedMatrix.testAxises.first().details)
         assertEquals(INVALID, savedMatrix.state)
-        assertEquals("Matrix: [${testMatrix.testMatrixId}] failed: Unknown error", savedMatrix.errorMessage())
     }
 
     @Test


### PR DESCRIPTION
Fixes #1155 

## Test Plan
> How do we know the code works?

In command line
1. go to test_project dir
2. run ```./gradlew assembleRelease```
3 run flank with unsigned apk
```
gcloud:
  app: ./test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-release-unsigned.apk
  test: ./test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk

flank:
  disable-sharding: true
```
4. flank should return user-friendly message reflecting gcloud cli message
Example:
```
┌─────────┬──────────────────────┬─────────────────┬──────────────┐
│ OUTCOME │      MATRIX ID       │ TEST AXIS VALUE │ TEST DETAILS │
├─────────┼──────────────────────┼─────────────────┼──────────────┤
│ INVALID │ matrix-1qa9ad1v8gswc │                 │ NO_SIGNATURE │
└─────────┴──────────────────────┴─────────────────┴──────────────┘
More details are available at:


  Uploading MatrixResultsReport.txt .
  Uploading JUnitReport.xml .

Matrices webLink
  matrix-1qa9ad1v8gswc Unable to get web link

Matrix: [matrix-1qa9ad1v8gswc] failed: At least one supplied APK file has a missing or invalid signature

Process finished with exit code 2

```

## Checklist

- [X] Unit tested
