### PR TITLE
fix: Fix flank-scripts test

### DIFF
--- a/flank-scripts/src/test/kotlin/flank/scripts/ci/nexttag/NextReleaseTagCommandTest.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/ci/nexttag/NextReleaseTagCommandTest.kt
@@ -6,12 +6,17 @@ import flank.scripts.FuelTestRunner
 import flank.scripts.ci.releasenotes.GitHubRelease
 import flank.scripts.github.getLatestReleaseTag
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.ExpectedSystemExit
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
+import java.time.LocalDate
+import java.time.Year
 
 @RunWith(FuelTestRunner::class)
 class NextReleaseTagCommandTest {
@@ -24,9 +29,18 @@ class NextReleaseTagCommandTest {
     @JvmField
     val systemExit = ExpectedSystemExit.none()!!
 
+    @After
+    fun tearDown() = unmockkAll()
+
     @Test
     fun `Should return properly message when success`() {
-        mockkStatic("flank.scripts.github.GithubApiKt") {
+        mockkStatic(
+            "flank.scripts.github.GithubApiKt",
+            "java.time.LocalDate",
+            "java.time.Year"
+        ) {
+            every { LocalDate.now() } returns LocalDate.of(2020, 9, 16)
+            every { Year.now() } returns Year.of(2020)
             coEvery { getLatestReleaseTag(any()) } returns Result.success(GitHubRelease("v20.09.0"))
 
             // when


### PR DESCRIPTION
Fixes #1176 

## Test Plan
> How do we know the code works?

`./gradlew clean test` finishes without error


