### PR TITLE
fix: Revert "feat: Dump shards and upload on every run (#1171)"

### DIFF
--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -5,7 +5,6 @@ import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyAndroidConfig
-import ftl.gc.GcStorage
 import ftl.mock.MockServer
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.dumpShards
@@ -48,10 +47,7 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         val config = AndroidArgs.load(Paths.get(configPath), cli = this).validate()
         runBlocking {
             if (dumpShards) dumpShards(args = config, obfuscatedOutput = obfuscate)
-            else {
-                config.dumpShardsWithGcloudUpload(obfuscate)
-                newTestRun(config)
-            }
+            else newTestRun(config)
         }
     }
 
@@ -60,9 +56,4 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         description = ["Measures test shards from given test apks and writes them into $ANDROID_SHARD_FILE file instead of executing."]
     )
     var dumpShards: Boolean = false
-}
-
-private suspend fun AndroidArgs.dumpShardsWithGcloudUpload(obfuscatedOutput: Boolean) {
-    dumpShards(args = this, obfuscatedOutput = obfuscatedOutput)
-    if (disableResultsUpload.not()) GcStorage.upload(ANDROID_SHARD_FILE, resultsBucket, resultsDir)
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -5,7 +5,6 @@ import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyIosConfig
-import ftl.gc.GcStorage
 import ftl.mock.MockServer
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
@@ -50,7 +49,6 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         if (dumpShards) {
             dumpShards(args = config, obfuscatedOutput = obfuscate)
         } else runBlocking {
-            config.dumpShardsWithGcloudUpload(obfuscate)
             newTestRun(config)
         }
     }
@@ -60,9 +58,4 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         description = ["Measures test shards from given test apks and writes them into $IOS_SHARD_FILE file instead of executing."]
     )
     var dumpShards: Boolean = false
-}
-
-private fun IosArgs.dumpShardsWithGcloudUpload(obfuscatedOutput: Boolean) {
-    dumpShards(args = this, obfuscatedOutput = obfuscatedOutput)
-    if (disableResultsUpload.not()) GcStorage.upload(IOS_SHARD_FILE, resultsBucket, resultsDir)
 }

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -30,6 +30,7 @@ suspend fun newTestRun(args: IArgs) = withTimeoutOrNull(args.parsedTimeout) {
 
         println()
         matrixMap.printMatricesWebLinks(args.project)
+
         matrixMap.validate(args.ignoreFailedTests)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
@@ -1,19 +1,11 @@
 package ftl.cli.firebase.test.android
 
 import com.google.common.truth.Truth.assertThat
-import ftl.args.AndroidArgs
 import ftl.args.yml.AppTestPair
 import ftl.config.Device
 import ftl.config.FtlConstants
-import ftl.gc.GcStorage
-import ftl.run.ANDROID_SHARD_FILE
-import ftl.run.dumpShards
 import ftl.run.exception.FlankConfigurationError
 import ftl.test.util.FlankTestRunner
-import io.mockk.coVerify
-import io.mockk.mockkObject
-import io.mockk.mockkStatic
-import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -530,27 +522,5 @@ class AndroidRunCommandTest {
             "--smart-flank-gcs-path=gs://test-lab-v9cn46bb990nx-kz69ymd4nm9aq/2020-08-26_15-20-23.850738_rtGt/JUnitReport.xml"
         )
         cmd.run()
-    }
-
-    @Test
-    fun `should dump shards on android test run`() {
-        mockkStatic("ftl.run.DumpShardsKt")
-        val runCmd = AndroidRunCommand()
-        runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-android-flank.yml"
-        runCmd.run()
-        coVerify { dumpShards(any<AndroidArgs>(), any(), any()) }
-    }
-
-    @Test
-    fun `should dump shards on android test run and not upload when disable-upload-results set`() {
-        mockkStatic("ftl.run.DumpShardsKt")
-        mockkObject(GcStorage) {
-            val runCmd = AndroidRunCommand()
-            runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-android-flank.yml"
-            CommandLine(runCmd).parseArgs("--disable-results-upload")
-            runCmd.run()
-            coVerify { dumpShards(any<AndroidArgs>(), any(), any()) }
-            verify(inverse = true) { GcStorage.upload(ANDROID_SHARD_FILE, any(), any()) }
-        }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
@@ -1,17 +1,10 @@
 package ftl.cli.firebase.test.ios
 
 import com.google.common.truth.Truth.assertThat
-import ftl.args.IosArgs
 import ftl.config.Device
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.isWindows
-import ftl.gc.GcStorage
-import ftl.run.IOS_SHARD_FILE
-import ftl.run.dumpShards
 import ftl.test.util.FlankTestRunner
-import io.mockk.mockkObject
-import io.mockk.mockkStatic
-import io.mockk.verify
 import org.junit.Assume.assumeFalse
 import org.junit.Rule
 import org.junit.Test
@@ -343,27 +336,5 @@ class IosRunCommandTest {
         CommandLine(cmd).parseArgs("--use-average-test-time-for-new-tests")
 
         assertThat(cmd.config.common.flank.useAverageTestTimeForNewTests).isTrue()
-    }
-
-    @Test
-    fun `should dump shards on ios test run`() {
-        mockkStatic("ftl.run.DumpShardsKt")
-        val runCmd = IosRunCommand()
-        runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-ios-flank.yml"
-        runCmd.run()
-        verify { dumpShards(any<IosArgs>(), any(), any()) }
-    }
-
-    @Test
-    fun `should dump shards on ios test run and not upload when disable-upload-results set`() {
-        mockkStatic("ftl.run.DumpShardsKt")
-        mockkObject(GcStorage) {
-            val runCmd = IosRunCommand()
-            runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-ios-flank.yml"
-            CommandLine(runCmd).parseArgs("--disable-results-upload")
-            runCmd.run()
-            verify { dumpShards(any<IosArgs>(), any(), any()) }
-            verify(inverse = true) { GcStorage.upload(IOS_SHARD_FILE, any(), any()) }
-        }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/json/MatrixMapTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/MatrixMapTest.kt
@@ -53,7 +53,7 @@ class MatrixMapTest {
     }
 
     @Test
-    fun `invalid matrix should contain a specific error message`() {
+    fun `invalid matrix should contains specyfic error message`() {
         val testMatrix = testMatrix()
         testMatrix.testMatrixId = "123"
         testMatrix.state = MatrixState.INVALID

--- a/test_runner/src/test/kotlin/ftl/json/MatrixMapTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/MatrixMapTest.kt
@@ -53,7 +53,7 @@ class MatrixMapTest {
     }
 
     @Test
-    fun `invalid matrix should contains specyfic error message`() {
+    fun `invalid matrix should contain a specific error message`() {
         val testMatrix = testMatrix()
         testMatrix.testMatrixId = "123"
         testMatrix.state = MatrixState.INVALID


### PR DESCRIPTION
This reverts commit 256147fd951ea5949a3f7a79d3f2dfa8b674b8f8.

Feature to be implemented in https://github.com/Flank/flank/issues/1184
