### PR TITLE
feat: Add support for "fail fast" feature on FTL

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -123,6 +123,14 @@ gcloud:
   ## The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
   # num-flaky-test-attempts: 0
 
+  ### Fail Fast
+  ## If true, only a single attempt at most will be made to run each execution/shard in the matrix.
+  ## Flaky test attempts are not affected. Normally, 2 or more attempts are made if a potential
+  ## infrastructure issue is detected. This feature is for latency sensitive workloads. The
+  ## incidence of execution failures may be significantly greater for fail-fast matrices and support
+  ## is more limited because of that expectation.
+  # fail-fast: false
+
   # -- IosGcloudYml --
 
   ### IOS Test Package Path
@@ -376,6 +384,14 @@ gcloud:
   ## The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
   ## The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
   # num-flaky-test-attempts: 0
+
+  ### Fail Fast
+  ## If true, only a single attempt at most will be made to run each execution/shard in the matrix.
+  ## Flaky test attempts are not affected. Normally, 2 or more attempts are made if a potential
+  ## infrastructure issue is detected. This feature is for latency sensitive workloads. The
+  ## incidence of execution failures may be significantly greater for fail-fast matrices and support
+  ## is more limited because of that expectation.
+  # fail-fast: false
 
   # -- AndroidGcloudYml --
 

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -53,6 +53,14 @@ gcloud:
   ## The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
   # num-flaky-test-attempts: 0
 
+  ### Fail Fast
+  ## If true, only a single attempt at most will be made to run each execution/shard in the matrix.
+  ## Flaky test attempts are not affected. Normally, 2 or more attempts are made if a potential
+  ## infrastructure issue is detected. This feature is for latency sensitive workloads. The
+  ## incidence of execution failures may be significantly greater for fail-fast matrices and support
+  ## is more limited because of that expectation.
+  # fail-fast: false
+
   # -- IosGcloudYml --
 
   ### IOS Test Package Path

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -53,6 +53,14 @@ gcloud:
   ## The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
   # num-flaky-test-attempts: 0
 
