### PR TITLE
fix: Print formatted message instead of throwing NPE

### DIFF
--- a/test_runner/src/main/kotlin/ftl/args/CreateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateAndroidArgs.kt
@@ -4,6 +4,7 @@ import ftl.args.yml.AppTestPair
 import ftl.config.AndroidConfig
 import ftl.config.android.AndroidFlankConfig
 import ftl.config.android.AndroidGcloudConfig
+import ftl.util.require
 
 fun createAndroidArgs(
     config: AndroidConfig? = null,
@@ -16,15 +17,15 @@ fun createAndroidArgs(
     // gcloud
     appApk = gcloud.app?.normalizeFilePath(),
     testApk = gcloud.test?.normalizeFilePath(),
-    useOrchestrator = gcloud.useOrchestrator!!,
-    testTargets = gcloud.testTargets!!.filterNotNull(),
+    useOrchestrator = gcloud::useOrchestrator.require(),
+    testTargets = gcloud::testTargets.require().filterNotNull(),
     testRunnerClass = gcloud.testRunnerClass,
-    roboDirectives = gcloud.roboDirectives!!.parseRoboDirectives(),
-    performanceMetrics = gcloud.performanceMetrics!!,
+    roboDirectives = gcloud::roboDirectives.require().parseRoboDirectives(),
+    performanceMetrics = gcloud::performanceMetrics.require(),
     numUniformShards = gcloud.numUniformShards,
-    environmentVariables = gcloud.environmentVariables!!,
-    autoGoogleLogin = gcloud.autoGoogleLogin!!,
-    additionalApks = gcloud.additionalApks!!.map { it.normalizeFilePath() },
+    environmentVariables = gcloud::environmentVariables.require(),
+    autoGoogleLogin = gcloud::autoGoogleLogin.require(),
+    additionalApks = gcloud::additionalApks.require().map { it.normalizeFilePath() },
     roboScript = gcloud.roboScript?.normalizeFilePath(),
 
     // flank
@@ -35,10 +36,10 @@ fun createAndroidArgs(
             environmentVariables = env
         )
     } ?: emptyList(),
-    useLegacyJUnitResult = flank.useLegacyJUnitResult!!,
-    scenarioLabels = gcloud.scenarioLabels!!,
+    useLegacyJUnitResult = flank::useLegacyJUnitResult.require(),
+    scenarioLabels = gcloud::scenarioLabels.require(),
     obfuscateDumpShards = obfuscate,
-    obbFiles = gcloud.obbfiles!!,
-    obbNames = gcloud.obbnames!!,
+    obbFiles = gcloud::obbfiles.require(),
+    obbNames = gcloud::obbnames.require(),
     grantPermissions = gcloud.grantPermissions
 )

--- a/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
@@ -4,6 +4,7 @@ import ftl.args.yml.toType
 import ftl.config.CommonConfig
 import ftl.run.status.OutputStyle
 import ftl.run.status.asOutputStyle
