### PR TITLE
fix: Uploading performance metrics for multiple matrices

### DIFF
--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -90,8 +90,6 @@ object GcStorage {
             )
         }.onFailure {
             println("Cannot upload performance metrics ${it.message}")
-        }.onSuccess {
-            println("Performance metrics uploaded to https://console.developers.google.com/storage/browser/$resultsBucket/$resultDir")
         }.getOrNull()
 
     fun uploadReportResult(testResult: String, args: IArgs, fileName: String) {

--- a/test_runner/src/main/kotlin/ftl/reports/api/PerformanceMetrics.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/api/PerformanceMetrics.kt
@@ -21,7 +21,9 @@ internal fun List<Pair<TestExecution, String>>.getAndUploadPerformanceMetrics(
             async(Dispatchers.IO) {
                 val performanceMetrics = testExecution.getPerformanceMetric()
                 performanceMetrics.save(gcsStoragePath, args)
-                performanceMetrics.upload(resultBucket = args.resultsBucket, resultDir = gcsStoragePath)
+                if (args.disableResultsUpload.not()) {
+                    performanceMetrics.upload(resultBucket = args.resultsBucket, resultDir = gcsStoragePath)
+                }
             }
         }
         .awaitAll()

--- a/test_runner/src/main/kotlin/ftl/util/ProgressBar.kt
+++ b/test_runner/src/main/kotlin/ftl/util/ProgressBar.kt
@@ -24,3 +24,19 @@ private class ProgressBarTask : TimerTask() {
         print(".")
     }
 }
+
+fun runWithProgress(
+    startMessage: String,
+    action: () -> Unit,
+    onError: (Exception) -> Unit
+) {
+    val progress = ProgressBar()
+    try {
+        progress.start(startMessage)
+        action()
+    } catch (e: Exception) {
+        onError(e)
+    } finally {
+        progress.stop()
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/util/ProgressBarTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/ProgressBarTest.kt
@@ -2,6 +2,9 @@ package ftl.util
 
 import com.google.common.truth.Truth.assertThat
 import ftl.test.util.TestHelper.normalizeLineEnding
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemOutRule
@@ -22,5 +25,54 @@ class ProgressBarTest {
 
         progress.stop()
         assertThat(systemOutRule.log.normalizeLineEnding()).isEqualTo("  hi .\n")
+    }
+
+    @Test
+    fun `should properly wrap progress bar execution using helper function for success`() {
+        // given
+        val action: Runnable = mockk {
+            every { run() } returns Unit
+        }
+        val onError: Runnable = mockk {
+            every { run() } returns Unit
+        }
+
+        // when
+        runWithProgress(
+            startMessage = "TEST",
+            action = { action.run() },
+            onError = { onError.run() }
+        )
+
+        // then
+        assertThat(systemOutRule.log).contains("  TEST .")
+        verify { action.run() }
+        verify(exactly = 0) { onError.run() }
+    }
+
+    @Test
+    fun `should properly wrap progress bar execution using helper function for failure`() {
+        // given
+        val action: Runnable = mockk {
+            every { run() } returns Unit
+        }
+        val onError: Runnable = mockk {
+            every { run() } returns Unit
+        }
+
+        // when
+        runWithProgress(
+            startMessage = "TEST",
+            action = {
+                action.run()
+                throw Exception()
+            },
+            onError = { onError.run() }
+        )
+
+        // then
+        assertThat(systemOutRule.log).contains("  TEST .")
+        verify { action.run() }
+        verify { onError.run() }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/util/ProgressBarTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/ProgressBarTest.kt
@@ -45,7 +45,7 @@ class ProgressBarTest {
         )
 
         // then
-        assertThat(systemOutRule.log).contains("  TEST .")
+        assertThat(systemOutRule.log).contains("  TEST ")
         verify { action.run() }
         verify(exactly = 0) { onError.run() }
     }
@@ -71,7 +71,7 @@ class ProgressBarTest {
         )
 
         // then
-        assertThat(systemOutRule.log).contains("  TEST .")
+        assertThat(systemOutRule.log).contains("  TEST ")
         verify { action.run() }
         verify { onError.run() }
     }


### PR DESCRIPTION
Fixes #1322 

## Test Plan
> How do we know the code works?

1. Run flank on Android physical device. For example with configuration entry:
```yaml
gcloud:
...
  device:
    - model: OnePlus6T
      version: 28
...
```
2. Run Flank with multiple matrices. Example with using option
```yaml
...
flank:
  num-test-runs: 2
...
```

3. Check that `performanceMetrics.json` is uploaded for each matrix

## Checklist

- [x] Unit tested
