### PR TITLE
refactor: Simplify beforeRunTests return singature

### DIFF
--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -44,10 +44,11 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
             MockServer.start()
         }
 
-        val config = AndroidArgs.load(Paths.get(configPath), cli = this).validate()
-        runBlocking {
-            if (dumpShards) dumpShards(args = config)
-            else newTestRun(config)
+        AndroidArgs.load(Paths.get(configPath), cli = this).validate().run {
+            runBlocking {
+                if (dumpShards) dumpShards()
+                else newTestRun()
+            }
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -44,12 +44,9 @@ class IosRunCommand : CommonRunCommand(), Runnable {
             MockServer.start()
         }
 
-        val config = IosArgs.load(Paths.get(configPath), cli = this).validate()
-
-        if (dumpShards) {
-            dumpShards(args = config)
-        } else runBlocking {
-            newTestRun(config)
+        IosArgs.load(Paths.get(configPath), cli = this).validate().run {
+            if (dumpShards) dumpShards()
+            else runBlocking { newTestRun() }
         }
     }
 

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -1,5 +1,6 @@
 package ftl.run
 
+import com.google.common.annotations.VisibleForTesting
 import ftl.args.AndroidArgs
 import ftl.args.IosArgs
 import ftl.args.isInstrumentationTest
@@ -12,31 +13,31 @@ import ftl.util.obfuscatePrettyPrinter
 import java.nio.file.Files
 import java.nio.file.Paths
 
-suspend fun dumpShards(
-    args: AndroidArgs,
+suspend fun AndroidArgs.dumpShards(
+    @VisibleForTesting
     shardFilePath: String = ANDROID_SHARD_FILE,
 ) {
-    if (!args.isInstrumentationTest) throw FlankConfigurationError(
+    if (!isInstrumentationTest) throw FlankConfigurationError(
         "Cannot dump shards for non instrumentation test, ensure test apk has been set."
     )
-    val shards: AndroidMatrixTestShards = args.getAndroidMatrixShards()
+    val shards: AndroidMatrixTestShards = getAndroidMatrixShards()
     saveShardChunks(
         shardFilePath = shardFilePath,
         shards = shards,
         size = shards.flatMap { it.value.shards.values }.count(),
-        obfuscatedOutput = args.obfuscateDumpShards
+        obfuscatedOutput = obfuscateDumpShards
     )
 }
 
-fun dumpShards(
-    args: IosArgs,
+fun IosArgs.dumpShards(
+    @VisibleForTesting
     shardFilePath: String = IOS_SHARD_FILE,
 ) {
     saveShardChunks(
         shardFilePath = shardFilePath,
-        shards = args.testShardChunks.testCases,
-        size = args.testShardChunks.size,
-        obfuscatedOutput = args.obfuscateDumpShards
+        shards = testShardChunks.testCases,
+        size = testShardChunks.size,
+        obfuscatedOutput = obfuscateDumpShards
     )
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -30,7 +30,7 @@ suspend fun AndroidArgs.dumpShards(
 }
 
 fun IosArgs.dumpShards(
-    @VisibleForTesting
+    // VisibleForTesting
     shardFilePath: String = IOS_SHARD_FILE,
 ) {
     saveShardChunks(

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -1,6 +1,5 @@
 package ftl.run
 
-import com.google.common.annotations.VisibleForTesting
 import ftl.args.AndroidArgs
 import ftl.args.IosArgs
 import ftl.args.isInstrumentationTest

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -14,7 +14,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 suspend fun AndroidArgs.dumpShards(
-    @VisibleForTesting
+    // VisibleForTesting
     shardFilePath: String = ANDROID_SHARD_FILE,
 ) {
     if (!isInstrumentationTest) throw FlankConfigurationError(

--- a/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
@@ -73,7 +73,7 @@ private suspend fun refreshMatrices(matrixMap: MatrixMap, args: IArgs) = corouti
 
     if (dirty) {
         println(FtlConstants.indent + "Updating matrix file")
-        updateMatrixFile(matrixMap, args)
+        args.updateMatrixFile(matrixMap)
     }
     println()
 }

--- a/test_runner/src/main/kotlin/ftl/run/common/FetchArtifacts.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/FetchArtifacts.kt
@@ -57,7 +57,7 @@ internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = corouti
 
     if (dirty) {
         println(FtlConstants.indent + "Updating matrix file")
-        updateMatrixFile(matrixMap, args)
+        args.updateMatrixFile(matrixMap)
         println()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/run/common/UpdateMatrixFile.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/UpdateMatrixFile.kt
@@ -7,12 +7,10 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
-internal fun updateMatrixFile(matrixMap: MatrixMap, args: IArgs): Path {
-    val matrixIdsPath = if (args.useLocalResultDir()) {
-        Paths.get(args.localResultDir, FtlConstants.matrixIdsFile)
-    } else {
-        Paths.get(args.localResultDir, matrixMap.runPath, FtlConstants.matrixIdsFile)
-    }
+internal fun IArgs.updateMatrixFile(matrixMap: MatrixMap): Path {
+    val matrixIdsPath = if (useLocalResultDir())
+        Paths.get(localResultDir, FtlConstants.matrixIdsFile) else
+        Paths.get(localResultDir, matrixMap.runPath, FtlConstants.matrixIdsFile)
     matrixIdsPath.parent.toFile().mkdirs()
     Files.write(matrixIdsPath, prettyPrint.toJson(matrixMap.map).toByteArray())
     return matrixIdsPath

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/UploadApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/UploadApks.kt
@@ -47,11 +47,11 @@ private fun GameLoopContext.upload(rootGcsBucket: String, runGcsPath: String) = 
 private fun SanityRoboTestContext.upload(rootGcsBucket: String, runGcsPath: String) =
     SanityRoboTestContext(app.uploadIfNeeded(rootGcsBucket, runGcsPath))
 
-suspend fun AndroidArgs.uploadAdditionalApks(runGcsPath: String) =
-    additionalApks.uploadToGcloudIfNeeded(runGcsPath, resultsBucket)
+suspend fun AndroidArgs.uploadAdditionalApks() =
+    additionalApks.uploadToGcloudIfNeeded(resultsDir, resultsBucket)
 
-suspend fun IosArgs.uploadAdditionalIpas(runGcsPath: String) =
-    additionalIpas.uploadToGcloudIfNeeded(runGcsPath, resultsBucket)
+suspend fun IosArgs.uploadAdditionalIpas() =
+    additionalIpas.uploadToGcloudIfNeeded(resultsDir, resultsBucket)
 
 private suspend fun List<String>.uploadToGcloudIfNeeded(
     runGcsPath: String,

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/UploadOtherFiles.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/UploadOtherFiles.kt
@@ -8,17 +8,15 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
-internal suspend fun IArgs.uploadOtherFiles(
-    runGcsPath: String
-): Map<String, String> = coroutineScope {
+internal suspend fun IArgs.uploadOtherFiles(): Map<String, String> = coroutineScope {
     otherFiles
         .map { (devicePath: String, filePath: String) ->
-            async(Dispatchers.IO) { devicePath to GcStorage.upload(filePath, resultsBucket, runGcsPath) }
+            async(Dispatchers.IO) { devicePath to GcStorage.upload(filePath, resultsBucket, resultsDir) }
         }.awaitAll().toMap()
 }
 
-internal suspend fun AndroidArgs.uploadObbFiles(runGcsPath: String): Map<String, String> = coroutineScope {
+internal suspend fun AndroidArgs.uploadObbFiles(): Map<String, String> = coroutineScope {
     obbFiles.map {
-        async(Dispatchers.IO) { it to GcStorage.upload(it, resultsBucket, runGcsPath) }
+        async(Dispatchers.IO) { it to GcStorage.upload(it, resultsBucket, resultsDir) }
     }.awaitAll().toMap()
 }

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunMessage.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunMessage.kt
@@ -5,8 +5,8 @@ import ftl.config.FtlConstants
 import ftl.shard.Chunk
 import ftl.shard.TestMethod
 
-internal fun beforeRunMessage(args: IArgs, testShardChunks: List<Chunk>): String {
-    val runCount = args.repeatTests
+internal fun IArgs.beforeRunMessage(testShardChunks: List<Chunk>): String {
+    val runCount = repeatTests
     val shardCount = testShardChunks.size
     val (classesCount, testsCount) = testShardChunks.partitionedTestCases.testAndClassesCount
 

--- a/test_runner/src/main/kotlin/ftl/util/FileReference.kt
+++ b/test_runner/src/main/kotlin/ftl/util/FileReference.kt
@@ -1,5 +1,6 @@
 package ftl.util
 
+import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.gc.GcStorage
 import ftl.run.exception.FlankGeneralError
@@ -27,6 +28,15 @@ fun FileReference.downloadIfNeeded() =
     if (local.isNotBlank()) this
     else copy(local = GcStorage.download(gcs))
 
-fun FileReference.uploadIfNeeded(rootGcsBucket: String, runGcsPath: String) =
+fun IArgs.uploadIfNeeded(file: FileReference): FileReference =
+    file.uploadIfNeeded(
+        rootGcsBucket = resultsBucket,
+        runGcsPath = resultsDir
+    )
+
+fun FileReference.uploadIfNeeded(
+    rootGcsBucket: String,
+    runGcsPath: String
+): FileReference =
     if (gcs.isNotBlank()) this
     else copy(gcs = GcStorage.upload(local, rootGcsBucket, runGcsPath))

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -1243,7 +1243,7 @@ AndroidArgs
         """.trimIndent()
 
         val parsedYml = AndroidArgs.load(yaml).validate()
-        val (matrixMap, chunks) = runBlocking { runAndroidTests(parsedYml) }
+        val (matrixMap, chunks) = runBlocking { parsedYml.runAndroidTests() }
         assertEquals(4, matrixMap.map.size)
         assertEquals(4, chunks.size)
     }
@@ -1381,7 +1381,7 @@ AndroidArgs
         every { runBlocking { any<AndroidArgs>().createAndroidTestContexts() } } returns listOf()
 
         val parsedYml = AndroidArgs.load(yaml).validate()
-        runBlocking { runAndroidTests(parsedYml) }
+        runBlocking { parsedYml.runAndroidTests() }
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
@@ -355,7 +355,7 @@ class IosRunCommandTest {
         val runCmd = IosRunCommand()
         runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-ios-flank.yml"
         runCmd.run()
-        verify { dumpShards(any<IosArgs>(), any()) }
+        verify { any<IosArgs>().dumpShards(any()) }
     }
 
     @Test
@@ -368,7 +368,7 @@ class IosRunCommandTest {
             runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-ios-flank.yml"
             CommandLine(runCmd).parseArgs("--disable-results-upload")
             runCmd.run()
-            verify { dumpShards(any<IosArgs>(), any()) }
+            verify { any<IosArgs>().dumpShards(any()) }
             verify(inverse = true) { GcStorage.upload(IOS_SHARD_FILE, any(), any()) }
         }
     }

--- a/test_runner/src/test/kotlin/ftl/run/DumpShardsKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/DumpShardsKtTest.kt
@@ -24,7 +24,8 @@ import org.junit.contrib.java.lang.system.SystemOutRule
 class DumpShardsKtTest {
 
     @get:Rule
-    val output: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+    val output: SystemOutRule =
+        SystemOutRule().enableLog().muteForSuccessfulTests()
 
     @After
     fun tearDown() = output.clearLog()
@@ -78,7 +79,7 @@ class DumpShardsKtTest {
         if (FtlConstants.isWindows) return // TODO Windows Linux subsytem does not contain all expected commands
         // when
         val actual = runBlocking {
-            dumpShards(AndroidArgs.load(mixedConfigYaml), TEST_SHARD_FILE)
+            AndroidArgs.load(mixedConfigYaml).dumpShards(TEST_SHARD_FILE)
             File(TEST_SHARD_FILE).apply { deleteOnExit() }.readText()
         }
 
@@ -135,13 +136,18 @@ class DumpShardsKtTest {
 
         // when
         val actual = runBlocking {
-            dumpShards(AndroidArgs.load(mixedConfigYaml, AndroidRunCommand().apply { obfuscate = true }), TEST_SHARD_FILE)
+            AndroidArgs.load(
+                yamlPath = mixedConfigYaml,
+                cli = AndroidRunCommand().apply { obfuscate = true }
+            ).dumpShards(TEST_SHARD_FILE)
             File(TEST_SHARD_FILE).apply { deleteOnExit() }.readText()
         }
 
         // then
         assertNotEquals(notExpected, actual)
-        assertThat(notExpected.split(System.lineSeparator()).size).isEqualTo(actual.split(System.lineSeparator()).size) // same line count
+        assertThat(notExpected.split(System.lineSeparator()).size).isEqualTo(
+            actual.split(System.lineSeparator()).size
+        ) // same line count
         assertThat(output.log).contains("Saved 3 shards to $TEST_SHARD_FILE")
     }
 
@@ -166,7 +172,7 @@ class DumpShardsKtTest {
         if (FtlConstants.isWindows) return // TODO Windows Linux subsytem does not contain all expected commands
         // when
         val actual = runBlocking {
-            dumpShards(IosArgs.load(ios2ConfigYaml), TEST_SHARD_FILE)
+            IosArgs.load(ios2ConfigYaml).dumpShards(TEST_SHARD_FILE)
             File(TEST_SHARD_FILE).apply { deleteOnExit() }.readText()
         }
 
@@ -197,13 +203,18 @@ class DumpShardsKtTest {
         if (FtlConstants.isWindows) return // TODO Windows Linux subsytem does not contain all expected commands
         // when
         val actual = runBlocking {
-            dumpShards(IosArgs.load(ios2ConfigYaml, IosRunCommand().apply { obfuscate = true }), TEST_SHARD_FILE)
+            IosArgs.load(
+                yamlPath = ios2ConfigYaml,
+                cli = IosRunCommand().apply { obfuscate = true }
+            ).dumpShards(TEST_SHARD_FILE)
             File(TEST_SHARD_FILE).apply { deleteOnExit() }.readText()
         }
 
         // then
         assertNotEquals(notExpected, actual)
-        assertThat(notExpected.split(System.lineSeparator()).size).isEqualTo(actual.split(System.lineSeparator()).size) // same line count
+        assertThat(notExpected.split(System.lineSeparator()).size).isEqualTo(
+            actual.split(System.lineSeparator()).size
+        ) // same line count
         assertThat(output.log).contains("Saved 2 shards to $TEST_SHARD_FILE")
     }
 }

--- a/test_runner/src/test/kotlin/ftl/run/GenericTestRunnerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/GenericTestRunnerTest.kt
@@ -28,13 +28,17 @@ class GenericTestRunnerTest {
 
     @Test
     fun testBeforeRunMessage1() {
-        val result = beforeRunMessage(createMock(1), listOf(Chunk(listOf(TestMethod(name = "", time = 0.0))))).normalizeLineEnding()
+        val result = createMock(1).beforeRunMessage(
+            listOf(Chunk(listOf(TestMethod(name = "", time = 0.0))))
+        ).normalizeLineEnding()
         assert(result, "  1 test / 1 shard\n")
     }
 
     @Test
     fun testBeforeRunMessage2() {
-        val result = beforeRunMessage(createMock(2), listOf(Chunk(listOf(TestMethod(name = "", time = 0.0))))).normalizeLineEnding()
+        val result = createMock(2).beforeRunMessage(
+            listOf(Chunk(listOf(TestMethod(name = "", time = 0.0))))
+        ).normalizeLineEnding()
         assert(
             result,
             """
@@ -48,8 +52,7 @@ class GenericTestRunnerTest {
 
     @Test
     fun testBeforeRunMessage3() {
-        val result = beforeRunMessage(
-            createMock(2),
+        val result = createMock(2).beforeRunMessage(
             List(6) { Chunk(listOf(TestMethod(name = "", time = 0.0))) }
         ).normalizeLineEnding()
         assert(
@@ -65,8 +68,7 @@ class GenericTestRunnerTest {
 
     @Test
     fun testBeforeRunMessage4() {
-        val result = beforeRunMessage(
-            createMock(100),
+        val result = createMock(100).beforeRunMessage(
             List(2) { Chunk(List(5) { TestMethod(name = "", time = 0.0) }) }
         ).normalizeLineEnding()
         assert(
@@ -86,8 +88,7 @@ class GenericTestRunnerTest {
             10 tests + 3 parameterized classes / 2 shards
         """.trimIndent()
 
-        val result = beforeRunMessage(
-            createMock(1),
+        val result = createMock(1).beforeRunMessage(
             listOf(
                 Chunk(
                     listOf(
@@ -122,8 +123,7 @@ class GenericTestRunnerTest {
             3 parameterized classes / 2 shards
         """.trimIndent()
 
-        val result = beforeRunMessage(
-            createMock(1),
+        val result = createMock(1).beforeRunMessage(
             listOf(
                 Chunk(
                     listOf(
@@ -152,8 +152,7 @@ class GenericTestRunnerTest {
               30 total parameterized classes
         """.trimIndent()
 
-        val result = beforeRunMessage(
-            createMock(10),
+        val result = createMock(10).beforeRunMessage(
             listOf(
                 Chunk(
                     listOf(
@@ -191,8 +190,7 @@ class GenericTestRunnerTest {
               30 total parameterized classes
         """.trimIndent()
 
-        val result = beforeRunMessage(
-            createMock(10),
+        val result = createMock(10).beforeRunMessage(
             listOf(
                 Chunk(
                     listOf(

--- a/test_runner/src/test/kotlin/ftl/run/TestRunnerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/TestRunnerTest.kt
@@ -114,7 +114,7 @@ class TestRunnerTest {
     fun `mockedAndroidTestRun local`() {
         val localConfig = AndroidArgs.load(Paths.get("src/test/kotlin/ftl/fixtures/flank.local.yml"))
         runBlocking {
-            newTestRun(localConfig)
+            localConfig.newTestRun()
         }
     }
 
@@ -122,7 +122,7 @@ class TestRunnerTest {
     fun `mockedAndroidTestRun gcsAndHistoryName`() {
         val gcsConfig = AndroidArgs.load(Paths.get("src/test/kotlin/ftl/fixtures/flank.gcs.yml"))
         runBlocking {
-            newTestRun(gcsConfig)
+            gcsConfig.newTestRun()
         }
     }
 
@@ -132,7 +132,7 @@ class TestRunnerTest {
 
         val config = IosArgs.load(Paths.get("src/test/kotlin/ftl/fixtures/flank.ios.yml"))
         runBlocking {
-            newTestRun(config)
+            config.newTestRun()
         }
     }
 
@@ -142,7 +142,7 @@ class TestRunnerTest {
 
         val config = IosArgs.load(Paths.get("src/test/kotlin/ftl/fixtures/flank.ios.gcs.yml"))
         runBlocking {
-            newTestRun(config)
+            config.newTestRun()
         }
     }
 
@@ -150,7 +150,7 @@ class TestRunnerTest {
     fun `matrix webLink should be printed before polling matrices`() {
         val localConfig = AndroidArgs.load(Paths.get("src/test/kotlin/ftl/fixtures/flank.local.yml"))
         runBlocking {
-            newTestRun(localConfig)
+            localConfig.newTestRun()
         }
         val matrixWebLinkHeader = "Matrices webLink"
         val matrixLink = Regex("(matrix-\\d+ https://console\\.firebase\\.google\\.com/project/.*/testlab/histories/.*/matrices/.*)(/executions/.*)?")
@@ -171,7 +171,7 @@ class TestRunnerTest {
             getMockedTestMatrix()
         )
         runBlocking {
-            newTestRun(localConfig)
+            localConfig.newTestRun()
         }
         val matrixWebLinkHeader = "Matrices webLink"
         val message = "Unable to get web link"

--- a/test_runner/src/test/kotlin/ftl/run/platform/RunAndroidTestsKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/RunAndroidTestsKtTest.kt
@@ -32,7 +32,7 @@ class RunAndroidTestsKtTest {
 
         // when
         val actual = runBlocking {
-            runAndroidTests(AndroidArgs.load(mixedConfigYaml))
+            AndroidArgs.load(mixedConfigYaml).runAndroidTests()
         }
 
         // then
@@ -49,7 +49,7 @@ class RunAndroidTestsKtTest {
             every { androidArgs.repeatTests } returns 2
 
             runBlocking {
-                runAndroidTests(androidArgs)
+                androidArgs.runAndroidTests()
             }
 
             verify {
@@ -76,7 +76,7 @@ class RunAndroidTestsKtTest {
             every { androidArgs.resultsBucket } returns "test_bucket"
 
             runBlocking {
-                runAndroidTests(androidArgs)
+                androidArgs.runAndroidTests()
             }
 
             verify(inverse = true) {


### PR DESCRIPTION
This PR is a cherrypicked refactor from #1321 

After merging this one, the #1321 will slim down a little.

## Checklist

- [x] Simplify beforeRunTests return signature
- [x] Treat Args as context

