### PR TITLE
ci: Use Github app token for creating release notes

### DIFF
--- a/.github/workflows/release_notes_generation.yml
+++ b/.github/workflows/release_notes_generation.yml
@@ -34,10 +34,17 @@ jobs:
       run: |
         flankScripts ci generateReleaseNotes --token=${{ secrets.GITHUB_TOKEN }}
 
+    - uses: tibdex/github-app-token@v1
+      id: generate-token
+      with:
+        app_id: ${{ secrets.FLANK_RELEASE_APP_ID }}
+        private_key: ${{ secrets.FLANK_RELEASE_PRIVATE_KEY }}
+
     - name: Commit files and create Pull request
       id: pr
       uses: peter-evans/create-pull-request@v3
       with:
+        token: ${{ steps.generate-token.outputs.token }}
         commit-message: "[Automatic PR] Generate release notes"
         signoff: false
         branch: 'release/${{ env.NEXT_RELEASE_TAG }}'


### PR DESCRIPTION
Fixes #1213 
Github app token is generated using [this](https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens) instructions

## Test Plan
> How do we know the code works?

All jobs are run properly in created PR (builds + integration tests when 2+ approves) when run release notes jobs.
