### PR TITLE
fix: test_runner:resolveArtifacts task

### DIFF
--- a/flank-scripts/src/main/kotlin/flank/scripts/testartifacts/core/ResolveArtifacts.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/testartifacts/core/ResolveArtifacts.kt
@@ -1,38 +1,25 @@
 package flank.scripts.testartifacts.core
 
 import com.jcabi.github.Repo
-import java.io.File
 
-fun Context.resolveArtifacts(repo: Repo = testArtifactsRepo()) {
-    resolveRemotelyOrFallback(
-        repo = repo,
-        fallback = { resolveFallback(repo) }
-    )
-}
-
-private fun Context.resolveRemotelyOrFallback(repo: Repo, fallback: () -> Unit) {
+fun Context.resolveArtifacts(
+    repo: Repo = testArtifactsRepo()
+) {
     if (isNewVersionAvailable(repo)) {
         downloadFixtures()
         unzipTestArtifacts()
         linkArtifacts()
-    } else fallback()
-}
-
-private fun Context.resolveFallback(repo: Repo) {
-    projectRoot.testArtifacts(branch).run {
+    } else projectRoot.testArtifacts(branch).run {
         if (exists()) println("* Resolved test artifacts for branch $branch under $absolutePath")
-        else tryResolveForMaster(repo)
+        else copy(branch = "master").run {
+            if (isNewVersionAvailable(repo)) {
+                downloadFixtures()
+                unzipTestArtifacts()
+                linkArtifacts()
+            } else projectRoot.testArtifacts(branch).run {
+                if (exists()) println("* Resolved test artifacts for branch $branch under $absolutePath")
+                else throw Exception("Cannot resolve test artifacts")
+            }
+        }
     }
-}
-
-private fun Context.tryResolveForMaster(repo: Repo) {
-    copy(branch = "master").resolveRemotelyOrFallback(
-        repo = repo,
-        fallback = { projectRoot.testArtifacts(branch).resolveLocallyOrThrow(branch) }
-    )
-}
-
-private fun File.resolveLocallyOrThrow(branch: String) {
-    if (exists()) println("* Resolved test artifacts for branch $branch under $absolutePath")
-    else throw Exception("Cannot resolve test artifacts")
 }


### PR DESCRIPTION
Fixes #1231 

## Test Plan
> How do we know the code works?

1. Change branch to different than `master` or create new from the latest master.
1. Make sure there are no dedicated artifacts for the current branch.
1. Run `./gradlew clean test`.
1. `test_runner:testArtifacts` task shouldn't fail, tests should start correctly.

