### PR TITLE
fix: Fix getting PR number on pull_request_review

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -15,6 +15,8 @@ jobs:
         id: reviews
         run: |
           PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          echo $PR_NUMBER
+          echo $GITHUB_REF
           export count2=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/flank/flank/pulls/${PR_NUMBER}/reviews -s | grep -i -c '"state": "APPROVED"')
           echo $count
           echo "::set-output name=approved::${count}"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -15,7 +15,7 @@ jobs:
         id: reviews
         run: |
           PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
-          export count=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/flank/flank/pulls/$PR_NUMBER/reviews -s | grep -i -c '"state": "APPROVED"')
+          export count2=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/flank/flank/pulls/${PR_NUMBER}/reviews -s | grep -i -c '"state": "APPROVED"')
           echo $count
           echo "::set-output name=approved::${count}"
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -17,7 +17,7 @@ jobs:
           PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
           echo $PR_NUMBER
           echo $GITHUB_REF
-          export count2=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/flank/flank/pulls/${PR_NUMBER}/reviews -s | grep -i -c '"state": "APPROVED"')
+          export count=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/flank/flank/pulls/${PR_NUMBER}/reviews -s | grep -i -c '"state": "APPROVED"')
           echo $count
           echo "::set-output name=approved::${count}"
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,7 +14,8 @@ jobs:
       - name: Count approve count
         id: reviews
         run: |
-          export count=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/flank/flank/pulls/${{github.event.number}}/reviews -s | grep -i -c '"state": "APPROVED"')
+          PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          export count=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/flank/flank/pulls/$PR_NUMBER/reviews -s | grep -i -c '"state": "APPROVED"')
           echo $count
           echo "::set-output name=approved::${count}"
 


### PR DESCRIPTION
## Test Plan
> How do we know the code works?

PR number for event `pull_request_review` is not correctly delivered withing `${{github.event.number}}`.
It needs to be fetched from `$GITHUB_REF`
