### PR TITLE
fix: Add fallback when cannot get reference to avoid failing tests on release

### DIFF
--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -27,7 +27,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.1.2"
+version = "1.1.3"
 group = "com.github.flank"
 
 application {

--- a/flank-scripts/src/main/kotlin/flank/scripts/utils/Git.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/utils/Git.kt
@@ -3,4 +3,10 @@ package flank.scripts.utils
 fun currentGitBranch(): String = "git branch --show-current".runForOutput()
     .trim()
     .takeIf(String::isNotBlank)
-    ?: getEnv("HEAD_REF")
+    ?: getFromEnvironmentVariableOrFallbackToMaster()
+
+private fun getFromEnvironmentVariableOrFallbackToMaster() =
+    runCatching { getEnv("HEAD_REF") }
+        .getOrDefault("")
+        .takeIf(String::isNotBlank)
+        ?: "master"


### PR DESCRIPTION

## Test Plan
> How do we know the code works?

When cannot get the branch name from git or `HEAD_REF` is missing. Tests artifacts are downloaded for master branch

