### PR TITLE
ci: Publishing and downloading flank scripts

### DIFF
--- a/.github/workflows/create_new_release.yml
+++ b/.github/workflows/create_new_release.yml
@@ -16,9 +16,9 @@ jobs:
           app_id: ${{ secrets.FLANK_RELEASE_APP_ID }}
           private_key: ${{ secrets.FLANK_RELEASE_PRIVATE_KEY }}
 
-      - name: Gradle Build flankScripts and add it to PATH
+      - name: Download flankScripts and add it to PATH
         run: |
-          ./flank-scripts/bash/buildFlankScripts.sh
+          ./gradlew :flank-scripts:download
           echo "./flank-scripts/bash" >> $GITHUB_PATH
       - name: Set next release tag variable
         run: |

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -13,9 +13,9 @@ jobs:
     if: ${{ github.event.action == 'opened' }}
     steps:
       - uses: actions/checkout@v2
-      - name: Gradle Build flankScripts and add it to PATH
+      - name: Download flankScripts and add it to PATH
         run: |
-          ./flank-scripts/bash/buildFlankScripts.sh
+          ./gradlew :flank-scripts:download
           echo "./flank-scripts/bash" >> $GITHUB_PATH
 
       - name: Copy properties

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
         git fetch --prune --unshallow --tags -f
         git tag
 
-    - name: Gradle Build flankScripts and add it to PATH
+    - name: Download flankScripts and add it to PATH
       run: |
-        ./flank-scripts/bash/buildFlankScripts.sh
+        ./gradlew :flank-scripts:download
         echo "./flank-scripts/bash" >> $GITHUB_PATH
 
     - name: Set env variables

--- a/.github/workflows/release_flank_scripts.yml
+++ b/.github/workflows/release_flank_scripts.yml
@@ -1,0 +1,24 @@
+name: RELEASE
+
+on:
+  push:
+    paths:
+      - 'flank-scripts/**'
+    branches:
+      - 'master'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+      with: 
+        submodules: true
+
+    - uses: gradle/wrapper-validation-action@v1
+
+    - name: Gradle Upload to bintray
+      uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: "flank-scripts:bintrayUpload -PJFROG_API_KEY=${{ secrets.JFROG_API_KEY }} -PJFROG_USER=${{ secrets.JFROG_USER }}"

--- a/.github/workflows/release_notes_generation.yml
+++ b/.github/workflows/release_notes_generation.yml
@@ -22,9 +22,9 @@ jobs:
       with:
         arguments: "test_runner:processCliAsciiDoc"
 
-    - name: Gradle Build flankScripts and add it to PATH
+    - name: Download flankScripts and add it to PATH
       run: |
-        ./flank-scripts/bash/buildFlankScripts.sh
+        ./gradlew :flank-scripts:download
         echo "./flank-scripts/bash" >> $GITHUB_PATH
 
     - name: Set next release tag variable

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -19,9 +19,9 @@ jobs:
         with:
             arguments: dependencyUpdates -DoutputFormatter=json -DoutputDir=.
 
-      - name: Gradle Build flankScripts and add it to PATH
+      - name: Download flankScripts and add it to PATH
         run: |
-          ./flank-scripts/bash/buildFlankScripts.sh
+          ./gradlew :flank-scripts:download
           echo "./flank-scripts/bash" >> $GITHUB_PATH
 
       - name: Update dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     kotlin(Plugins.Kotlin.PLUGIN_JVM) version Versions.KOTLIN
     id(Plugins.DETEKT_PLUGIN) version Versions.DETEKT
     id(Plugins.BEN_MANES_PLUGIN) version Versions.BEN_MANES