+  ### Fail Fast
+  ## If true, only a single attempt at most will be made to run each execution/shard in the matrix.
+  ## Flaky test attempts are not affected. Normally, 2 or more attempts are made if a potential
+  ## infrastructure issue is detected. This feature is for latency sensitive workloads. The
+  ## incidence of execution failures may be significantly greater for fail-fast matrices and support
+  ## is more limited because of that expectation.
+  # fail-fast: false
+
   # -- AndroidGcloudYml --
 
   ## Android Application Path

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -12,7 +12,7 @@ data class AndroidArgs(
     val useOrchestrator: Boolean,
     val roboDirectives: List<FlankRoboDirective>,
     val roboScript: String?,
-    val environmentVariables: Map<String, String>, // should not be printed, becuase could contains sensitive informations
+    val environmentVariables: Map<String, String>, // should not be printed, because could contain sensitive information
     val grantPermissions: String?,
     val scenarioLabels: List<String>,
     val obbFiles: List<String>,
@@ -63,6 +63,7 @@ AndroidArgs
       device: ${ArgsToString.objectsToString(devices)}
       num-flaky-test-attempts: $flakyTestAttempts
       test-targets-for-shard: ${ArgsToString.listOfListToString(testTargetsForShard)}
+      fail-fast: $failFast
 
     flank:
       max-test-shards: $maxTestShards

--- a/test_runner/src/main/kotlin/ftl/args/CommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CommonArgs.kt
@@ -22,6 +22,7 @@ data class CommonArgs(
     override val type: Type?,
     override val directoriesToPull: List<String>,
     override val scenarioNumbers: List<String>,
+    override val failFast: Boolean,
 
     // flank
     override val project: String,

--- a/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
@@ -30,6 +30,7 @@ fun CommonConfig.createCommonArgs(
     otherFiles = gcloud::otherFiles.require().mapValues { (_, path) -> path.normalizeFilePath() },
     scenarioNumbers = gcloud::scenarioNumbers.require(),
     type = gcloud.type?.toType(),
+    failFast = gcloud::failFast.require(),
 
     // flank
     maxTestShards = flank::maxTestShards.require(),

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -27,6 +27,7 @@ interface IArgs {
     val scenarioNumbers: List<String>
     val type: Type? get() = null
     val directoriesToPull: List<String>
+    val failFast: Boolean
 
     // FlankYml
     val maxTestShards: Int

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -49,6 +49,7 @@ IosArgs
       type: ${type?.ymlName}
       app: $app
       test-special-entitlements: $testSpecialEntitlements
+      fail-fast: $failFast
 
     flank:
       max-test-shards: $maxTestShards

--- a/test_runner/src/main/kotlin/ftl/config/common/CommonGcloudConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/common/CommonGcloudConfig.kt
@@ -162,6 +162,16 @@ data class CommonGcloudConfig @JsonIgnore constructor(
     @set:JsonProperty("type")
     var type: String? by data
 
+    @set:CommandLine.Option(
+        names = ["--fail-fast"],
+        description = ["If true, only a single attempt at most will be made to run each " +
+                "execution/shard in the matrix. Flaky test attempts are not affected. Normally, " +
+                "2 or more attempts are made if a potential infrastructure issue is detected." +
+                " This feature is for latency sensitive workloads."]
+    )
+    @set:JsonProperty("fail-fast")
+    var failFast: Boolean? by data
+
     constructor() : this(mutableMapOf<String, Any?>().withDefault { null })
 
     companion object : IYmlKeys {
@@ -189,6 +199,7 @@ data class CommonGcloudConfig @JsonIgnore constructor(
             otherFiles = emptyMap()
             type = null
             scenarioNumbers = emptyList()
+            failFast = false
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
@@ -84,6 +84,7 @@ object GcAndroidTestMatrix {
             .setResultStorage(resultsStorage)
             .setEnvironmentMatrix(environmentMatrix)
             .setFlakyTestAttempts(args.flakyTestAttempts)
+            .setFailFast(args.failFast)
         try {
             return GcTesting.get.projects().testMatrices().create(args.project, testMatrix)
         } catch (e: Exception) {

--- a/test_runner/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
@@ -95,6 +95,7 @@ object GcIosTestMatrix {
             .setEnvironmentMatrix(environmentMatrix)
             .setResultStorage(resultStorage)
             .setFlakyTestAttempts(args.flakyTestAttempts)
+            .setFailFast(args.failFast)
 
         try {
             return GcTesting.get.projects().testMatrices().create(args.project, testMatrix)

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -346,6 +346,7 @@ AndroidArgs
           orientation: portrait
       num-flaky-test-attempts: 3
       test-targets-for-shard: 
+      fail-fast: false
 
     flank:
       max-test-shards: 7
@@ -422,6 +423,7 @@ AndroidArgs
           orientation: portrait
       num-flaky-test-attempts: 0
       test-targets-for-shard: 
+      fail-fast: false
 
     flank:
       max-test-shards: 1
@@ -1225,6 +1227,23 @@ AndroidArgs
           output-style: unknown
       """
         AndroidArgs.load(yaml).validate()
+    }
+
+
+    @Test
+    fun `cli fail-fast`() {
+        val cli = AndroidRunCommand()
+        CommandLine(cli).parseArgs("--fail-fast")
+
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+      """
+        assertThat(AndroidArgs.load(yaml).validate().failFast).isEqualTo(false)
+
+        val args = AndroidArgs.load(yaml, cli).validate()
+        assertThat(args.failFast).isEqualTo(true)
     }
 
     @Test
@@ -2378,7 +2397,10 @@ AndroidArgs
     }
 }
 
-private fun AndroidArgs.Companion.load(yamlData: String, cli: AndroidRunCommand? = null): AndroidArgs =
+private fun AndroidArgs.Companion.load(
+    yamlData: String,
+    cli: AndroidRunCommand? = null
+): AndroidArgs =
     load(StringReader(yamlData), cli)
 
 fun getAndroidShardChunks(args: AndroidArgs): List<Chunk> =

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -247,6 +247,7 @@ IosArgs
       type: xctest
       app: 
       test-special-entitlements: true
+      fail-fast: false
 
     flank:
       max-test-shards: 7
@@ -311,6 +312,7 @@ IosArgs
       type: xctest
       app: 
       test-special-entitlements: false
+      fail-fast: false
 
     flank:
       max-test-shards: 1
@@ -874,6 +876,22 @@ IosArgs
 
         val args = IosArgs.load(yaml, cli)
         assertThat(args.outputStyle).isEqualTo(OutputStyle.Multi)
+    }
+
+    @Test
+    fun `cli fail-fast`() {
+        val cli = IosRunCommand()
+        CommandLine(cli).parseArgs("--fail-fast")
+
+        val yaml = """
+        gcloud:
+          test: $testPath
+          xctestrun-file: $testPath
+      """
+        assertThat(IosArgs.load(yaml).validate().failFast).isEqualTo(false)
+
+        val args = IosArgs.load(yaml, cli).validate()
+        assertThat(args.failFast).isEqualTo(true)
     }
 
     private fun getValidTestsSample() = listOf(


### PR DESCRIPTION
Fixes (N/A)

## Test Plan
> How do we know the code works?

Ran a locally built jar in CI, verified that this flag is behaving as expected.

## Checklist

- [X] Documented
- [X] Unit tested

## Background
When a matrix hits an infrastructure errors, it is automatically retried. This can cause issues in time sensitive scenarios, as results can take ~5-15m longer to report after an infrastructure error occurs. This PR exposes this flag via the CLI.