### PR TITLE
fix: Fix printing supported versions id 

### DIFF
--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -34,7 +34,7 @@ object AndroidCatalog {
 
     private fun getModels(projectId: String) = deviceCatalog(projectId).models
 
-    fun Device.getDeviceSupportedVersionId(projectId: String): List<String> = getModels(projectId).find { it.id == model }?.supportedVersionIds
+    fun Device.getSupportedVersionId(projectId: String): List<String> = getModels(projectId).find { it.id == model }?.supportedVersionIds
         ?: emptyList()
 
     fun supportedVersionsAsTable(projectId: String) = getVersionsList(projectId).asPrintableTable()

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -2,6 +2,7 @@ package ftl.android
 
 import com.google.api.services.testing.model.AndroidDevice
 import com.google.api.services.testing.model.AndroidDeviceCatalog
+import ftl.config.Device
 import ftl.environment.android.asPrintableTable
 import ftl.environment.android.getDescription
 import ftl.environment.asPrintableTable
@@ -32,6 +33,9 @@ object AndroidCatalog {
     fun describeModel(projectId: String, modelId: String) = getModels(projectId).getDescription(modelId)
 
     private fun getModels(projectId: String) = deviceCatalog(projectId).models
+
+    fun Device.getDeviceSupportedVersionId(projectId: String): List<String> = getModels(projectId).find { it.id == model }?.supportedVersionIds
+        ?: emptyList()
 
     fun supportedVersionsAsTable(projectId: String) = getVersionsList(projectId).asPrintableTable()
 

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -1,6 +1,7 @@
 package ftl.args
 
 import ftl.android.AndroidCatalog
+import ftl.android.AndroidCatalog.getDeviceSupportedVersionId
 import ftl.android.IncompatibleModelVersion
 import ftl.android.SupportedDeviceConfig
 import ftl.android.UnsupportedModelId
@@ -108,7 +109,7 @@ private fun AndroidArgs.assertDevicesSupported() = devices
                     AndroidCatalog.androidVersionIds(project)
                 }"
             )
-            IncompatibleModelVersion -> throw IncompatibleTestDimensionError("Incompatible model, '${device.model}', and version, '${device.version}'\nSupported version ids for '${device.model}': $check")
+            IncompatibleModelVersion -> throw IncompatibleTestDimensionError("Incompatible model, '${device.model}', and version, '${device.version}'\nSupported version ids for '${device.model}': ${device.getDeviceSupportedVersionId(project).joinToString { it }}")
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -1,7 +1,7 @@
 package ftl.args
 
 import ftl.android.AndroidCatalog
-import ftl.android.AndroidCatalog.getDeviceSupportedVersionId
+import ftl.android.AndroidCatalog.getSupportedVersionId
 import ftl.android.IncompatibleModelVersion
 import ftl.android.SupportedDeviceConfig
 import ftl.android.UnsupportedModelId
@@ -109,7 +109,7 @@ private fun AndroidArgs.assertDevicesSupported() = devices
                     AndroidCatalog.androidVersionIds(project)
                 }"
             )
-            IncompatibleModelVersion -> throw IncompatibleTestDimensionError("Incompatible model, '${device.model}', and version, '${device.version}'\nSupported version ids for '${device.model}': ${device.getDeviceSupportedVersionId(project).joinToString { it }}")
+            IncompatibleModelVersion -> throw IncompatibleTestDimensionError("Incompatible model, '${device.model}', and version, '${device.version}'\nSupported version ids for '${device.model}': ${device.getSupportedVersionId(project).joinToString { it }}")
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -2,6 +2,7 @@ package ftl.args
 
 import ftl.args.yml.Type
 import ftl.ios.IosCatalog
+import ftl.ios.IosCatalog.getSupportedVersionId
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.IncompatibleTestDimensionError
 
