### PR TITLE
fix: release notes slack tweaks

### DIFF
--- a/flank-actions/Dockerfile
+++ b/flank-actions/Dockerfile
@@ -17,6 +17,8 @@ RUN chmod +x /compile.sh
 
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && /compile.sh"
 
+COPY entrypoint.sh /entrypoint.sh
+
 RUN chmod +x /entrypoint.sh
 
 RUN chmod +x /sendMessage

--- a/flank-actions/entrypoint.sh
+++ b/flank-actions/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
-echo 'Sending message'
-./sendMessage $INPUT_XOXCTOKEN $INPUT_MESSAGE $INPUT_CHANNEL $INPUT_COOKIE
+echo 'Attempting to sendMessage'
+cd /
+./sendMessage "$INPUT_XOXCTOKEN" "$INPUT_CHANNEL" "$INPUT_MESSAGE" "$INPUT_COOKIE"
+
 echo 'Sending message done!'

--- a/flank-actions/slackService.kt
+++ b/flank-actions/slackService.kt
@@ -17,7 +17,6 @@ fun sendMessage(args: Array<String>): Int{
         Common.EXIT_CODE_SUCCESS
     }
     catch(e: Exception) {
-        error("Error has occured: $e")
         Common.EXIT_CODE_FAILURE
     }
 }

--- a/flank-actions/slackService.kt
+++ b/flank-actions/slackService.kt
@@ -6,7 +6,7 @@ fun sendMessage(args: Array<String>): Int{
     val token = args[Common.ARGS_TOKEN]
     val channel = args[Common.ARGS_CHANNEL]
     val message = args[Common.ARGS_MESSAGE]
-    val cookie = args.copyOfRange(Common.ARGS_COOKIE, args.lastIndex).joinToString(" ")
+    val cookie = args[Common.ARGS_COOKIE]
 
     return try {
         val (req, rep, res) = Fuel.get(Common.URL_SLACK, 
@@ -14,19 +14,10 @@ fun sendMessage(args: Array<String>): Int{
             .header(Headers.COOKIE to cookie)
             .responseString()
 
-        debug("Result: $res")
         Common.EXIT_CODE_SUCCESS
     }
     catch(e: Exception) {
         error("Error has occured: $e")
         Common.EXIT_CODE_FAILURE
     }
-}
-
-fun debug(message: String){
-    println("::debug::$message")
-}
-
-fun error(message: String) {
-    println("::error::$message")
 }


### PR DESCRIPTION
Fixes #1156 
The release notes were having AUTH issues. Fixed it as bash in GitHub actions was splitting the incoming cookie into multiple args instead of one. 

It is very difficult to test as it requires a full release.

Need to release this to the marketplace and then do another pull request to fix the action.