### PR TITLE
docs: Added documentation about Cucumber support

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,10 @@ and flank's example [gradle-export-api](https://github.com/Flank/flank/tree/mast
     - Clear IDE cache using `File > Invalidate Caches / Restart`
     - Re-import project using root `build.gradle.kts`
     - Sync project again
+    
+5) > Does Flank support Cucumber?
+   
+   Please check [document](docs/cucumber_support.md) for more info
 
 # Resources
 

--- a/docs/cucumber_support.md
+++ b/docs/cucumber_support.md
@@ -1,0 +1,17 @@
+# Cucumber support
+
+Firebase test lab and Flank [do not support](https://firebase.google.com/docs/test-lab/troubleshooting?platform=android#support-for-platforms-android) Cucumber. 
+However, you could run these tests. 
+ - To make them work properly please disable sharding using `.yml` options:
+    ```yaml
+    flank:
+      disable-sharding: true
+    ```
+    or by using command-line option
+    ```shell script
+      --disable-sharding
+    ```
+
+ - If you would like to use orchestrator please make sure that you are using at least version `1.3.0` of it.
+ - [Currently](https://github.com/Flank/flank/issues/1189), Flank will run Cucumber tests only if there are other Instrumented tests to run in your test apk. 
+    In other cases Flank will fast fail with `There are no tests to run` message. 


### PR DESCRIPTION
Answers #1118 

## Test Plan
> How do we know the code works?

This is documentation about using Cucumber in Flank. 
More work-related to Cucumber support will probably continue in task #1189 

## Checklist

- [ ] Documented
