### PR TITLE
fix: Nested subdirectories in results-dir

### DIFF
--- a/test_runner/src/main/kotlin/ftl/util/MatrixUtil.kt
+++ b/test_runner/src/main/kotlin/ftl/util/MatrixUtil.kt
@@ -5,14 +5,10 @@ import ftl.json.MatrixMap
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-fun resolveLocalRunPath(matrices: MatrixMap, args: IArgs): String {
-    if (args.useLocalResultDir()) return args.localResultDir
-
-    val runPath = File(matrices.runPath)
-    if (!runPath.exists()) return join(args.localResultDir, runPath.name)
-
-    // avoid File().toString() as that will use a '\' path separator.
-    return matrices.runPath
+fun resolveLocalRunPath(matrices: MatrixMap, args: IArgs) = when {
+    args.useLocalResultDir() -> args.localResultDir
+    File(matrices.runPath).exists() -> matrices.runPath
+    else -> join(args.localResultDir, matrices.runPath).also { localPath -> File(localPath).mkdirs() }
 }
 
 fun timeoutToSeconds(timeout: String): Long {

--- a/test_runner/src/test/kotlin/ftl/util/MatrixUtilTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/MatrixUtilTest.kt
@@ -2,14 +2,17 @@ package ftl.util
 
 import com.google.common.truth.Truth.assertThat
 import ftl.args.AndroidArgs
+import ftl.args.IArgs
 import ftl.json.MatrixMap
 import ftl.test.util.FlankTestRunner
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.junit.After
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 
 @RunWith(FlankTestRunner::class)
 class MatrixUtilTest {
@@ -35,15 +38,30 @@ class MatrixUtilTest {
     }
 
     @Test
-    fun `resolveLocalRunPath validInput`() {
-        val matrixMap = mockk<MatrixMap>()
-        every { matrixMap.runPath } returns "a/b"
+    fun `should return localResultDir if provided`() {
+        val mockedArgs = mockk<IArgs>()
+        every { mockedArgs.useLocalResultDir() } returns true
+        every { mockedArgs.localResultDir } returns "/tmp"
 
-        assertThat(resolveLocalRunPath(matrixMap, AndroidArgs.default())).isEqualTo("results/b")
+        assertThat(resolveLocalRunPath(MatrixMap(emptyMap(), ""), mockedArgs)).isEqualTo("/tmp")
     }
 
     @Test
-    fun `resolveLocalRunPath pathExists`() {
+    fun `should newly created directory and if do not use localResultDir and runPath not exist`() {
+        // given
+        val matrixMap = mockk<MatrixMap>()
+        every { matrixMap.runPath } returns "a/b"
+
+        // when
+        val localRunPath = resolveLocalRunPath(matrixMap, AndroidArgs.default())
+
+        // then
+        assertThat(localRunPath).isEqualTo("results/a/b")
+        assertTrue(File(localRunPath).exists())
+    }
+
+    @Test
+    fun `should return run path if directory already exist`() {
         val matrixMap = mockk<MatrixMap>()
         every { matrixMap.runPath } returns "/tmp"
 


### PR DESCRIPTION
Fixes #1309 

Nested directories are supported out of the box in GCloud results upload. 
However Flank has an issue that it throws an exception because it did not properly store results in the local directory.
In order to support nested directories, local issue must be fixed

## Test Plan
> How do we know the code works?

1. Set configuration to contains nested result directories usimg `results-dir`
ex: 
```yaml
gcloud:
...
  results-dir: nested/results
....
```
2. Run tests and see that results are properly updated to  GCloud storage and stored locally

## Checklist

- [x] Unit tested
