### PR TITLE
fix: Empty branch name in workflows

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -29,7 +29,7 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REF: ${{ github.ref }}
         with:
           arguments: "clean build"
 

--- a/.github/workflows/windows-non-wsl-workflow.yml
+++ b/.github/workflows/windows-non-wsl-workflow.yml
@@ -30,7 +30,7 @@ jobs:
       shell: cmd
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        HEAD_REF: ${{ github.head_ref }}
+        HEAD_REF: ${{ github.ref }}
       run: |
           gradlew.bat clean build
 

--- a/.github/workflows/wsl-workflow.yml
+++ b/.github/workflows/wsl-workflow.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Gradle clean build
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        HEAD_REF: ${{ github.head_ref }}
+        HEAD_REF: ${{ github.ref }}
       run: |
           ./gradlew clean build
 


### PR DESCRIPTION
Hotfix for empty branch name in workflows:
* `windows-non-wsl-workflow`
* `wsl-workflow and integration_tests`
* `integration_tests`