+    id(Plugins.JFROG_BINTRAY) version Versions.BINTRAY
 }
 
 repositories {

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -160,7 +160,7 @@ tasks.register("checkIfVersionUpdated") {
     val isVersionChanged = withTempFile {
         outputStream().use {
             project.exec {
-                commandLine(listOf("git", "diff", "..master", "--name-only"))
+                commandLine(listOf("git", "diff", "origin/master", "HEAD", "--name-only"))
                 standardOutput = it
             }
         }
@@ -180,7 +180,7 @@ tasks.register("checkIfVersionUpdated") {
 fun isVersionChangedInBuildGradle(): Boolean = withTempFile {
     outputStream().use {
         project.exec {
-            commandLine(listOf("git", "diff", "..master", "--", "build.gradle.kts"))
+            commandLine(listOf("git", "diff", "origin/master", "HEAD", "--", "build.gradle.kts"))
             standardOutput = it
         }
     }

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -67,7 +67,7 @@ publishing {
             pom {
                 name.set("Flank-scripts")
                 description.set("Scripts for Flank")
-                url.set("https://github.com/flank/flank")
+                url.set("https://github.com/Flank/flank")
 
                 licenses {
                     license {

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -159,6 +159,11 @@ tasks.register("download") {
 tasks.register("checkIfVersionUpdated") {
     val isVersionChanged = withTempFile {
         outputStream().use {
+
+            project.exec {
+                commandLine("git", "fetch", "--no-tags", "-v")
+            }
+
             project.exec {
                 commandLine(listOf("git", "diff", "origin/master", "HEAD", "--name-only"))
                 standardOutput = it

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -157,6 +157,7 @@ tasks.register("download") {
 }
 
 tasks.register("checkIfVersionUpdated") {
+    group = "verification"
     val isVersionChanged = withTempFile {
         outputStream().use {
 

--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -382,7 +382,7 @@ fun execAndGetStdout(vararg args: String): String {
 }
 
 val resolveArtifacts by tasks.registering {
-    dependsOn(":flank-scripts:prepareJar")
+    dependsOn(":flank-scripts:download")
     group = "verification"
     doLast {
         val flankScriptsRunnerName = if(DefaultNativePlatform.getCurrentOperatingSystem().isWindows)

--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     jacoco
     kotlin(Plugins.Kotlin.PLUGIN_JVM)
     id(Plugins.DETEKT_PLUGIN)
-    id(Plugins.JFROG_BINTRAY) version Versions.BINTRAY
+    id(Plugins.JFROG_BINTRAY)
     id(Plugins.MAVEN_PUBLISH)
     id(Plugins.PLUGIN_SHADOW_JAR) version Versions.SHADOW
 }


### PR DESCRIPTION
Fixes #1347

`flank-scripts` is now published to JFrog Bintray [1], so instead of building `flank-scripts` each time when running some workflow on GitHub actions or when you need it, you could just download it using simple gradle task[2].
`flank-scripts` support now versioning, so there is a requirement to update its version each time you changed some files inside `flank-scripts` directory, otherwise, detekt task will fail[3].
Each GitHub actions workflow is updated to download latest version instead of building `flank-scripts` to save time and resources.[4]

## Test Plan
> How do we know the code works?

[1] 
1. Run `gradlew :flank-scripts:bintrayUpload` (bintray account needed)
1. Flank scripts should be updated on bintray

[2]
1. Run `gradlew :flank-scripts:download`
1. `flankScripts.jar` should be downloaded to `flank-scripts/bash`

[3]
1. Change some files under `flank-scripts`
1. Run `gradlew check` or `gradlew detekt`
1. Gradle task should failed (please notice that in current PR, version is updated)
1. Update version in `flank-scripts/build.gradle.kts`
1. Run `gradlew check` or `gradlew detekt`
1. Gradle task should succeed

[4]
1. Check if all workflows has replaced
```yaml
- name: Gradle Build flankScripts and add it to PATH
        run: |
          ./flank-scripts/bash/buildFlankScripts.sh
          echo "./flank-scripts/bash" >> $GITHUB_PATH
```

to
```yaml
- name: Download flankScripts and add it to PATH
        run: |
          ./gradlew :flank-scripts:download
          echo "./flank-scripts/bash" >> $GITHUB_PATH
```

## Checklist

- [x] Publish Flank-scripts to JFrog Bintray
- [x] Create Github workflow which will make it after each push to master
- [x] Create task to download latest version from JFrog Bintray
- [x] Replace Github actions Workflow building to downloading `flank-scripts`
- [x] Add method to prevent merging flank-scripts without version update
