### PR TITLE
feat: Dump shards and upload on every run

### DIFF
--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -5,6 +5,7 @@ import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyAndroidConfig
+import ftl.gc.GcStorage
 import ftl.mock.MockServer
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.dumpShards
@@ -47,7 +48,12 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         val config = AndroidArgs.load(Paths.get(configPath), cli = this).validate()
         runBlocking {
             if (dumpShards) dumpShards(args = config, obfuscatedOutput = obfuscate)
-            else newTestRun(config, obfuscate)
+            else {
+                dumpShards(args = config, obfuscatedOutput = obfuscate)
+                if (config.disableResultsUpload.not())
+                    GcStorage.upload(ANDROID_SHARD_FILE, config.resultsBucket, config.resultsDir)
+                newTestRun(config)
+            }
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -5,7 +5,6 @@ import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyAndroidConfig
-import ftl.gc.GcStorage
 import ftl.mock.MockServer
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.dumpShards
@@ -48,12 +47,7 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         val config = AndroidArgs.load(Paths.get(configPath), cli = this).validate()
         runBlocking {
             if (dumpShards) dumpShards(args = config, obfuscatedOutput = obfuscate)
-            else {
-                newTestRun(config)
-                dumpShards(args = config, obfuscatedOutput = obfuscate)
-                GcStorage.upload(ANDROID_SHARD_FILE, config.resultsBucket, config.resultsDir)
-            }
-
+            else newTestRun(config, obfuscate)
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -5,6 +5,7 @@ import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyAndroidConfig
+import ftl.gc.GcStorage
 import ftl.mock.MockServer
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.dumpShards
@@ -47,7 +48,12 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         val config = AndroidArgs.load(Paths.get(configPath), cli = this).validate()
         runBlocking {
             if (dumpShards) dumpShards(args = config, obfuscatedOutput = obfuscate)
-            else newTestRun(config)
+            else {
+                newTestRun(config)
+                dumpShards(args = config, obfuscatedOutput = obfuscate)
+                GcStorage.upload(ANDROID_SHARD_FILE, config.resultsBucket, config.resultsDir)
+            }
+
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -49,9 +49,7 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         runBlocking {
             if (dumpShards) dumpShards(args = config, obfuscatedOutput = obfuscate)
             else {
-                dumpShards(args = config, obfuscatedOutput = obfuscate)
-                if (config.disableResultsUpload.not())
-                    GcStorage.upload(ANDROID_SHARD_FILE, config.resultsBucket, config.resultsDir)
+                config.dumpShardsWithGcloudUpload(obfuscate)
                 newTestRun(config)
             }
         }
@@ -62,4 +60,9 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         description = ["Measures test shards from given test apks and writes them into $ANDROID_SHARD_FILE file instead of executing."]
     )
     var dumpShards: Boolean = false
+}
+
+private suspend fun AndroidArgs.dumpShardsWithGcloudUpload(obfuscatedOutput: Boolean) {
+    dumpShards(args = this, obfuscatedOutput = obfuscatedOutput)
+    if (disableResultsUpload.not()) GcStorage.upload(ANDROID_SHARD_FILE, resultsBucket, resultsDir)
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -50,9 +50,7 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         if (dumpShards) {
             dumpShards(args = config, obfuscatedOutput = obfuscate)
         } else runBlocking {
-            dumpShards(args = config, obfuscatedOutput = obfuscate)
-            if (config.disableResultsUpload.not())
-                GcStorage.upload(IOS_SHARD_FILE, config.resultsBucket, config.resultsDir)
+            config.dumpShardsWithGcloudUpload(obfuscate)
             newTestRun(config)
         }
     }
@@ -62,4 +60,9 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         description = ["Measures test shards from given test apks and writes them into $IOS_SHARD_FILE file instead of executing."]
     )
     var dumpShards: Boolean = false
