### PR TITLE
fix: Flank web documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Flank is a [massively parallel Android and iOS test runner](https://docs.google.
 
 Flank is YAML compatible with [the gcloud CLI](https://cloud.google.com/sdk/gcloud/reference/alpha/firebase/test). Flank provides extra features to accelerate velocity and increase quality.
 
-### Documentation is at [flank.github.io/flank](flank.github.io/flank)
+### Documentation is at [flank.github.io/flank](https://flank.github.io/flank/)


### PR DESCRIPTION

## Test Plan
> How do we know the code works?

Proper link redirects to the documentation page

