### PR TITLE
feat: Add --test-special-entitlements for iOS

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -176,6 +176,11 @@ gcloud:
   ## The type of iOS test to run. TYPE must be one of: xctest, game-loop. Default: xctest
   # type: xctest
 
+  ## Enables testing special app entitlements. Re-signs an app having special entitlements with a new application-identifier.
+  ## This currently supports testing Push Notifications (aps-environment) entitlement for up to one app in a project.
+  ## Note: Because this changes the app's identifier, make sure none of the resources in your zip file contain direct references to the test app's bundle id.
+  # test-special-entitlements: false
+
 flank:
   # -- FlankYml --
 

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -107,6 +107,11 @@ gcloud:
   ## The type of iOS test to run. TYPE must be one of: xctest, game-loop. Default: xctest
   # type: xctest
 
+  ## Enables testing special app entitlements. Re-signs an app having special entitlements with a new application-identifier.
+  ## This currently supports testing Push Notifications (aps-environment) entitlement for up to one app in a project.
+  ## Note: Because this changes the app's identifier, make sure none of the resources in your zip file contain direct references to the test app's bundle id.
+  # test-special-entitlements: false
+
 flank:
   # -- FlankYml --
 
@@ -144,7 +149,7 @@ flank:
   ## Default: 240.0
   # default-class-test-time: 30
 
-## Disables sharding. Useful for parameterized tests.
+  ## Disables sharding. Useful for parameterized tests.
   # disable-sharding: false
 
   ## always run - these tests are inserted at the beginning of every shard

--- a/test_runner/src/main/kotlin/ftl/args/CreateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateIosArgs.kt
@@ -30,7 +30,8 @@ private fun createIosArgs(
     xcodeVersion = gcloud.xcodeVersion,
     additionalIpas = gcloud.additionalIpas!!.map { it.normalizeFilePath() },
     testTargets = flank.testTargets?.filterNotNull().orEmpty(),
-    obfuscateDumpShards = obfuscate
+    obfuscateDumpShards = obfuscate,
+    testSpecialEntitlements = gcloud.testSpecialEntitlements ?: false
 )
 
 private fun convertToShardCount(inputValue: Int) =

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -14,7 +14,8 @@ data class IosArgs(
     val xcodeVersion: String?,
     val testTargets: List<String>,
     val obfuscateDumpShards: Boolean,
-    val additionalIpas: List<String>
+    val additionalIpas: List<String>,
+    val testSpecialEntitlements: Boolean?
 ) : IArgs by commonArgs {
 
     override val useLegacyJUnitResult = true
@@ -45,6 +46,7 @@ IosArgs
       additional-ipas: ${ArgsToString.listToString(additionalIpas)}
       scenario-numbers: ${ArgsToString.listToString(scenarioNumbers)}
       type: ${type?.ymlName}
+      test-special-entitlements: $testSpecialEntitlements
 
     flank:
       max-test-shards: $maxTestShards

--- a/test_runner/src/main/kotlin/ftl/config/ios/IosGcloudConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/ios/IosGcloudConfig.kt
@@ -58,6 +58,17 @@ data class IosGcloudConfig @JsonIgnore constructor(
     @set:JsonProperty("additional-ipas")
     var additionalIpas: List<String>? by data
 
+    @set:CommandLine.Option(
+        names = ["--test-special-entitlements"],
+        description = ["Enables testing special app entitlements. Re-signs an app having special entitlements with a new" +
+            " application-identifier. This currently supports testing Push Notifications (aps-environment) entitlement " +
+            "for up to one app in a project.\n" +
+            "Note: Because this changes the app's identifier, make sure none of the resources in your zip file contain " +
+            "direct references to the test app's bundle id."]
+    )
+    @set:JsonProperty("test-special-entitlements")
+    var testSpecialEntitlements: Boolean? by data
+
     constructor() : this(mutableMapOf<String, Any?>().withDefault { null })
 
     companion object : IYmlKeys {
@@ -73,6 +84,7 @@ data class IosGcloudConfig @JsonIgnore constructor(
             xctestrunFile = null
             xcodeVersion = null
             additionalIpas = emptyList()
+            testSpecialEntitlements = false
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
@@ -65,6 +65,7 @@ object GcIosTestMatrix {
             .setTestsZip(FileReference().setGcsPath(testZipGcsPath))
             .setXctestrun(FileReference().setGcsPath(xctestrunFileGcsPath))
             .setXcodeVersion(args.xcodeVersion)
+            .setTestSpecialEntitlements(args.testSpecialEntitlements)
 
         val iOSTestSetup = IosTestSetup()
             .setNetworkProfile(args.networkProfile)

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -12,10 +12,12 @@ fun main() {
     // run "gradle check" to generate required fixtures
     val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
         ?: "YOUR PROJECT ID"
+/*
 
     val quantity = "multiple"
     val type = "gameloop"
     val extra = "obb"
+*/
 
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151
@@ -24,14 +26,15 @@ fun main() {
 //            "--debug",
             "firebase",
             "test",
-            "android",
+            "ios",
             "run",
 //            "--dry",
 //            "--dump-shards",
             "--output-style=single",
 //            "--full-junit-result",
 //            "--legacy-junit-result",
-            "-c=test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type-$extra.yml",
+            "-c=/Users/piotr/Projekty/gogo/flank/test_runner/src/test/kotlin/ftl/fixtures/simple-ios-flank.yml",
+//            "-c=test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type-$extra.yml",
             "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"
         )

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -78,6 +78,7 @@ class IosArgsTest {
             orientation: default
           num-flaky-test-attempts: 4
           type: xctest
+          test-special-entitlements: true
 
         flank:
           max-test-shards: 7
@@ -244,6 +245,7 @@ IosArgs
         - $testIpa2
       scenario-numbers: 
       type: xctest
+      test-special-entitlements: true
 
     flank:
       max-test-shards: 7
@@ -306,6 +308,7 @@ IosArgs
       additional-ipas: 
       scenario-numbers: 
       type: xctest
+      test-special-entitlements: false
 
     flank:
       max-test-shards: 1

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
@@ -398,4 +398,12 @@ class IosRunCommandTest {
 
         assertThat(cmd.config.common.gcloud.type).isEqualTo("a")
     }
+
+    @Test
+    fun `should properly parse test-special-entitlements`() {
+        val cmd = IosRunCommand()
+        CommandLine(cmd).parseArgs("--test-special-entitlements")
+
+        assertThat(cmd.config.platform.gcloud.testSpecialEntitlements).isEqualTo(true)
+    }
 }


### PR DESCRIPTION
Fixes #1197 

## Test Plan
> How do we know the code works?

`--test-special-entitlements` is properly passed as a parameter using CLI and `yaml` config.
I've tested this option using Gcloud and Flank and behavior is the same.
I do not know how to test the impact  of this option on tests

## Checklist

- [x] Documented
- [x] Unit tested
