### PR TITLE
ci: Add directory filter for IT

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,8 +7,40 @@ on:
     types: submitted
 
 jobs:
-  check_approve_count:
+  check:
+    name: Check files
+    outputs:
+      should_run: ${{ steps.check_files.outputs.should_run }}
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: check modified files
+        id: check_files
+        run: |
+          git diff --name-only --diff-filter=AMDR HEAD^ HEAD > diffs.txt
+          echo "---------------"
+          cat diffs.txt
+          echo "---------------"
+          SHOULD_RUN='false'
+          while IFS= read -r file
+          do
+            if [[ $file == test_runner/* ]] || [[ $file == integration_tests/* ]]; then
+              SHOULD_RUN='true'
+              break
+            fi
+          done < diffs.txt
+          rm diffs.txt
+          echo "Should run IT: ${SHOULD_RUN}"
+          echo "::set-output name=should_run::${SHOULD_RUN}"
+
+  check_approve_count:
+    needs: [ check ]
+    runs-on: ubuntu-latest
+    if: needs.check.outputs.should_run == 'true'
     outputs:
       approve_count: ${{ steps.reviews.outputs.approved }}
     steps:
@@ -121,4 +153,3 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         with:
           arguments: "--info :integration_tests:test --tests IntegrationTests.shouldMatchAndroidSuccessExitCodeAndPattern -Dflank-path=../test_runner/build/libs/flank.jar -Dyml-path=./src/test/resources/flank_android.yml"
-


### PR DESCRIPTION
Fixes #1337 

This PR adds step for IT workflow. It checks with `git diff` if any modified/removed/created/moved files were in `test_runner` and/or `integration_tests` directory.

## Test Plan
> How do we know the code works?

No straightforward way to do this. The added step is a simple bash script that sets output either to true or false.
To verify you can copy the script and run locally
```
git diff --name-only --diff-filter=AMDR HEAD^ HEAD > diffs.txt
echo "---------------"
cat diffs.txt
echo "---------------"
SHOULD_RUN='false'
while IFS= read -r file
do
  if [[ $file == test_runner/* ]] || [[ $file == integration_tests/* ]]; then
    SHOULD_RUN='true'
    break
  fi
done < diffs.txt
rm diffs.txt
echo "Should run IT: ${SHOULD_RUN}"
echo "::set-output name=should_run::${SHOULD_RUN}"
```

If case there are any files changed in `test_runner`/`integration_tests` `echo "::set-output name=should_run::true"` should be printed. Otherwise `echo "::set-output name=should_run::false"`


