### PR TITLE
fix: Disable cache for :test_runner:shadowJar task

### DIFF
--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -21,6 +21,7 @@ val artifactID = "flank"
 
 val shadowJar: ShadowJar by tasks
 shadowJar.apply {
+    outputs.cacheIf { false } // to investigate if better solution is possible
     archiveClassifier.set("")
     archiveBaseName.set(artifactID)
     mergeServiceFiles()


### PR DESCRIPTION
Fixes incorrect revision for locally built shadowJar.

1. Run `./gradlew updateFlank/flankFullRun/shadowJar`
1. Run `flank -v`
1. Compare revision with latest commit hash on current branch
