### PR TITLE
test: Remove verification test for edge cases of incorrect outcome in flaky tests

### DIFF
--- a/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
@@ -236,33 +236,4 @@ class SavedMatrixTest {
             savedMatrix.outcome
         )
     }
-
-    @Ignore("Should be used to verify https://github.com/Flank/flank/issues/918 fix")
-    @Test
-    fun `savedMatrix should have flaky outcome when at least one test is flaky`() {
-        val expectedOutcome = "flaky"
-        val successStepExecution = createStepExecution(1) // success
-        // https://github.com/Flank/flank/issues/918
-        // This test covers edge case where summary for both step and execution is null and outcome of
-        // saved matrix was not changed and is set to success
-        val malformed = createStepExecution(stepId = -666, executionId = -666) // flaky
-
-        // below order in the list matters!
-        val executions = listOf(
-            successStepExecution,
-            successStepExecution,
-            malformed
-        )
-
-        val testMatrix = testMatrix().apply {
-            testMatrixId = "123"
-            state = FINISHED
-            resultStorage = createResultsStorage()
-            testExecutions = executions
-        }
-
-        val savedMatrix = createSavedMatrix(testMatrix)
-
-        assertEquals(expectedOutcome, savedMatrix.outcome)
-    }
 }

--- a/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
@@ -16,7 +16,6 @@ import ftl.util.MatrixState.INVALID
 import ftl.util.MatrixState.PENDING
 import ftl.util.webLink
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 


### PR DESCRIPTION
Fixes #918 

## Test Plan
> How do we know the code works?

Ignored test should be removed from SavedMatrixTest
