### PR TITLE
fix: Fix incorrect printed shards number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ local.properties
 /report.json
 results
 xcuserdata/
+android_shards.json

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -23,7 +23,7 @@ suspend fun dumpShards(
     saveShardChunks(
         shardFilePath = shardFilePath,
         shards = shards,
-        size = shards.size,
+        size = shards.flatMap { it.value.shards.values }.count(),
         obfuscatedOutput = args.obfuscateDumpShards
     )
 }

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -12,12 +12,10 @@ fun main() {
     // run "gradle check" to generate required fixtures
     val projectId = System.getenv("GOOGLE_CLOUD_PROJECT")
         ?: "YOUR PROJECT ID"
-/*
 
     val quantity = "multiple"
     val type = "gameloop"
     val extra = "obb"
-*/
 
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151
@@ -33,8 +31,7 @@ fun main() {
             "--output-style=single",
 //            "--full-junit-result",
 //            "--legacy-junit-result",
-            "-c=/Users/piotr/Projekty/gogo/flank/test_runner/src/test/kotlin/ftl/fixtures/simple-ios-flank.yml",
-//            "-c=test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type-$extra.yml",
+            "-c=test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type-$extra.yml",
             "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"
         )

--- a/test_runner/src/test/kotlin/ftl/run/DumpShardsKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/DumpShardsKtTest.kt
@@ -16,9 +16,18 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
+import org.junit.After
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.SystemOutRule
 
 @RunWith(FlankTestRunner::class)
 class DumpShardsKtTest {
+
+    @get:Rule
+    val output: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @After
+    fun tearDown() = output.clearLog()
 
     @Test
     fun `dump shards android`() {
@@ -75,6 +84,7 @@ class DumpShardsKtTest {
 
         // then
         assertEqualsIgnoreNewlineStyle(expected, actual)
+        assertThat(output.log).contains("Saved 3 shards to $TEST_SHARD_FILE")
     }
 
     @Test
@@ -132,6 +142,7 @@ class DumpShardsKtTest {
         // then
         assertNotEquals(notExpected, actual)
         assertThat(notExpected.split(System.lineSeparator()).size).isEqualTo(actual.split(System.lineSeparator()).size) // same line count
+        assertThat(output.log).contains("Saved 3 shards to $TEST_SHARD_FILE")
     }
 
     @Test
@@ -161,6 +172,7 @@ class DumpShardsKtTest {
 
         // then
         assertEquals(expected, actual)
+        assertThat(output.log).contains("Saved 2 shards to $TEST_SHARD_FILE")
     }
 
     @Test
@@ -192,6 +204,7 @@ class DumpShardsKtTest {
         // then
         assertNotEquals(notExpected, actual)
         assertThat(notExpected.split(System.lineSeparator()).size).isEqualTo(actual.split(System.lineSeparator()).size) // same line count
+        assertThat(output.log).contains("Saved 2 shards to $TEST_SHARD_FILE")
     }
 }
 


### PR DESCRIPTION
Fixes #1296 

## Test Plan
> How do we know the code works?

1. Prepare config:
    ```
    gcloud:
      app: [app from test artifacts]
      test: [multiple-success test apk]
    flank:
      max-test-shards: 50
    ```
1. Run flank for android with --dump-shards
1. Observe `Saved 15 shards to android_shards.json` is being printed.

## Checklist

- [x] Unit tested
