### PR TITLE
fix: Add additional index to matrix when multiple test runs

### DIFF
--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -57,7 +57,7 @@ internal suspend fun runAndroidTests(args: AndroidArgs): TestResult = coroutineS
             testMatrices += executeAndroidTestMatrix(runCount = args.repeatTests) { runIndex ->
                 GcAndroidTestMatrix.build(
                     androidTestConfig = androidTestConfig,
-                    runGcsPath = runGcsPath.calculateMatrixValue(contextIndex, runIndex),
+                    runGcsPath = runGcsPath.createGcsPath(contextIndex, runIndex),
                     additionalApkGcsPaths = additionalApks,
                     androidDeviceList = devices,
                     args = args,
@@ -78,7 +78,7 @@ internal suspend fun runAndroidTests(args: AndroidArgs): TestResult = coroutineS
     )
 }
 
-private fun String.calculateMatrixValue(contextIndex: Int, runIndex: Int) =
+private fun String.createGcsPath(contextIndex: Int, runIndex: Int) =
     if (runIndex == 0) "$this/matrix_$contextIndex/"
     else "$this/matrix_${contextIndex}_$runIndex/"
 

--- a/test_runner/src/test/kotlin/ftl/run/platform/RunAndroidTestsKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/RunAndroidTestsKtTest.kt
@@ -1,10 +1,14 @@
 package ftl.run.platform
 
 import ftl.args.AndroidArgs
+import ftl.gc.GcAndroidTestMatrix
 import ftl.run.model.TestResult
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.mixedConfigYaml
 import ftl.test.util.should
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -33,5 +37,55 @@ class RunAndroidTestsKtTest {
 
         // then
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should add additional index if repeatTests set`() {
+        val androidArgs = AndroidArgs.load(mixedConfigYaml)
+        mockkObject(GcAndroidTestMatrix, androidArgs) {
+
+            every { androidArgs.resultsDir } returns "test_dir"
+            every { androidArgs.resultsBucket } returns "test_bucket"
+            every { androidArgs.repeatTests } returns 2
+
+            runBlocking {
+                runAndroidTests(androidArgs)
+            }
+
+            verify {
+                GcAndroidTestMatrix.build(any(), any(), "test_dir/matrix_0/", any(), any(), any(), any())
+                GcAndroidTestMatrix.build(any(), any(), "test_dir/matrix_0_1/", any(), any(), any(), any())
+                GcAndroidTestMatrix.build(any(), any(), "test_dir/matrix_1/", any(), any(), any(), any())
+                GcAndroidTestMatrix.build(any(), any(), "test_dir/matrix_1_1/", any(), any(), any(), any())
+                GcAndroidTestMatrix.build(any(), any(), "test_dir/matrix_2/", any(), any(), any(), any())
+                GcAndroidTestMatrix.build(any(), any(), "test_dir/matrix_2_1/", any(), any(), any(), any())
+            }
+
+            verify(inverse = true) {
+                GcAndroidTestMatrix.build(any(), any(), "test_dir/matrix_0_2/", any(), any(), any(), any())
+            }
+        }
+    }
+
+    @Test
+    fun `shouldn't add additional index if repeatTests not set`() {
+        val androidArgs = AndroidArgs.load(mixedConfigYaml)
+        mockkObject(GcAndroidTestMatrix, androidArgs) {
+
+            every { androidArgs.resultsDir } returns "test_dir"
+            every { androidArgs.resultsBucket } returns "test_bucket"
+
+            runBlocking {
+                runAndroidTests(androidArgs)
+            }
+
+            verify(inverse = true) {
+                GcAndroidTestMatrix.build(any(), any(), "test_dir/matrix_0_1/", any(), any(), any(), any())
+            }
+
+            verify {
+                GcAndroidTestMatrix.build(any(), any(), "test_dir/matrix_0/", any(), any(), any(), any())
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1258 

## Test Plan
> How do we know the code works?

1. When ```num-test-runs``` set Flank should add to the matrix directory name ```_$index``` on end.
2. When ```num-test-runs``` not set directory name shouldn't contain an additional index.
