### PR TITLE
fix: Release job missing env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
 
     - name: Gradle Build Flank
       uses: eskatos/gradle-command-action@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HEAD_REF: ${{ github.head_ref }}
       with:
         arguments: "clean test_runner:build test_runner:shadowJar"
         


### PR DESCRIPTION
This is a hotfix for missing env variables in the release workflow.