### PR TITLE
ci: Add current date to dependecy PR

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -28,14 +28,18 @@ jobs:
         run: |
           flankScripts dependencies update
 
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
       - name: Commit files and create Pull request
         id: pr
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: "[Automatic PR] Dependencies update"
           signoff: false
-          branch: 'dependencies_update'
-          title: 'build: Dependencies updates'
+          branch: "dependencies-update-${{ steps.date.outputs.date }}"
+          title: "build: Dependencies updates [${{ steps.date.outputs.date }}]"
           body: "Dependencies updates"
           labels: |
             automated pr


### PR DESCRIPTION
Fixes #1239 

Adds current date to dependency update PR title and branch name:
`dependencies-update-2020-10-15`
`build: Dependencies updates [2020-10-15]`