+}
+
+fun IosArgs.dumpShardsWithGcloudUpload(obfuscatedOutput: Boolean) {
+    dumpShards(args = this, obfuscatedOutput = obfuscatedOutput)
+    if (disableResultsUpload.not()) GcStorage.upload(IOS_SHARD_FILE, resultsBucket, resultsDir)
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -5,6 +5,7 @@ import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyIosConfig
+import ftl.gc.GcStorage
 import ftl.mock.MockServer
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
@@ -49,7 +50,10 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         if (dumpShards) {
             dumpShards(args = config, obfuscatedOutput = obfuscate)
         } else runBlocking {
-            newTestRun(config, obfuscate)
+            dumpShards(args = config, obfuscatedOutput = obfuscate)
+            if (config.disableResultsUpload.not())
+                GcStorage.upload(IOS_SHARD_FILE, config.resultsBucket, config.resultsDir)
+            newTestRun(config)
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -62,7 +62,7 @@ class IosRunCommand : CommonRunCommand(), Runnable {
     var dumpShards: Boolean = false
 }
 
-fun IosArgs.dumpShardsWithGcloudUpload(obfuscatedOutput: Boolean) {
+private fun IosArgs.dumpShardsWithGcloudUpload(obfuscatedOutput: Boolean) {
     dumpShards(args = this, obfuscatedOutput = obfuscatedOutput)
     if (disableResultsUpload.not()) GcStorage.upload(IOS_SHARD_FILE, resultsBucket, resultsDir)
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -5,7 +5,6 @@ import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyIosConfig
-import ftl.gc.GcStorage
 import ftl.mock.MockServer
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
@@ -50,9 +49,7 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         if (dumpShards) {
             dumpShards(args = config, obfuscatedOutput = obfuscate)
         } else runBlocking {
-            newTestRun(config)
-            dumpShards(args = config, obfuscatedOutput = obfuscate)
-            GcStorage.upload(IOS_SHARD_FILE, config.resultsBucket, config.resultsDir)
+            newTestRun(config, obfuscate)
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -5,6 +5,7 @@ import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyIosConfig
+import ftl.gc.GcStorage
 import ftl.mock.MockServer
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
@@ -50,6 +51,8 @@ class IosRunCommand : CommonRunCommand(), Runnable {
             dumpShards(args = config, obfuscatedOutput = obfuscate)
         } else runBlocking {
             newTestRun(config)
+            dumpShards(args = config, obfuscatedOutput = obfuscate)
+            GcStorage.upload(IOS_SHARD_FILE, config.resultsBucket, config.resultsDir)
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -16,7 +16,7 @@ suspend fun dumpShards(
     args: AndroidArgs,
     shardFilePath: String = ANDROID_SHARD_FILE,
     obfuscatedOutput: Boolean = false
-): String {
+) {
     if (!args.isInstrumentationTest) throw FlankConfigurationError(
         "Cannot dump shards for non instrumentation test, ensure test apk has been set."
     )
@@ -27,21 +27,19 @@ suspend fun dumpShards(
         size = shards.size,
         obfuscatedOutput = obfuscatedOutput
     )
-    return shardFilePath
 }
 
 fun dumpShards(
     args: IosArgs,
     shardFilePath: String = IOS_SHARD_FILE,
     obfuscatedOutput: Boolean = false
-): String {
+) {
     saveShardChunks(
         shardFilePath = shardFilePath,
         shards = args.testShardChunks.testCases,
         size = args.testShardChunks.size,
         obfuscatedOutput = obfuscatedOutput
     )
-    return shardFilePath
 }
 
 private fun saveShardChunks(

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -1,7 +1,6 @@
 package ftl.run
 
 import ftl.args.AndroidArgs
-import ftl.args.IArgs
 import ftl.args.IosArgs
 import ftl.args.isInstrumentationTest
 import ftl.run.common.prettyPrint
@@ -12,10 +11,6 @@ import ftl.shard.testCases
 import ftl.util.obfuscatePrettyPrinter
 import java.nio.file.Files
 import java.nio.file.Paths
-
-suspend fun dumpShards(args: IArgs, obfuscatedOutput: Boolean = false) =
-    if (args is AndroidArgs) dumpShards(args, ANDROID_SHARD_FILE, obfuscatedOutput)
-    else dumpShards(args as IosArgs, IOS_SHARD_FILE, obfuscatedOutput)
 
 suspend fun dumpShards(
     args: AndroidArgs,

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -1,6 +1,7 @@
 package ftl.run
 
 import ftl.args.AndroidArgs
+import ftl.args.IArgs
 import ftl.args.IosArgs
 import ftl.args.isInstrumentationTest
 import ftl.run.common.prettyPrint
@@ -12,11 +13,15 @@ import ftl.util.obfuscatePrettyPrinter
 import java.nio.file.Files
 import java.nio.file.Paths
 
+suspend fun dumpShards(args: IArgs, obfuscatedOutput: Boolean = false) =
+    if (args is AndroidArgs) dumpShards(args, ANDROID_SHARD_FILE, obfuscatedOutput)
+    else dumpShards(args as IosArgs, IOS_SHARD_FILE, obfuscatedOutput)
+
 suspend fun dumpShards(
     args: AndroidArgs,
     shardFilePath: String = ANDROID_SHARD_FILE,
     obfuscatedOutput: Boolean = false
-) {
+): String {
     if (!args.isInstrumentationTest) throw FlankConfigurationError(
         "Cannot dump shards for non instrumentation test, ensure test apk has been set."
     )
@@ -27,19 +32,21 @@ suspend fun dumpShards(
         size = shards.size,
         obfuscatedOutput = obfuscatedOutput
     )
+    return shardFilePath
 }
 
 fun dumpShards(
     args: IosArgs,
     shardFilePath: String = IOS_SHARD_FILE,
     obfuscatedOutput: Boolean = false
-) {
+): String {
     saveShardChunks(
         shardFilePath = shardFilePath,
         shards = args.testShardChunks.testCases,
         size = args.testShardChunks.size,
         obfuscatedOutput = obfuscatedOutput
     )
+    return shardFilePath
 }
 
 private fun saveShardChunks(

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -3,7 +3,6 @@ package ftl.run
 import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
-import ftl.gc.GcStorage
 import ftl.json.SavedMatrix
 import ftl.json.updateMatrixMap
 import ftl.json.validate
@@ -19,7 +18,7 @@ import ftl.run.platform.runIosTests
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeoutOrNull
 
-suspend fun newTestRun(args: IArgs, obfuscate: Boolean = false) = withTimeoutOrNull(args.parsedTimeout) {
+suspend fun newTestRun(args: IArgs) = withTimeoutOrNull(args.parsedTimeout) {
     println(args)
     val (matrixMap, testShardChunks, ignoredTests) = cancelTestsOnTimeout(args.project) { runTests(args) }
 
@@ -31,9 +30,6 @@ suspend fun newTestRun(args: IArgs, obfuscate: Boolean = false) = withTimeoutOrN
 
         println()
         matrixMap.printMatricesWebLinks(args.project)
-        dumpShards(args, obfuscate).takeIf { args.disableResultsUpload.not() }?.let { shardFile ->
-            GcStorage.upload(shardFile, args.resultsBucket, args.resultsDir)
-        }
         matrixMap.validate(args.ignoreFailedTests)
     }
 }

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -3,6 +3,7 @@ package ftl.run
 import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
+import ftl.gc.GcStorage
 import ftl.json.SavedMatrix
 import ftl.json.updateMatrixMap
 import ftl.json.validate
@@ -27,7 +28,7 @@ suspend fun newTestRun(args: IArgs) = withTimeoutOrNull(args.parsedTimeout) {
         cancelTestsOnTimeout(args.project, matrixMap.map) { fetchArtifacts(matrixMap, args) }
 
         ReportManager.generate(matrixMap, args, testShardChunks, ignoredTests)
-
+        
         println()
         matrixMap.printMatricesWebLinks(args.project)
 

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
@@ -531,7 +531,6 @@ class AndroidRunCommandTest {
     @Test
     fun `should dump shards on android test run`() {
         mockkStatic("ftl.run.DumpShardsKt")
-        mockkStatic("ftl.run.NewTestRunKt")
         val runCmd = AndroidRunCommand()
         runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-android-flank.yml"
         runCmd.run()

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
@@ -1,11 +1,15 @@
 package ftl.cli.firebase.test.android
 
 import com.google.common.truth.Truth.assertThat
+import ftl.args.AndroidArgs
 import ftl.args.yml.AppTestPair
 import ftl.config.Device
 import ftl.config.FtlConstants
+import ftl.run.dumpShards
 import ftl.run.exception.FlankConfigurationError
 import ftl.test.util.FlankTestRunner
+import io.mockk.coVerify
+import io.mockk.mockkStatic
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -522,5 +526,15 @@ class AndroidRunCommandTest {
             "--smart-flank-gcs-path=gs://test-lab-v9cn46bb990nx-kz69ymd4nm9aq/2020-08-26_15-20-23.850738_rtGt/JUnitReport.xml"
         )
         cmd.run()
+    }
+
+    @Test
+    fun `should dump shards on every run`() {
+        mockkStatic("ftl.run.DumpShardsKt")
+        mockkStatic("ftl.run.NewTestRunKt")
+        val runCmd = AndroidRunCommand()
+        runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-android-flank.yml"
+        runCmd.run()
+        coVerify { dumpShards(any<AndroidArgs>(), any(), any()) }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
@@ -529,7 +529,7 @@ class AndroidRunCommandTest {
     }
 
     @Test
-    fun `should dump shards on every run`() {
+    fun `should dump shards on android test run`() {
         mockkStatic("ftl.run.DumpShardsKt")
         mockkStatic("ftl.run.NewTestRunKt")
         val runCmd = AndroidRunCommand()

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
@@ -1,10 +1,14 @@
 package ftl.cli.firebase.test.ios
 
 import com.google.common.truth.Truth.assertThat
+import ftl.args.IosArgs
 import ftl.config.Device
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.isWindows
+import ftl.run.dumpShards
 import ftl.test.util.FlankTestRunner
+import io.mockk.mockkStatic
+import io.mockk.verify
 import org.junit.Assume.assumeFalse
 import org.junit.Rule
 import org.junit.Test
@@ -336,5 +340,15 @@ class IosRunCommandTest {
         CommandLine(cmd).parseArgs("--use-average-test-time-for-new-tests")
 
         assertThat(cmd.config.common.flank.useAverageTestTimeForNewTests).isTrue()
+    }
+
+    @Test
+    fun `should dump shards on every run`() {
+        mockkStatic("ftl.run.DumpShardsKt")
+        mockkStatic("ftl.run.NewTestRunKt")
+        val runCmd = IosRunCommand()
+        runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-ios-flank.yml"
+        runCmd.run()
+        verify { dumpShards(any<IosArgs>(), any(), any()) }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
@@ -345,7 +345,6 @@ class IosRunCommandTest {
     @Test
     fun `should dump shards on ios test run`() {
         mockkStatic("ftl.run.DumpShardsKt")
-        mockkStatic("ftl.run.NewTestRunKt")
         val runCmd = IosRunCommand()
         runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-ios-flank.yml"
         runCmd.run()

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
@@ -343,7 +343,7 @@ class IosRunCommandTest {
     }
 
     @Test
-    fun `should dump shards on every run`() {
+    fun `should dump shards on ios test run`() {
         mockkStatic("ftl.run.DumpShardsKt")
         mockkStatic("ftl.run.NewTestRunKt")
         val runCmd = IosRunCommand()

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
@@ -5,8 +5,11 @@ import ftl.args.IosArgs
 import ftl.config.Device
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.isWindows
+import ftl.gc.GcStorage
+import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
 import ftl.test.util.FlankTestRunner
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.Assume.assumeFalse
@@ -349,5 +352,18 @@ class IosRunCommandTest {
         runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-ios-flank.yml"
         runCmd.run()
         verify { dumpShards(any<IosArgs>(), any(), any()) }
+    }
+
+    @Test
+    fun `should dump shards on ios test run and not upload when disable-upload-results set`() {
+        mockkStatic("ftl.run.DumpShardsKt")
+        mockkObject(GcStorage) {
+            val runCmd = IosRunCommand()
+            runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-ios-flank.yml"
+            CommandLine(runCmd).parseArgs("--disable-results-upload")
+            runCmd.run()
+            verify { dumpShards(any<IosArgs>(), any(), any()) }
+            verify(inverse = true) { GcStorage.upload(IOS_SHARD_FILE, any(), any()) }
+        }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/json/MatrixMapTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/MatrixMapTest.kt
@@ -53,7 +53,7 @@ class MatrixMapTest {
     }
 
     @Test
-    fun `invalid matrix should contains specyfic error message`() {
+    fun `invalid matrix should contain a specific error message`() {
         val testMatrix = testMatrix()
         testMatrix.testMatrixId = "123"
         testMatrix.state = MatrixState.INVALID


### PR DESCRIPTION
Fixes #1160 

## Test Plan
> How do we know the code works?

1. Flank should dump shards and upload them to gcs on every run.
2.  When --disable-results-upload set, Flank should dump shards to file but not upload them to gcs.

## Checklist

- [X] Unit tested