@@ -66,7 +67,7 @@ private fun IosArgs.assertXcodeSupported() = when {
 
 private fun IosArgs.assertDevicesSupported() = devices.forEach { device ->
     if (!IosCatalog.supportedDevice(device.model, device.version, this.project))
-        throw IncompatibleTestDimensionError("iOS ${device.version} on ${device.model} is not a supported device")
+        throw IncompatibleTestDimensionError("iOS ${device.version} on ${device.model} is not a supported\nSupported version ids for '${device.model}': ${device.getSupportedVersionId(project).joinToString { it }}")
 }
 
 private fun IosArgs.assertTestFiles() {

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -67,7 +67,7 @@ private fun IosArgs.assertXcodeSupported() = when {
 
 private fun IosArgs.assertDevicesSupported() = devices.forEach { device ->
     if (!IosCatalog.supportedDevice(device.model, device.version, this.project))
-        throw IncompatibleTestDimensionError("iOS ${device.version} on ${device.model} is not a supported\nSupported version ids for '${device.model}': ${device.getSupportedVersionId(project).joinToString { it }}")
+        throw IncompatibleTestDimensionError("iOS ${device.version} on ${device.model} is not a supported\nSupported version ids for '${device.model}': ${device.getSupportedVersionId(project).joinToString()}")
 }
 
 private fun IosArgs.assertTestFiles() {

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -1,6 +1,7 @@
 package ftl.ios
 
 import com.google.api.services.testing.model.IosDeviceCatalog
+import ftl.config.Device
 import ftl.environment.asPrintableTable
 import ftl.environment.common.asPrintableTable
 import ftl.environment.getLocaleDescription
@@ -50,6 +51,9 @@ object IosCatalog {
         versionId: String,
         projectId: String
     ) = iosDeviceCatalog(projectId).models.find { it.id == modelId }?.supportedVersionIds?.contains(versionId) ?: false
+
+    fun Device.getSupportedVersionId(projectId: String): List<String> = iosDeviceCatalog(projectId).models.find { it.id == model }?.supportedVersionIds
+        ?: emptyList()
 
     // Device catalogMap is different depending on the project id
     private fun iosDeviceCatalog(

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -29,6 +29,7 @@ import ftl.run.exception.IncompatibleTestDimensionError
 import ftl.run.model.GameLoopContext
 import ftl.shard.Chunk
 import ftl.shard.TestMethod
+import ftl.test.util.TestHelper.getThrowable
 import ftl.util.asFileReference
 import io.mockk.every
 import io.mockk.mockkObject
@@ -2356,6 +2357,24 @@ AndroidArgs
             - com.example.test
         """.trimIndent()
         AndroidArgs.load(yaml).validate()
+    }
+
+    @Test
+    fun `should return correct message if version is not supported for device`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          device:
+            - model: Nexus7
+              version: 28
+        """.trimIndent()
+        val errorMessage = getThrowable { AndroidArgs.load(yaml).validate() }.message ?: ""
+        val expectedMessage = """
+            Incompatible model, 'Nexus7', and version, '28'
+            Supported version ids for 'Nexus7': 19, 21, 22
+        """.trimIndent()
+        assertEquals(expectedMessage, errorMessage)
     }
 }
 

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -129,8 +129,8 @@ flank:
 
     @Test
     fun `args invalidDeviceExits`() {
-        assertThrowsWithMessage(Throwable::class, "iOS 99.9 on iphoneZ is not a supported device") {
-            val invalidDevice = mutableListOf(Device("iphoneZ", "99.9"))
+        assertThrowsWithMessage(Throwable::class, "iOS 11.2 on iphonexsmax is not a supported\nSupported version ids for 'iphonexsmax': 12.0, 12.1") {
+            val invalidDevice = mutableListOf(Device("iphonexsmax", "11.2"))
             createIosArgs(
                 config = defaultIosConfig().apply {
                     common.gcloud.devices = invalidDevice


### PR DESCRIPTION
Fixes #1328 

## Test Plan
> How do we know the code works?

1. Run Flank with a configured device with not supported API level

```
  device:
    - model: OnePlus6T
      version: 19

```

or if you want to check how the message looks when we have more than one supported version

```

  device:
    - model: Nexus7
      version: 28

```

2. Error message should look like:

```

Incompatible model, 'OnePlus6T', and version, '19'
Supported version ids for 'OnePlus6T': 28


```


## Checklist

- [X] Fix printing on android
- [x] Verification and fix iOs
- [X] Unit tested