+import ftl.util.require
 import ftl.util.uniqueObjectName
 
 fun CommonConfig.createCommonArgs(
@@ -12,44 +13,44 @@ fun CommonConfig.createCommonArgs(
     data = data,
 
     // gcloud
-    devices = gcloud.devices!!,
+    devices = gcloud::devices.require(),
     resultsBucket = ArgsHelper.createGcsBucket(
-        projectId = flank.project!!,
-        bucket = gcloud.resultsBucket!!
+        projectId = flank::project.require(),
+        bucket = gcloud::resultsBucket.require()
     ),
     resultsDir = gcloud.resultsDir ?: uniqueObjectName(),
-    recordVideo = gcloud.recordVideo!!,
-    testTimeout = gcloud.timeout!!,
-    async = gcloud.async!!,
+    recordVideo = gcloud::recordVideo.require(),
+    testTimeout = gcloud::timeout.require(),
+    async = gcloud::async.require(),
     resultsHistoryName = gcloud.resultsHistoryName,
-    flakyTestAttempts = gcloud.flakyTestAttempts!!,
+    flakyTestAttempts = gcloud::flakyTestAttempts.require(),
     networkProfile = gcloud.networkProfile,
     clientDetails = gcloud.clientDetails,
-    directoriesToPull = gcloud.directoriesToPull!!,
-    otherFiles = gcloud.otherFiles!!.mapValues { (_, path) -> path.normalizeFilePath() },
-    scenarioNumbers = gcloud.scenarioNumbers!!,
+    directoriesToPull = gcloud::directoriesToPull.require(),
+    otherFiles = gcloud::otherFiles.require().mapValues { (_, path) -> path.normalizeFilePath() },
+    scenarioNumbers = gcloud::scenarioNumbers.require(),
     type = gcloud.type?.toType(),
 
     // flank
-    maxTestShards = flank.maxTestShards!!,
-    shardTime = flank.shardTime!!,
-    repeatTests = flank.repeatTests!!,
-    smartFlankGcsPath = flank.smartFlankGcsPath!!,
-    smartFlankDisableUpload = flank.smartFlankDisableUpload!!,
-    testTargetsAlwaysRun = flank.testTargetsAlwaysRun!!,
-    runTimeout = flank.runTimeout!!,
-    fullJUnitResult = flank.fullJUnitResult!!,
-    project = flank.project!!,
+    maxTestShards = flank::maxTestShards.require(),
+    shardTime = flank::shardTime.require(),
+    repeatTests = flank::repeatTests.require(),
+    smartFlankGcsPath = flank::smartFlankGcsPath.require(),
+    smartFlankDisableUpload = flank::smartFlankDisableUpload.require(),
+    testTargetsAlwaysRun = flank::testTargetsAlwaysRun.require(),
+    runTimeout = flank::runTimeout.require(),
+    fullJUnitResult = flank::fullJUnitResult.require(),
+    project = flank::project.require(),
     outputStyle = outputStyle,
-    keepFilePath = flank.keepFilePath!!,
-    ignoreFailedTests = flank.ignoreFailedTests!!,
-    filesToDownload = flank.filesToDownload!!,
-    disableSharding = flank.disableSharding!!,
-    localResultDir = flank.localResultsDir!!,
-    disableResultsUpload = flank.disableResultsUpload!!,
-    defaultTestTime = flank.defaultTestTime!!,
-    defaultClassTestTime = flank.defaultClassTestTime!!,
-    useAverageTestTimeForNewTests = flank.useAverageTestTimeForNewTests!!
+    keepFilePath = flank::keepFilePath.require(),
+    ignoreFailedTests = flank::ignoreFailedTests.require(),
+    filesToDownload = flank::filesToDownload.require(),
+    disableSharding = flank::disableSharding.require(),
+    localResultDir = flank::localResultsDir.require(),
+    disableResultsUpload = flank::disableResultsUpload.require(),
+    defaultTestTime = flank::defaultTestTime.require(),
+    defaultClassTestTime = flank::defaultClassTestTime.require(),
+    useAverageTestTimeForNewTests = flank::useAverageTestTimeForNewTests.require()
 ).apply {
     ArgsHelper.createJunitBucket(project, smartFlankGcsPath)
 }

--- a/test_runner/src/main/kotlin/ftl/args/CreateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateIosArgs.kt
@@ -4,6 +4,7 @@ import ftl.args.yml.Type
 import ftl.config.IosConfig
 import ftl.config.ios.IosFlankConfig
 import ftl.config.ios.IosGcloudConfig
+import ftl.util.require
 
 fun createIosArgs(
     config: IosConfig,
@@ -28,7 +29,7 @@ private fun createIosArgs(
     xctestrunZip = gcloud.test?.normalizeFilePath().orEmpty(),
     xctestrunFile = gcloud.xctestrunFile?.normalizeFilePath().orEmpty(),
     xcodeVersion = gcloud.xcodeVersion,
-    additionalIpas = gcloud.additionalIpas!!.map { it.normalizeFilePath() },
+    additionalIpas = gcloud::additionalIpas.require().map { it.normalizeFilePath() },
     testTargets = flank.testTargets?.filterNotNull().orEmpty(),
     obfuscateDumpShards = obfuscate,
     app = gcloud.app?.normalizeFilePath().orEmpty(),

--- a/test_runner/src/main/kotlin/ftl/util/Utils.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Utils.kt
@@ -2,6 +2,7 @@
 
 package ftl.util
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import ftl.run.exception.FlankGeneralError
 import java.io.InputStream
 import java.io.StringWriter
@@ -12,6 +13,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Random
 import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KProperty
 
 fun String.trimStartLine(): String {
@@ -132,3 +134,12 @@ fun <R : MutableMap<String, Any>, T> mutableMapProperty(
     override fun setValue(thisRef: R, property: KProperty<*>, value: T) =
         thisRef.set(name ?: property.name, value as Any)
 }
+
+/**
+ * Used to validate values from yml config file.
+ * Should be used only on properties with [JsonProperty] annotation.
+ */
+fun <T> KMutableProperty<T?>.require() =
+    getter.call() ?: throw FlankGeneralError(
+        "Invalid value for [${setter.annotations.filterIsInstance<JsonProperty>().first().value}]: no argument value found"
+    )

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -1928,6 +1928,7 @@ AndroidArgs
         """.trimIndent()
         AndroidArgs.load(yaml).validate()
     }
+
     @Test(expected = FlankGeneralError::class)
     fun `should throw exception if incorrect type requested`() {
         val yaml = """
@@ -2304,6 +2305,37 @@ AndroidArgs
             - $obbFile
         """.trimIndent()
         AndroidArgs.load(yaml).validate()
+    }
+
+    @Test
+    fun `should throw exception if incorrect (empty) value used in yml config file`() {
+        assertThrowsWithMessage(
+            clazz = FlankGeneralError::class,
+            message = "Invalid value for [test-targets]: no argument value found"
+        ) {
+            AndroidArgs.load(
+                """
+            gcloud:
+              app: any/path.apk
+              test-targets:
+        """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun `should not throw exception if incorrect (empty) value used in yml config file is overwriten with command line`() {
+        val cli = AndroidRunCommand()
+        CommandLine(cli).parseArgs("--legacy-junit-result")
+
+        AndroidArgs.load(
+            """
+            gcloud:
+              app: any/path.apk
+            flank:
+              legacy-junit-result:
+        """.trimIndent(), cli
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #1294 

## Test Plan
> How do we know the code works?

1. Prepare config, for instance:
    ```
    gcloud:
      app: [any app]
    flank:
      legacy-junit-result:
    ```
    (notice no value for `legacy-junit-result`)
1. Run flank with created config
1. Flank run should terminate with a message `Invalid value for [legacy-junit-result]: no argument value found` and without any stack trace
1. Run again but with `--legacy-junit-result` flag
1. Flank should proceed normally and `legacy-junit-result` should be equal `true`

## Checklist

- [x] Unit tested
