### PR TITLE
chore: use title+body for commit message

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,6 +7,7 @@ pull_request_rules:
         strict: true
         strict_method: rebase
         method: squash
+        commit_message: title+body
   - name: ask to fix PR title
     conditions:
       - status-failure=check_title


### PR DESCRIPTION
## Test Plan
> How do we know the code works?

Mergify will use PR title and body as commit message and description when will merge PR.
It prevents us for having dummy message as commit messages and long list of unsquashed messages in description
![image](https://user-images.githubusercontent.com/65554637/99635258-0250f400-2a42-11eb-9815-cb06be923c46.png)

