### PR TITLE
docs: Added documentation about missing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,12 @@ flank:
   ## The JUnit XML is used to determine failure. (default: false)
   # ignore-failed-tests: true
 
+  ## Output style of execution status. May be one of [verbose, multi, single].
+  ## For runs with only one test execution the default value is 'verbose', in other cases
+  ## 'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles
+  ## which don't support ansi codes, to avoid corrupted output use single or verbose.
+  # output-style: single
+
   ## Enable create additional local junit result on local storage with failure nodes on passed flaky tests.
   # full-junit-result: false
 
@@ -291,6 +297,10 @@ gcloud:
   ## The path to the binary file containing instrumentation tests.
   ## The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
   test: ../test_projects/android/apks/app-debug-androidTest.apk
+
+  ## A list of up to 100 additional APKs to install, in addition to those being directly tested.
+  ## The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
+  # additional-apks: additional-apk1.apk,additional-apk2.apk,additional-apk3.apk
 
   ## Automatically log into the test device using a preconfigured Google account before beginning the test.
   ## Disabled by default. Use --auto-google-login to enable.
@@ -452,6 +462,12 @@ flank:
   ## This flag allows fallback for legacy xml junit results parsing
   ## Currently available for android, iOS still uses only legacy way.
   # legacy-junit-result: false
+
+  ## Output style of execution status. May be one of [verbose, multi, single].
+  ## For runs with only one test execution the default value is 'verbose', in other cases
+  ## 'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles
+  ## which don't support ansi codes, to avoid corrupted output use single or verbose.
+  # output-style: single
 
   ## Enable create additional local junit result on local storage with failure nodes on passed flaky tests.
   # full-junit-result: false

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -56,6 +56,10 @@ gcloud:
   ## The given path may be in the local filesystem or in Google Cloud Storage using a URL beginning with gs://.
   test: ../test_projects/android/apks/app-debug-androidTest.apk
 
+  ## A list of up to 100 additional APKs to install, in addition to those being directly tested.
+  ## The path may be in the local filesystem or in Google Cloud Storage using gs:// notation.
+  # additional-apks: additional-apk1.apk,additional-apk2.apk,additional-apk3.apk
+
   ## Automatically log into the test device using a preconfigured Google account before beginning the test.
   ## Disabled by default. Use --auto-google-login to enable.
   # auto-google-login: true


### PR DESCRIPTION
Fixes #1183 

## Test Plan
> How do we know the code works?

All options are documented both in `.yml` example and `README.md` on main page

## Checklist

- [x] `output-style`
- [x] `additional-apks`
- [x] Ensure that all options are documented

