### PR TITLE
fix: Fix withClassName filter

### DIFF
--- a/test_projects/android/app/src/androidTestMultiple/java/com.example.test_app.similar/SimilarNameTest1.kt
+++ b/test_projects/android/app/src/androidTestMultiple/java/com.example.test_app.similar/SimilarNameTest1.kt
@@ -1,0 +1,21 @@
+package com.example.test_app.similar
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.test_app.BaseInstrumentedTest
+import org.junit.Ignore
+import androidx.test.filters.Suppress
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SimilarNameTest1 : BaseInstrumentedTest() {
+
+    @Test
+    fun test1() = testMethod()
+
+    @Test
+    fun test2() = testMethod()
+
+    @Test
+    fun test19() = testMethod()
+}

--- a/test_projects/android/app/src/androidTestMultiple/java/com.example.test_app.similar/SimilarNameTest10.kt
+++ b/test_projects/android/app/src/androidTestMultiple/java/com.example.test_app.similar/SimilarNameTest10.kt
@@ -1,0 +1,21 @@
+package com.example.test_app.similar
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.test_app.BaseInstrumentedTest
+import org.junit.Ignore
+import androidx.test.filters.Suppress
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SimilarNameTest10 : BaseInstrumentedTest() {
+
+    @Test
+    fun test1() = testMethod()
+
+    @Test
+    fun test2() = testMethod()
+
+    @Test
+    fun test19() = testMethod()
+}

--- a/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
+++ b/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
@@ -150,12 +150,20 @@ object TestFilters {
         }
     )
 
-    private fun withClassName(classNames: List<String>): TestFilter = TestFilter(
-        describe = "withClassName (${classNames.joinToString(", ")})",
-        shouldRun = { testMethod ->
-            withPackageName(classNames).shouldRun(testMethod)
-        }
-    )
+    private fun withClassName(classNames: List<String>): TestFilter {
+        val splittedClassNames = classNames.map { it.split("#") }
+        return TestFilter(
+            describe = "withClassName (${classNames.joinToString(", ")})",
+            shouldRun = { testMethod ->
+                val splittedName = testMethod.testName.split("#")
+                splittedClassNames.any { className ->
+                    // className.size == 1 => foo.bar.TestClass1
+                    // className.size != 1 => foo.bar.TestClass1#testMethod1
+                    splittedName[0] == className[0] && (className.size == 1 || splittedName[1] == className[1])
+                }
+            }
+        )
+    }
 
     private fun withAnnotation(annotations: List<String>): TestFilter = TestFilter(
         describe = "withAnnotation (${annotations.joinToString(", ")})",

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
@@ -70,7 +70,9 @@ internal fun InstrumentationTestContext.getFlankTestMethods(
             .filter(testFilter.shouldRun)
             .filterNot(parameterizedClasses::belong)
             .map(TestMethod::toFlankTestMethod).toList()
-            .plus(parameterizedClasses.map(String::toFlankTestMethod))
+            .plus(parameterizedClasses
+                .filter { testFilter.shouldRun(TestMethod(it, emptyList())) }
+                .map(String::toFlankTestMethod))
     }
 
 private fun List<String>.belong(method: TestMethod) = any { className -> method.testName.startsWith(className) }

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
@@ -90,7 +90,8 @@ private val ignoredAnnotations = listOf(
 
 private fun String.toFlankTestMethod() = FlankTestMethod("class $this", ignored = false, isParameterizedClass = true)
 
-private fun InstrumentationTestContext.getParametrizedClasses(): List<String> =
+@VisibleForTesting
+internal fun InstrumentationTestContext.getParametrizedClasses(): List<String> =
     DexParser.readDexFiles(test.local).fold(emptyList()) { accumulator, file: DexFile ->
         accumulator + file.classDefs
             .filter(file::isParametrizedClass)

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
@@ -70,12 +70,14 @@ internal fun InstrumentationTestContext.getFlankTestMethods(
             .filter(testFilter.shouldRun)
             .filterNot(parameterizedClasses::belong)
             .map(TestMethod::toFlankTestMethod).toList()
-            .plus(parameterizedClasses
-                .filter { testFilter.shouldRun(TestMethod(it, emptyList())) }
-                .map(String::toFlankTestMethod))
+            .plus(parameterizedClasses.onlyShouldRun(testFilter))
     }
 
 private fun List<String>.belong(method: TestMethod) = any { className -> method.testName.startsWith(className) }
+
+private fun List<String>.onlyShouldRun(filter: TestFilter) = this
+    .filter { filter.shouldRun(TestMethod(it, emptyList())) }
+    .map { FlankTestMethod("class $it", ignored = false, isParameterizedClass = true) }
 
 private fun TestMethod.toFlankTestMethod() = FlankTestMethod(
     testName = "class $testName",
@@ -87,8 +89,6 @@ private val ignoredAnnotations = listOf(
     "androidx.test.filters.Suppress",
     "android.support.test.filters.Suppress"
 )
-
-private fun String.toFlankTestMethod() = FlankTestMethod("class $this", ignored = false, isParameterizedClass = true)
 
 @VisibleForTesting
 internal fun InstrumentationTestContext.getParametrizedClasses(): List<String> =


### PR DESCRIPTION
Fixes #1227, #1234 

Similar class/method names were considered as one due to `testMethod.testName.startsWith(className)` check, with:
```
test-targets:
  - class foo.bar.TestClass1
```
all `foo.bar.TestClass1`, `foo.bar.TestClass121`, `foo.bar.TestClass1aaaa` return `true` for `shouldRun` check. The same is applicable for test methods

## Test Plan
> How do we know the code works?

1. build finish without any errors
1. generate apks with `[flank root] ./test_projects/android/bash/generate_apks.sh ~`
1. start flank run with config: 
    ```yaml
    gcloud:
      app: ~/app-debug.apk
      test: ~/app-multiple-success-debug-androidTest.apk
      test-targets:
        - class com.example.test_app.similar.SimilarNameTest1
    ```
    and observe only 3 tests are launched
1. start flank run with config: 
    ```yaml
    gcloud:
      app: ~/app-debug.apk
      test: ~/app-multiple-success-debug-androidTest.apk
      test-targets:
        - class com.example.test_app.similar.SimilarNameTest1#test1
    ```
    and observe only 1 test is launched

## Checklist

- [x] Unit tested
