### PR TITLE
feat: Add new output style to print smaller output

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -305,11 +305,12 @@ flank:
   ## The JUnit XML is used to determine failure. (default: false)
   # ignore-failed-tests: true
 
-  ### Output Style
-  ## Output style of execution status. May be one of [verbose, multi, single].
+  ### Output Style flag
+  ## Output style of execution status. May be one of [verbose, multi, single, compact].
   ## For runs with only one test execution the default value is 'verbose', in other cases
   ## 'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles
   ## which don't support ansi codes, to avoid corrupted output use single or verbose.
+  ## The output style `compact` is used to produce less detailed output, it prints just Args, test and matrix count, weblinks, cost, and result reports.
   # output-style: single
 
   ### Full Junit Result flag
@@ -650,10 +651,11 @@ flank:
   # legacy-junit-result: false
 
   ### Output Style flag
-  ## Output style of execution status. May be one of [verbose, multi, single].
+  ## Output style of execution status. May be one of [verbose, multi, single, compact].
   ## For runs with only one test execution the default value is 'verbose', in other cases
   ## 'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles
   ## which don't support ansi codes, to avoid corrupted output use single or verbose.
+  ## The output style `compact` is used to produce less detailed output, it prints just Args, test and matrix count, weblinks, cost, and result reports.
   # output-style: single
 
   ### Full Junit Result flag

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,7 @@
+# Logs in Flank
+
+1. Log level depends on the output style.
+1. ```Simple, multi``` and ```verbose``` output style prints logs from ```SIMPLE``` and ```DETAILED``` levels.
+1. ```Compact``` style prints log only from ```SIMPLE``` level.
+1. If you want a print message for all output styles uses ```log``` or ```logLn``` with only ```message``` parameter.
+1. If you want print message more detailed message use ```log``` or ```logLn``` and set ```level``` to ```OutputLogLevel.DETAILED```

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -200,4 +200,4 @@ fun execAndGetStdout(vararg args: String): String {
     return stdout.toString().trimEnd()
 }
 
-tasks["detekt"].dependsOn(tasks["checkIfVersionUpdated"])
+//tasks["detekt"].dependsOn(tasks["checkIfVersionUpdated"])

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -28,7 +28,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.1.4"
+version = "1.1.5"
 group = "com.github.flank"
 
 application {
@@ -200,4 +200,4 @@ fun execAndGetStdout(vararg args: String): String {
     return stdout.toString().trimEnd()
 }
 
-//tasks["detekt"].dependsOn(tasks["checkIfVersionUpdated"])
+tasks["detekt"].dependsOn(tasks["checkIfVersionUpdated"])

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -28,7 +28,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.1.5"
+version = "1.1.4"
 group = "com.github.flank"
 
 application {

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -236,10 +236,11 @@ flank:
   # ignore-failed-tests: true
 
   ### Output Style
-  ## Output style of execution status. May be one of [verbose, multi, single].
+  ## Output style of execution status. May be one of [verbose, multi, single, compact].
   ## For runs with only one test execution the default value is 'verbose', in other cases
   ## 'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles
   ## which don't support ansi codes, to avoid corrupted output use single or verbose.
+  ## The output style `compact` is used to produce less detailed output, it prints just Args, test and matrix count, weblinks, cost, and result reports.
   # output-style: single
 
   ### Full Junit Result flag

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -318,10 +318,11 @@ flank:
   # legacy-junit-result: false
 
   ### Output Style flag
-  ## Output style of execution status. May be one of [verbose, multi, single].
+  ## Output style of execution status. May be one of [verbose, multi, single, compact].
   ## For runs with only one test execution the default value is 'verbose', in other cases
   ## 'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles
   ## which don't support ansi codes, to avoid corrupted output use single or verbose.
+  ## The output style `compact` is used to produce less detailed output, it prints just Args, test and matrix count, weblinks, cost, and result reports.
   # output-style: single
 
   ### Full Junit Result flag

--- a/test_runner/src/main/kotlin/ftl/Main.kt
+++ b/test_runner/src/main/kotlin/ftl/Main.kt
@@ -9,7 +9,7 @@ import ftl.cli.firebase.test.IPBlocksCommand
 import ftl.cli.firebase.test.IosCommand
 import ftl.cli.firebase.test.NetworkProfilesCommand
 import ftl.cli.firebase.test.ProvidedSoftwareCommand
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.log.setDebugLogging
 import ftl.util.readRevision
 import ftl.util.readVersion
@@ -54,9 +54,9 @@ class Main : Runnable {
             // Flank must invoke exitProcess to exit cleanly.
             // https://github.com/bugsnag/bugsnag-java/issues/151
             withGlobalExceptionHandling {
-                logLine("version: " + readVersion())
-                logLine("revision: " + readRevision())
-                logLine()
+                logLn("version: " + readVersion())
+                logLn("revision: " + readRevision())
+                logLn()
                 CommandLine(Main()).execute(*args)
             }
         }

--- a/test_runner/src/main/kotlin/ftl/Main.kt
+++ b/test_runner/src/main/kotlin/ftl/Main.kt
@@ -9,6 +9,7 @@ import ftl.cli.firebase.test.IPBlocksCommand
 import ftl.cli.firebase.test.IosCommand
 import ftl.cli.firebase.test.NetworkProfilesCommand
 import ftl.cli.firebase.test.ProvidedSoftwareCommand
+import ftl.log.logLine
 import ftl.log.setDebugLogging
 import ftl.util.readRevision
 import ftl.util.readVersion
@@ -53,9 +54,9 @@ class Main : Runnable {
             // Flank must invoke exitProcess to exit cleanly.
             // https://github.com/bugsnag/bugsnag-java/issues/151
             withGlobalExceptionHandling {
-                println("version: " + readVersion())
-                println("revision: " + readRevision())
-                println()
+                logLine("version: " + readVersion())
+                logLine("revision: " + readRevision())
+                logLine()
                 CommandLine(Main()).execute(*args)
             }
         }

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -10,7 +10,7 @@ import ftl.environment.common.asPrintableTable
 import ftl.environment.getLocaleDescription
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
-import ftl.log.logLine
+import ftl.log.logLn
 
 /**
  * Contains lists of possible Android device and version ids, as well as checks
@@ -78,7 +78,7 @@ object AndroidCatalog {
         val form = deviceCatalog(projectId).models
             .find { it.id.equals(modelId, ignoreCase = true) }?.form
             ?: DeviceType.PHYSICAL.name.also {
-                logLine("Unable to find device type for $modelId. PHYSICAL used as fallback in cost calculations")
+                logLn("Unable to find device type for $modelId. PHYSICAL used as fallback in cost calculations")
             }
 
         return form.equals(DeviceType.VIRTUAL.name, ignoreCase = true)

--- a/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -10,6 +10,7 @@ import ftl.environment.common.asPrintableTable
 import ftl.environment.getLocaleDescription
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
+import ftl.log.logLine
 
 /**
  * Contains lists of possible Android device and version ids, as well as checks
@@ -77,7 +78,7 @@ object AndroidCatalog {
         val form = deviceCatalog(projectId).models
             .find { it.id.equals(modelId, ignoreCase = true) }?.form
             ?: DeviceType.PHYSICAL.name.also {
-                println("Unable to find device type for $modelId. PHYSICAL used as fallback in cost calculations")
+                logLine("Unable to find device type for $modelId. PHYSICAL used as fallback in cost calculations")
             }
 
         return form.equals(DeviceType.VIRTUAL.name, ignoreCase = true)

--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -20,6 +20,7 @@ import ftl.config.credential
 import ftl.config.defaultCredentialPath
 import ftl.gc.GcStorage
 import ftl.gc.GcToolResults
+import ftl.log.logLine
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
@@ -171,7 +172,7 @@ object ArgsHelper {
                     .build()
             )
         } catch (e: Exception) {
-            println("Warning: Failed to make bucket for $projectId\nCause: ${e.message}")
+            logLine("Warning: Failed to make bucket for $projectId\nCause: ${e.message}")
         }
 
         return bucket
@@ -187,8 +188,8 @@ object ArgsHelper {
                 GenericJson::class.java
             )["project_id"] as String
         } catch (e: Exception) {
-            println("Parsing $defaultCredentialPath failed:")
-            println(e.printStackTrace())
+            logLine("Parsing $defaultCredentialPath failed:")
+            logLine(e.printStackTrace())
         }
 
         return null
@@ -211,7 +212,7 @@ object ArgsHelper {
             val envName = matcher.group(1)
             val envValue: String? = System.getenv(envName)
             if (envValue == null) {
-                println("WARNING: $envName not found")
+                logLine("WARNING: $envName not found")
             }
             matcher.appendReplacement(buffer, envValue ?: "")
         }

--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -20,7 +20,7 @@ import ftl.config.credential
 import ftl.config.defaultCredentialPath
 import ftl.gc.GcStorage
 import ftl.gc.GcToolResults
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
@@ -172,7 +172,7 @@ object ArgsHelper {
                     .build()
             )
         } catch (e: Exception) {
-            logLine("Warning: Failed to make bucket for $projectId\nCause: ${e.message}")
+            logLn("Warning: Failed to make bucket for $projectId\nCause: ${e.message}")
         }
 
         return bucket
@@ -188,8 +188,8 @@ object ArgsHelper {
                 GenericJson::class.java
             )["project_id"] as String
         } catch (e: Exception) {
-            logLine("Parsing $defaultCredentialPath failed:")
-            logLine(e.printStackTrace())
+            logLn("Parsing $defaultCredentialPath failed:")
+            logLn(e.printStackTrace())
         }
 
         return null
@@ -212,7 +212,7 @@ object ArgsHelper {
             val envName = matcher.group(1)
             val envValue: String? = System.getenv(envName)
             if (envValue == null) {
-                logLine("WARNING: $envName not found")
+                logLn("WARNING: $envName not found")
             }
             matcher.appendReplacement(buffer, envValue ?: "")
         }

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -87,6 +87,6 @@ interface IArgs {
 val IArgs.logLevel
     get() = if (outputStyle == OutputStyle.Compact) OutputLogLevel.SIMPLE else OutputLogLevel.DETAILED
 
-fun IArgs.setLogLevel() = also {
+fun IArgs.setupLogLevel() = also {
     ftl.log.setLogLevel(logLevel)
 }

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -85,7 +85,7 @@ interface IArgs {
 }
 
 val IArgs.logLevel
-    get() = if (outputStyle == OutputStyle.Compact) OutputLogLevel.LOW else OutputLogLevel.All
+    get() = if (outputStyle == OutputStyle.Compact) OutputLogLevel.SIMPLE else OutputLogLevel.DETAILED
 
 fun IArgs.setLogLevel() = also {
     ftl.log.setLogLevel(logLevel)

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -3,6 +3,7 @@ package ftl.args
 import ftl.args.yml.Type
 import ftl.config.Device
 import ftl.config.common.CommonFlankConfig.Companion.defaultLocalResultsDir
+import ftl.log.OutputLogLevel
 import ftl.run.status.OutputStyle
 import ftl.util.timeoutToMils
 
@@ -81,4 +82,11 @@ interface IArgs {
     interface ICompanion {
         val validArgs: Map<String, List<String>>
     }
+}
+
+val IArgs.logLevel
+    get() = if (outputStyle == OutputStyle.Compact) OutputLogLevel.LOW else OutputLogLevel.HIGH
+
+fun IArgs.setLogLevel() = also {
+    ftl.log.setLogLevel(logLevel)
 }

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -85,7 +85,7 @@ interface IArgs {
 }
 
 val IArgs.logLevel
-    get() = if (outputStyle == OutputStyle.Compact) OutputLogLevel.LOW else OutputLogLevel.HIGH
+    get() = if (outputStyle == OutputStyle.Compact) OutputLogLevel.LOW else OutputLogLevel.All
 
 fun IArgs.setLogLevel() = also {
     ftl.log.setLogLevel(logLevel)

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -9,6 +9,7 @@ import ftl.android.UnsupportedVersionId
 import ftl.args.yml.Type
 import ftl.config.containsPhysicalDevices
 import ftl.config.containsVirtualDevices
+import ftl.log.logLine
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
 import ftl.run.exception.IncompatibleTestDimensionError
@@ -146,7 +147,7 @@ private fun AndroidArgs.assertMaxTestShardsByDeviceType() =
     }
 
 private fun AndroidArgs.assertDevicesShards() {
-    if (inVirtualRange && !inPhysicalRange) println("Physical devices configured, but max-test-shards limit set to $maxTestShards, for physical devices range is ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.first} to ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}, you additionally have configured virtual devices. In this case, the physical limit will be decreased to: ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}")
+    if (inVirtualRange && !inPhysicalRange) logLine("Physical devices configured, but max-test-shards limit set to $maxTestShards, for physical devices range is ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.first} to ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}, you additionally have configured virtual devices. In this case, the physical limit will be decreased to: ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}")
     else if (!inVirtualRange && !inPhysicalRange) throwMaxTestShardsLimitExceeded()
 }
 
@@ -217,15 +218,15 @@ private fun AndroidArgs.assertOtherFiles() {
 
 private fun AndroidArgs.checkEnvironmentVariables() {
     if (environmentVariables.isNotEmpty() && directoriesToPull.isEmpty())
-        println("WARNING: environment-variables set but directories-to-pull is empty, this will result in the coverage file  not downloading to the bucket.")
+        logLine("WARNING: environment-variables set but directories-to-pull is empty, this will result in the coverage file  not downloading to the bucket.")
 }
 
 private fun AndroidArgs.checkFilesToDownload() {
     if (filesToDownload.isNotEmpty() && directoriesToPull.isEmpty())
-        println("WARNING: files-to-download is set but directories-to-pull is empty, the coverage file may fail to download into the bucket.")
+        logLine("WARNING: files-to-download is set but directories-to-pull is empty, the coverage file may fail to download into the bucket.")
 }
 
 private fun AndroidArgs.checkNumUniformShards() {
     if ((numUniformShards ?: 0) > 0 && disableSharding)
-        println("WARNING: disable-sharding is enabled with num-uniform-shards = $numUniformShards, Flank will ignore num-uniform-shards and disable sharding.")
+        logLine("WARNING: disable-sharding is enabled with num-uniform-shards = $numUniformShards, Flank will ignore num-uniform-shards and disable sharding.")
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -9,7 +9,7 @@ import ftl.android.UnsupportedVersionId
 import ftl.args.yml.Type
 import ftl.config.containsPhysicalDevices
 import ftl.config.containsVirtualDevices
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
 import ftl.run.exception.IncompatibleTestDimensionError
@@ -147,7 +147,7 @@ private fun AndroidArgs.assertMaxTestShardsByDeviceType() =
     }
 
 private fun AndroidArgs.assertDevicesShards() {
-    if (inVirtualRange && !inPhysicalRange) logLine("Physical devices configured, but max-test-shards limit set to $maxTestShards, for physical devices range is ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.first} to ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}, you additionally have configured virtual devices. In this case, the physical limit will be decreased to: ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}")
+    if (inVirtualRange && !inPhysicalRange) logLn("Physical devices configured, but max-test-shards limit set to $maxTestShards, for physical devices range is ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.first} to ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}, you additionally have configured virtual devices. In this case, the physical limit will be decreased to: ${IArgs.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE.last}")
     else if (!inVirtualRange && !inPhysicalRange) throwMaxTestShardsLimitExceeded()
 }
 
@@ -218,15 +218,15 @@ private fun AndroidArgs.assertOtherFiles() {
 
 private fun AndroidArgs.checkEnvironmentVariables() {
     if (environmentVariables.isNotEmpty() && directoriesToPull.isEmpty())
-        logLine("WARNING: environment-variables set but directories-to-pull is empty, this will result in the coverage file  not downloading to the bucket.")
+        logLn("WARNING: environment-variables set but directories-to-pull is empty, this will result in the coverage file  not downloading to the bucket.")
 }
 
 private fun AndroidArgs.checkFilesToDownload() {
     if (filesToDownload.isNotEmpty() && directoriesToPull.isEmpty())
-        logLine("WARNING: files-to-download is set but directories-to-pull is empty, the coverage file may fail to download into the bucket.")
+        logLn("WARNING: files-to-download is set but directories-to-pull is empty, the coverage file may fail to download into the bucket.")
 }
 
 private fun AndroidArgs.checkNumUniformShards() {
     if ((numUniformShards ?: 0) > 0 && disableSharding)
-        logLine("WARNING: disable-sharding is enabled with num-uniform-shards = $numUniformShards, Flank will ignore num-uniform-shards and disable sharding.")
+        logLn("WARNING: disable-sharding is enabled with num-uniform-shards = $numUniformShards, Flank will ignore num-uniform-shards and disable sharding.")
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateCommonArgs.kt
@@ -4,6 +4,7 @@ import ftl.config.Device
 import ftl.config.FtlConstants
 import ftl.config.defaultCredentialPath
 import ftl.gc.GcStorage
+import ftl.log.logLine
 import ftl.reports.FullJUnitReport
 import ftl.reports.JUnitReport
 import ftl.run.exception.FlankConfigurationError
@@ -72,10 +73,10 @@ private fun CommonArgs.assertSmartFlankGcsPath() = with(smartFlankGcsPath) {
 
 fun IArgs.checkResultsDirUnique() {
     if (useLegacyJUnitResult && GcStorage.exist(resultsBucket, resultsDir))
-        println("WARNING: Google cloud storage result directory should be unique, otherwise results from multiple test matrices will be overwritten or intermingled\n")
+        logLine("WARNING: Google cloud storage result directory should be unique, otherwise results from multiple test matrices will be overwritten or intermingled\n")
 }
 
 fun IArgs.checkDisableSharding() {
     if (disableSharding && maxTestShards > 0)
-        println("WARNING: disable-sharding enabled with max-test-shards = $maxTestShards, Flank will ignore max-test-shard and disable sharding.")
+        logLine("WARNING: disable-sharding enabled with max-test-shards = $maxTestShards, Flank will ignore max-test-shard and disable sharding.")
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateCommonArgs.kt
@@ -4,7 +4,7 @@ import ftl.config.Device
 import ftl.config.FtlConstants
 import ftl.config.defaultCredentialPath
 import ftl.gc.GcStorage
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.reports.FullJUnitReport
 import ftl.reports.JUnitReport
 import ftl.run.exception.FlankConfigurationError
@@ -73,10 +73,10 @@ private fun CommonArgs.assertSmartFlankGcsPath() = with(smartFlankGcsPath) {
 
 fun IArgs.checkResultsDirUnique() {
     if (useLegacyJUnitResult && GcStorage.exist(resultsBucket, resultsDir))
-        logLine("WARNING: Google cloud storage result directory should be unique, otherwise results from multiple test matrices will be overwritten or intermingled\n")
+        logLn("WARNING: Google cloud storage result directory should be unique, otherwise results from multiple test matrices will be overwritten or intermingled\n")
 }
 
 fun IArgs.checkDisableSharding() {
     if (disableSharding && maxTestShards > 0)
-        logLine("WARNING: disable-sharding enabled with max-test-shards = $maxTestShards, Flank will ignore max-test-shard and disable sharding.")
+        logLn("WARNING: disable-sharding enabled with max-test-shards = $maxTestShards, Flank will ignore max-test-shard and disable sharding.")
 }

--- a/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.node.MissingNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.google.common.annotations.VisibleForTesting
 import ftl.args.ArgsHelper.yamlMapper
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.util.loadFile
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
@@ -117,7 +117,7 @@ object YamlDeprecated {
     private fun validate(key: Key, keyValue: JsonNode): Transform? {
         transforms.forEach {
             if (it.old == key) {
-                logLine("${it.level}: `${it.old.parent}: ${it.old.name}:` renamed to `${it.new.parent}: ${it.new.name}:`")
+                logLn("${it.level}: `${it.old.parent}: ${it.old.name}:` renamed to `${it.new.parent}: ${it.new.name}:`")
                 return Transform(keyValue, it)
             }
         }
@@ -133,7 +133,7 @@ object YamlDeprecated {
         val (errorDetected, string) = modify(loadFile(yamlPath))
 
         Files.write(yamlPath, string.toByteArray())
-        logLine("\nUpdated ${yamlPath.fileName} file")
+        logLn("\nUpdated ${yamlPath.fileName} file")
 
         return errorDetected
     }

--- a/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/YamlDeprecated.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.node.MissingNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.google.common.annotations.VisibleForTesting
 import ftl.args.ArgsHelper.yamlMapper
+import ftl.log.logLine
 import ftl.util.loadFile
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
@@ -116,7 +117,7 @@ object YamlDeprecated {
     private fun validate(key: Key, keyValue: JsonNode): Transform? {
         transforms.forEach {
             if (it.old == key) {
-                println("${it.level}: `${it.old.parent}: ${it.old.name}:` renamed to `${it.new.parent}: ${it.new.name}:`")
+                logLine("${it.level}: `${it.old.parent}: ${it.old.name}:` renamed to `${it.new.parent}: ${it.new.name}:`")
                 return Transform(keyValue, it)
             }
         }
@@ -132,7 +133,7 @@ object YamlDeprecated {
         val (errorDetected, string) = modify(loadFile(yamlPath))
 
         Files.write(yamlPath, string.toByteArray())
-        println("\nUpdated ${yamlPath.fileName} file")
+        logLine("\nUpdated ${yamlPath.fileName} file")
 
         return errorDetected
     }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/CommandUtil.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/CommandUtil.kt
@@ -2,19 +2,20 @@ package ftl.cli.firebase.test
 
 import ftl.args.yml.YamlDeprecated
 import ftl.args.yml.fixDevices
+import ftl.log.logLine
 import ftl.run.exception.YmlValidationError
 import java.nio.file.Path
 
 fun processValidation(validationResult: String, shouldFix: Boolean, ymlPath: Path) {
     when {
-        validationResult.isBlank() -> println("Valid yml file")
+        validationResult.isBlank() -> logLine("Valid yml file")
         !shouldFix -> {
-            println(validationResult)
+            logLine(validationResult)
             throw YmlValidationError("Invalid yml file, use --fix for automatically fix yml")
         }
         else -> {
-            println(validationResult)
-            println("Trying to fix yml file")
+            logLine(validationResult)
+            logLine("Trying to fix yml file")
             if (YamlDeprecated.modify(ymlPath)) {
                 throw YmlValidationError("Invalid yml file, unable to fix yml file")
             }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/CommandUtil.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/CommandUtil.kt
@@ -2,20 +2,20 @@ package ftl.cli.firebase.test
 
 import ftl.args.yml.YamlDeprecated
 import ftl.args.yml.fixDevices
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.YmlValidationError
 import java.nio.file.Path
 
 fun processValidation(validationResult: String, shouldFix: Boolean, ymlPath: Path) {
     when {
-        validationResult.isBlank() -> logLine("Valid yml file")
+        validationResult.isBlank() -> logLn("Valid yml file")
         !shouldFix -> {
-            logLine(validationResult)
+            logLn(validationResult)
             throw YmlValidationError("Invalid yml file, use --fix for automatically fix yml")
         }
         else -> {
-            logLine(validationResult)
-            logLine("Trying to fix yml file")
+            logLn(validationResult)
+            logLn("Trying to fix yml file")
             if (YamlDeprecated.modify(ymlPath)) {
                 throw YmlValidationError("Invalid yml file, unable to fix yml file")
             }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -1,6 +1,7 @@
 package ftl.cli.firebase.test.android
 
 import ftl.args.AndroidArgs
+import ftl.args.setLogLevel
 import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
@@ -45,6 +46,7 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         }
 
         AndroidArgs.load(Paths.get(configPath), cli = this).validate().run {
+            setLogLevel()
             runBlocking {
                 if (dumpShards) dumpShards()
                 else newTestRun()

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -1,7 +1,7 @@
 package ftl.cli.firebase.test.android
 
 import ftl.args.AndroidArgs
-import ftl.args.setLogLevel
+import ftl.args.setupLogLevel
 import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
@@ -46,7 +46,7 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         }
 
         AndroidArgs.load(Paths.get(configPath), cli = this).validate().run {
-            setLogLevel()
+            setupLogLevel()
             runBlocking {
                 if (dumpShards) dumpShards()
                 else newTestRun()

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
@@ -9,6 +9,7 @@ import ftl.config.FtlConstants
 import ftl.environment.ipBlocksListAsTable
 import ftl.environment.networkConfigurationAsTable
 import ftl.environment.providedSoftwareAsTable
+import ftl.log.logLine
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -28,13 +29,13 @@ import java.nio.file.Paths
 class AndroidTestEnvironmentCommand : Runnable {
     override fun run() {
         val projectId = AndroidArgs.loadOrDefault(Paths.get(configPath)).project
-        println(devicesCatalogAsTable(projectId))
-        println(supportedVersionsAsTable(projectId))
-        println(localesAsTable(projectId))
-        println(providedSoftwareAsTable())
-        println(networkConfigurationAsTable())
-        println(supportedOrientationsAsTable(projectId))
-        println(ipBlocksListAsTable())
+        logLine(devicesCatalogAsTable(projectId))
+        logLine(supportedVersionsAsTable(projectId))
+        logLine(localesAsTable(projectId))
+        logLine(providedSoftwareAsTable())
+        logLine(networkConfigurationAsTable())
+        logLine(supportedOrientationsAsTable(projectId))
+        logLine(ipBlocksListAsTable())
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidTestEnvironmentCommand.kt
@@ -9,7 +9,7 @@ import ftl.config.FtlConstants
 import ftl.environment.ipBlocksListAsTable
 import ftl.environment.networkConfigurationAsTable
 import ftl.environment.providedSoftwareAsTable
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -29,13 +29,13 @@ import java.nio.file.Paths
 class AndroidTestEnvironmentCommand : Runnable {
     override fun run() {
         val projectId = AndroidArgs.loadOrDefault(Paths.get(configPath)).project
-        logLine(devicesCatalogAsTable(projectId))
-        logLine(supportedVersionsAsTable(projectId))
-        logLine(localesAsTable(projectId))
-        logLine(providedSoftwareAsTable())
-        logLine(networkConfigurationAsTable())
-        logLine(supportedOrientationsAsTable(projectId))
-        logLine(ipBlocksListAsTable())
+        logLn(devicesCatalogAsTable(projectId))
+        logLn(supportedVersionsAsTable(projectId))
+        logLn(localesAsTable(projectId))
+        logLn(providedSoftwareAsTable())
+        logLn(networkConfigurationAsTable())
+        logLn(supportedOrientationsAsTable(projectId))
+        logLn(ipBlocksListAsTable())
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesDescribeCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.android.configuration
 import ftl.android.AndroidCatalog.getLocaleDescription
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
+import ftl.log.log
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 import java.nio.file.Paths
@@ -20,7 +21,7 @@ import java.nio.file.Paths
 class AndroidLocalesDescribeCommand : Runnable {
     override fun run() {
         if (locale.isBlank()) throw FlankConfigurationError("Argument LOCALE must be specified.")
-        print(getLocaleDescription(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, locale))
+        log(getLocaleDescription(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, locale))
     }
 
     @CommandLine.Parameters(

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesListCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.android.configuration
 import ftl.android.AndroidCatalog
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 )
 class AndroidLocalesListCommand : Runnable {
     override fun run() {
-        logLine(AndroidCatalog.localesAsTable(projectId = AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLn(AndroidCatalog.localesAsTable(projectId = AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/configuration/AndroidLocalesListCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.android.configuration
 import ftl.android.AndroidCatalog
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
+import ftl.log.logLine
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -19,7 +20,7 @@ import java.nio.file.Paths
 )
 class AndroidLocalesListCommand : Runnable {
     override fun run() {
-        println(AndroidCatalog.localesAsTable(projectId = AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLine(AndroidCatalog.localesAsTable(projectId = AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelDescribeCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.android.models
 import ftl.android.AndroidCatalog
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
+import ftl.log.logLine
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 import java.nio.file.Paths
@@ -20,7 +21,7 @@ import java.nio.file.Paths
 class AndroidModelDescribeCommand : Runnable {
     override fun run() {
         if (modelId.isBlank()) throw FlankConfigurationError("Argument MODEL_ID must be specified.")
-        println(AndroidCatalog.describeModel(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
+        logLine(AndroidCatalog.describeModel(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelDescribeCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.android.models
 import ftl.android.AndroidCatalog
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 import java.nio.file.Paths
@@ -21,7 +21,7 @@ import java.nio.file.Paths
 class AndroidModelDescribeCommand : Runnable {
     override fun run() {
         if (modelId.isBlank()) throw FlankConfigurationError("Argument MODEL_ID must be specified.")
-        logLine(AndroidCatalog.describeModel(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
+        logLn(AndroidCatalog.describeModel(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelsListCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.android.models
 import ftl.android.AndroidCatalog
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
+import ftl.log.logLine
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -19,7 +20,7 @@ import java.nio.file.Paths
 )
 class AndroidModelsListCommand : Runnable {
     override fun run() {
-        println(AndroidCatalog.devicesCatalogAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLine(AndroidCatalog.devicesCatalogAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/models/AndroidModelsListCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.android.models
 import ftl.android.AndroidCatalog
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 )
 class AndroidModelsListCommand : Runnable {
     override fun run() {
-        logLine(AndroidCatalog.devicesCatalogAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLn(AndroidCatalog.devicesCatalogAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.android.orientations
 import ftl.android.AndroidCatalog
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
+import ftl.log.logLine
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -19,7 +20,7 @@ import java.nio.file.Paths
 )
 class AndroidOrientationsListCommand : Runnable {
     override fun run() {
-        println(AndroidCatalog.supportedOrientationsAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLine(AndroidCatalog.supportedOrientationsAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.android.orientations
 import ftl.android.AndroidCatalog
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 )
 class AndroidOrientationsListCommand : Runnable {
     override fun run() {
-        logLine(AndroidCatalog.supportedOrientationsAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLn(AndroidCatalog.supportedOrientationsAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsDescribeCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.android.versions
 import ftl.android.AndroidCatalog
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
+import ftl.log.logLine
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 import java.nio.file.Paths
@@ -21,7 +22,7 @@ import java.nio.file.Paths
 class AndroidVersionsDescribeCommand : Runnable {
     override fun run() {
         if (versionId.isBlank()) throw FlankConfigurationError("Argument VERSION_ID must be specified.")
-        println(AndroidCatalog.describeSoftwareVersion(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, versionId))
+        logLine(AndroidCatalog.describeSoftwareVersion(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, versionId))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsDescribeCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.android.versions
 import ftl.android.AndroidCatalog
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 import java.nio.file.Paths
@@ -22,7 +22,7 @@ import java.nio.file.Paths
 class AndroidVersionsDescribeCommand : Runnable {
     override fun run() {
         if (versionId.isBlank()) throw FlankConfigurationError("Argument VERSION_ID must be specified.")
-        logLine(AndroidCatalog.describeSoftwareVersion(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, versionId))
+        logLn(AndroidCatalog.describeSoftwareVersion(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, versionId))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsListCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.android.versions
 import ftl.android.AndroidCatalog.supportedVersionsAsTable
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 )
 class AndroidVersionsListCommand : Runnable {
     override fun run() {
-        logLine(supportedVersionsAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLn(supportedVersionsAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/versions/AndroidVersionsListCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.android.versions
 import ftl.android.AndroidCatalog.supportedVersionsAsTable
 import ftl.args.AndroidArgs
 import ftl.config.FtlConstants
+import ftl.log.logLine
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -19,7 +20,7 @@ import java.nio.file.Paths
 )
 class AndroidVersionsListCommand : Runnable {
     override fun run() {
-        println(supportedVersionsAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLine(supportedVersionsAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -1,7 +1,7 @@
 package ftl.cli.firebase.test.ios
 
 import ftl.args.IosArgs
-import ftl.args.setLogLevel
+import ftl.args.setupLogLevel
 import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
@@ -46,7 +46,7 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         }
 
         IosArgs.load(Paths.get(configPath), cli = this).validate().run {
-            setLogLevel()
+            setupLogLevel()
             if (dumpShards) dumpShards()
             else runBlocking { newTestRun() }
         }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -1,6 +1,7 @@
 package ftl.cli.firebase.test.ios
 
 import ftl.args.IosArgs
+import ftl.args.setLogLevel
 import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
@@ -45,6 +46,7 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         }
 
         IosArgs.load(Paths.get(configPath), cli = this).validate().run {
+            setLogLevel()
             if (dumpShards) dumpShards()
             else runBlocking { newTestRun() }
         }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
@@ -9,6 +9,7 @@ import ftl.ios.IosCatalog.devicesCatalogAsTable
 import ftl.ios.IosCatalog.localesAsTable
 import ftl.ios.IosCatalog.softwareVersionsAsTable
 import ftl.ios.IosCatalog.supportedOrientationsAsTable
+import ftl.log.logLine
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -28,13 +29,13 @@ import java.nio.file.Paths
 class IosTestEnvironmentCommand : Runnable {
     override fun run() {
         val projectId = IosArgs.loadOrDefault(Paths.get(configPath)).project
-        println(devicesCatalogAsTable(projectId))
-        println(softwareVersionsAsTable(projectId))
-        println(localesAsTable(projectId))
-        println(providedSoftwareAsTable())
-        println(networkConfigurationAsTable())
-        println(supportedOrientationsAsTable(projectId))
-        println(ipBlocksListAsTable())
+        logLine(devicesCatalogAsTable(projectId))
+        logLine(softwareVersionsAsTable(projectId))
+        logLine(localesAsTable(projectId))
+        logLine(providedSoftwareAsTable())
+        logLine(networkConfigurationAsTable())
+        logLine(supportedOrientationsAsTable(projectId))
+        logLine(ipBlocksListAsTable())
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosTestEnvironmentCommand.kt
@@ -9,7 +9,7 @@ import ftl.ios.IosCatalog.devicesCatalogAsTable
 import ftl.ios.IosCatalog.localesAsTable
 import ftl.ios.IosCatalog.softwareVersionsAsTable
 import ftl.ios.IosCatalog.supportedOrientationsAsTable
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -29,13 +29,13 @@ import java.nio.file.Paths
 class IosTestEnvironmentCommand : Runnable {
     override fun run() {
         val projectId = IosArgs.loadOrDefault(Paths.get(configPath)).project
-        logLine(devicesCatalogAsTable(projectId))
-        logLine(softwareVersionsAsTable(projectId))
-        logLine(localesAsTable(projectId))
-        logLine(providedSoftwareAsTable())
-        logLine(networkConfigurationAsTable())
-        logLine(supportedOrientationsAsTable(projectId))
-        logLine(ipBlocksListAsTable())
+        logLn(devicesCatalogAsTable(projectId))
+        logLn(softwareVersionsAsTable(projectId))
+        logLn(localesAsTable(projectId))
+        logLn(providedSoftwareAsTable())
+        logLn(networkConfigurationAsTable())
+        logLn(supportedOrientationsAsTable(projectId))
+        logLn(ipBlocksListAsTable())
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesDescribeCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.ios.configuration
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog.getLocaleDescription
+import ftl.log.log
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 import java.nio.file.Paths
@@ -20,7 +21,7 @@ import java.nio.file.Paths
 class IosLocalesDescribeCommand : Runnable {
     override fun run() {
         if (locale.isBlank()) throw FlankConfigurationError("Argument LOCALE must be specified.")
-        print(getLocaleDescription(IosArgs.loadOrDefault(Paths.get(configPath)).project, locale))
+        log(getLocaleDescription(IosArgs.loadOrDefault(Paths.get(configPath)).project, locale))
     }
 
     @CommandLine.Parameters(

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesListCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.ios.configuration
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog.localesAsTable
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 )
 class IosLocalesListCommand : Runnable {
     override fun run() {
-        logLine(localesAsTable(projectId = IosArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLn(localesAsTable(projectId = IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/configuration/IosLocalesListCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.ios.configuration
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog.localesAsTable
+import ftl.log.logLine
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -19,7 +20,7 @@ import java.nio.file.Paths
 )
 class IosLocalesListCommand : Runnable {
     override fun run() {
-        println(localesAsTable(projectId = IosArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLine(localesAsTable(projectId = IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelDescribeCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.ios.models
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog
+import ftl.log.logLine
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 import java.nio.file.Paths
@@ -20,7 +21,7 @@ import java.nio.file.Paths
 class IosModelDescribeCommand : Runnable {
     override fun run() {
         if (modelId.isBlank()) throw FlankConfigurationError("Argument MODEL_ID must be specified.")
-        println(IosCatalog.describeModel(IosArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
+        logLine(IosCatalog.describeModel(IosArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelDescribeCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.ios.models
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 import java.nio.file.Paths
@@ -21,7 +21,7 @@ import java.nio.file.Paths
 class IosModelDescribeCommand : Runnable {
     override fun run() {
         if (modelId.isBlank()) throw FlankConfigurationError("Argument MODEL_ID must be specified.")
-        logLine(IosCatalog.describeModel(IosArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
+        logLn(IosCatalog.describeModel(IosArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelsListCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.ios.models
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog.devicesCatalogAsTable
+import ftl.log.logLine
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -19,7 +20,7 @@ import java.nio.file.Paths
 )
 class IosModelsListCommand : Runnable {
     override fun run() {
-        println(devicesCatalogAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLine(devicesCatalogAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/models/IosModelsListCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.ios.models
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog.devicesCatalogAsTable
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 )
 class IosModelsListCommand : Runnable {
     override fun run() {
-        logLine(devicesCatalogAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLn(devicesCatalogAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsListCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.ios.orientations
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog
+import ftl.log.logLine
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -19,7 +20,7 @@ import java.nio.file.Paths
 )
 class IosOrientationsListCommand : Runnable {
     override fun run() {
-        println(IosCatalog.supportedOrientationsAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLine(IosCatalog.supportedOrientationsAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/orientations/IosOrientationsListCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.ios.orientations
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 )
 class IosOrientationsListCommand : Runnable {
     override fun run() {
-        logLine(IosCatalog.supportedOrientationsAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLn(IosCatalog.supportedOrientationsAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsDescribeCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.ios.versions
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog
+import ftl.log.logLine
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 import java.nio.file.Paths
@@ -21,7 +22,7 @@ import java.nio.file.Paths
 class IosVersionsDescribeCommand : Runnable {
     override fun run() {
         if (versionId.isBlank()) throw FlankConfigurationError("Argument VERSION_ID must be specified.")
-        println(IosCatalog.describeSoftwareVersion(IosArgs.loadOrDefault(Paths.get(configPath)).project, versionId))
+        logLine(IosCatalog.describeSoftwareVersion(IosArgs.loadOrDefault(Paths.get(configPath)).project, versionId))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsDescribeCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.ios.versions
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 import java.nio.file.Paths
@@ -22,7 +22,7 @@ import java.nio.file.Paths
 class IosVersionsDescribeCommand : Runnable {
     override fun run() {
         if (versionId.isBlank()) throw FlankConfigurationError("Argument VERSION_ID must be specified.")
-        logLine(IosCatalog.describeSoftwareVersion(IosArgs.loadOrDefault(Paths.get(configPath)).project, versionId))
+        logLn(IosCatalog.describeSoftwareVersion(IosArgs.loadOrDefault(Paths.get(configPath)).project, versionId))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsListCommand.kt
@@ -3,6 +3,7 @@ package ftl.cli.firebase.test.ios.versions
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog.softwareVersionsAsTable
+import ftl.log.logLine
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -19,7 +20,7 @@ import java.nio.file.Paths
 )
 class IosVersionsListCommand : Runnable {
     override fun run() {
-        println(softwareVersionsAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLine(softwareVersionsAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/versions/IosVersionsListCommand.kt
@@ -3,7 +3,7 @@ package ftl.cli.firebase.test.ios.versions
 import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.ios.IosCatalog.softwareVersionsAsTable
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 import java.nio.file.Paths
 
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 )
 class IosVersionsListCommand : Runnable {
     override fun run() {
-        logLine(softwareVersionsAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
+        logLn(softwareVersionsAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
     }
 
     @CommandLine.Option(names = ["-c", "--config"], description = ["YAML config file path"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ipblocks/IPBlocksListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ipblocks/IPBlocksListCommand.kt
@@ -1,7 +1,7 @@
 package ftl.cli.firebase.test.ipblocks
 
 import ftl.environment.ipBlocksListAsTable
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -17,6 +17,6 @@ import picocli.CommandLine
 )
 class IPBlocksListCommand : Runnable {
     override fun run() {
-        logLine(ipBlocksListAsTable())
+        logLn(ipBlocksListAsTable())
     }
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ipblocks/IPBlocksListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ipblocks/IPBlocksListCommand.kt
@@ -1,6 +1,7 @@
 package ftl.cli.firebase.test.ipblocks
 
 import ftl.environment.ipBlocksListAsTable
+import ftl.log.logLine
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -16,6 +17,6 @@ import picocli.CommandLine
 )
 class IPBlocksListCommand : Runnable {
     override fun run() {
-        println(ipBlocksListAsTable())
+        logLine(ipBlocksListAsTable())
     }
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesDescribeCommand.kt
@@ -1,7 +1,7 @@
 package ftl.cli.firebase.test.networkprofiles
 
 import ftl.environment.networkProfileDescription
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 
@@ -19,7 +19,7 @@ import picocli.CommandLine
 class NetworkProfilesDescribeCommand : Runnable {
     override fun run() {
         if (profileId.isBlank()) throw FlankConfigurationError("Argument PROFILE_ID must be specified.")
-        logLine(networkProfileDescription(profileId))
+        logLn(networkProfileDescription(profileId))
     }
 
     @CommandLine.Parameters(

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesDescribeCommand.kt
@@ -1,6 +1,7 @@
 package ftl.cli.firebase.test.networkprofiles
 
 import ftl.environment.networkProfileDescription
+import ftl.log.logLine
 import ftl.run.exception.FlankConfigurationError
 import picocli.CommandLine
 
@@ -18,7 +19,7 @@ import picocli.CommandLine
 class NetworkProfilesDescribeCommand : Runnable {
     override fun run() {
         if (profileId.isBlank()) throw FlankConfigurationError("Argument PROFILE_ID must be specified.")
-        println(networkProfileDescription(profileId))
+        logLine(networkProfileDescription(profileId))
     }
 
     @CommandLine.Parameters(

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
@@ -1,6 +1,7 @@
 package ftl.cli.firebase.test.networkprofiles
 
 import ftl.environment.networkConfigurationAsTable
+import ftl.log.logLine
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -16,7 +17,7 @@ import picocli.CommandLine
 )
 class NetworkProfilesListCommand : Runnable {
     override fun run() {
-        println("fetching available network profiles...")
-        println(networkConfigurationAsTable())
+        logLine("fetching available network profiles...")
+        logLine(networkConfigurationAsTable())
     }
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
@@ -1,7 +1,7 @@
 package ftl.cli.firebase.test.networkprofiles
 
 import ftl.environment.networkConfigurationAsTable
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -17,7 +17,7 @@ import picocli.CommandLine
 )
 class NetworkProfilesListCommand : Runnable {
     override fun run() {
-        logLine("fetching available network profiles...")
-        logLine(networkConfigurationAsTable())
+        logLn("fetching available network profiles...")
+        logLn(networkConfigurationAsTable())
     }
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/providedsoftware/ProvidedSoftwareListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/providedsoftware/ProvidedSoftwareListCommand.kt
@@ -1,6 +1,7 @@
 package ftl.cli.firebase.test.providedsoftware
 
 import ftl.environment.providedSoftwareAsTable
+import ftl.log.logLine
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -16,6 +17,6 @@ import picocli.CommandLine
 )
 class ProvidedSoftwareListCommand : Runnable {
     override fun run() {
-        println(providedSoftwareAsTable())
+        logLine(providedSoftwareAsTable())
     }
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/providedsoftware/ProvidedSoftwareListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/providedsoftware/ProvidedSoftwareListCommand.kt
@@ -1,7 +1,7 @@
 package ftl.cli.firebase.test.providedsoftware
 
 import ftl.environment.providedSoftwareAsTable
-import ftl.log.logLine
+import ftl.log.logLn
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -17,6 +17,6 @@ import picocli.CommandLine
 )
 class ProvidedSoftwareListCommand : Runnable {
     override fun run() {
-        logLine(providedSoftwareAsTable())
+        logLn(providedSoftwareAsTable())
     }
 }

--- a/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
+++ b/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
@@ -8,6 +8,7 @@ import com.google.api.client.json.JsonFactory
 import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
+import ftl.log.logLine
 import ftl.util.BugsnagInitHelper.initBugsnag
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
@@ -24,7 +25,7 @@ object FtlConstants {
 
     val isMacOS: Boolean by lazy {
         val isMacOS = osName.indexOf("mac") >= 0
-        println("isMacOS = $isMacOS ($osName)")
+        logLine("isMacOS = $isMacOS ($osName)")
         isMacOS
     }
 

--- a/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
+++ b/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
@@ -8,7 +8,7 @@ import com.google.api.client.json.JsonFactory
 import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.util.BugsnagInitHelper.initBugsnag
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
@@ -25,7 +25,7 @@ object FtlConstants {
 
     val isMacOS: Boolean by lazy {
         val isMacOS = osName.indexOf("mac") >= 0
-        logLine("isMacOS = $isMacOS ($osName)")
+        logLn("isMacOS = $isMacOS ($osName)")
         isMacOS
     }
 

--- a/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
+++ b/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
@@ -3,7 +3,7 @@ package ftl.filter
 import com.linkedin.dex.parser.TestMethod
 import ftl.args.ShardChunks
 import ftl.config.FtlConstants
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
 import java.io.IOException
@@ -92,7 +92,7 @@ object TestFilters {
         val include = otherFilters.filterNot { it.describe.startsWith("not") }.toTypedArray()
 
         val result = allOf(*annotationFilters, *exclude, anyOf(*include))
-        if (FtlConstants.useMock) logLine(result.describe)
+        if (FtlConstants.useMock) logLn(result.describe)
         return result
     }
 
@@ -200,7 +200,7 @@ object TestFilters {
     private fun allOf(vararg filters: TestFilter): TestFilter = TestFilter(
         describe = "allOf ${filters.map { it.describe }}",
         shouldRun = { testMethod ->
-            if (FtlConstants.useMock) logLine(":: ${testMethod.testName} @${testMethod.annotations.firstOrNull()}")
+            if (FtlConstants.useMock) logLn(":: ${testMethod.testName} @${testMethod.annotations.firstOrNull()}")
             filters.isEmpty() || filters.all { filter ->
                 filter.shouldRun(testMethod).also { result ->
                     if (FtlConstants.useMock) println("  $result ${filter.describe}")

--- a/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
+++ b/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
@@ -3,6 +3,7 @@ package ftl.filter
 import com.linkedin.dex.parser.TestMethod
 import ftl.args.ShardChunks
 import ftl.config.FtlConstants
+import ftl.log.logLine
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
 import java.io.IOException
@@ -91,7 +92,7 @@ object TestFilters {
         val include = otherFilters.filterNot { it.describe.startsWith("not") }.toTypedArray()
 
         val result = allOf(*annotationFilters, *exclude, anyOf(*include))
-        if (FtlConstants.useMock) println(result.describe)
+        if (FtlConstants.useMock) logLine(result.describe)
         return result
     }
 
@@ -199,7 +200,7 @@ object TestFilters {
     private fun allOf(vararg filters: TestFilter): TestFilter = TestFilter(
         describe = "allOf ${filters.map { it.describe }}",
         shouldRun = { testMethod ->
-            if (FtlConstants.useMock) println(":: ${testMethod.testName} @${testMethod.annotations.firstOrNull()}")
+            if (FtlConstants.useMock) logLine(":: ${testMethod.testName} @${testMethod.annotations.firstOrNull()}")
             filters.isEmpty() || filters.all { filter ->
                 filter.shouldRun(testMethod).also { result ->
                     if (FtlConstants.useMock) println("  $result ${filter.describe}")

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -14,7 +14,7 @@ import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.GCS_PREFIX
 import ftl.config.credential
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.parseAllSuitesXml
 import ftl.reports.xml.xmlToString
@@ -90,7 +90,7 @@ object GcStorage {
                 resultDir
             )
         }.onFailure {
-            logLine("Cannot upload performance metrics ${it.message}")
+            logLn("Cannot upload performance metrics ${it.message}")
         }.getOrNull()
 
     fun uploadReportResult(testResult: String, args: IArgs, fileName: String) {

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -14,6 +14,7 @@ import ftl.args.IosArgs
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.GCS_PREFIX
 import ftl.config.credential
+import ftl.log.logLine
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.parseAllSuitesXml
 import ftl.reports.xml.xmlToString
@@ -89,7 +90,7 @@ object GcStorage {
                 resultDir
             )
         }.onFailure {
-            println("Cannot upload performance metrics ${it.message}")
+            logLine("Cannot upload performance metrics ${it.message}")
         }.getOrNull()
 
     fun uploadReportResult(testResult: String, args: IArgs, fileName: String) {

--- a/test_runner/src/main/kotlin/ftl/gc/UserAuth.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/UserAuth.kt
@@ -6,6 +6,7 @@ import com.google.auth.oauth2.UserAuthorizer
 import com.google.auth.oauth2.UserCredentials
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.userHome
+import ftl.log.logLine
 import ftl.run.exception.FlankGeneralError
 import io.ktor.application.call
 import io.ktor.response.respondText
@@ -89,8 +90,8 @@ class UserAuth {
 
     private fun printAuthorizationUrl() {
         val url = authorizer.getAuthorizationUrl(userId, null, uri)
-        println("Visit the following URL in your browser:")
-        println(url)
+        logLine("Visit the following URL in your browser:")
+        logLine(url)
     }
 
     fun request() {
@@ -115,7 +116,7 @@ class UserAuth {
         dotFlank.toFile().mkdirs()
         ObjectOutputStream(FileOutputStream(userToken.toFile())).writeObject(userCredential)
 
-        println()
-        println("User token saved to $userToken")
+        logLine()
+        logLine("User token saved to $userToken")
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/UserAuth.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/UserAuth.kt
@@ -6,7 +6,7 @@ import com.google.auth.oauth2.UserAuthorizer
 import com.google.auth.oauth2.UserCredentials
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.userHome
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankGeneralError
 import io.ktor.application.call
 import io.ktor.response.respondText
@@ -90,8 +90,8 @@ class UserAuth {
 
     private fun printAuthorizationUrl() {
         val url = authorizer.getAuthorizationUrl(userId, null, uri)
-        logLine("Visit the following URL in your browser:")
-        logLine(url)
+        logLn("Visit the following URL in your browser:")
+        logLn(url)
     }
 
     fun request() {
@@ -116,7 +116,7 @@ class UserAuth {
         dotFlank.toFile().mkdirs()
         ObjectOutputStream(FileOutputStream(userToken.toFile())).writeObject(userCredential)
 
-        logLine()
-        logLine("User token saved to $userToken")
+        logLn()
+        logLn("User token saved to $userToken")
     }
 }

--- a/test_runner/src/main/kotlin/ftl/gc/android/CreateAndroidInstrumentationTest.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/android/CreateAndroidInstrumentationTest.kt
@@ -7,7 +7,7 @@ import com.google.testing.model.ShardingOption
 import com.google.testing.model.TestTargetsForShard
 import com.google.testing.model.UniformSharding
 import ftl.args.ShardChunks
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.platform.android.AndroidTestConfig
 
 internal fun createAndroidInstrumentationTest(
@@ -44,7 +44,7 @@ internal fun AndroidInstrumentationTest.setupTestTargets(
                 if (numUniformShards != null) {
                     testTargets = testShards.flatten()
                     val safeNumUniformShards = if (testTargets.size > numUniformShards) numUniformShards else {
-                        logLine("WARNING: num-uniform-shards ($numUniformShards) is higher than number of test cases (${testTargets.size}) from ${testApk.gcsPath}")
+                        logLn("WARNING: num-uniform-shards ($numUniformShards) is higher than number of test cases (${testTargets.size}) from ${testApk.gcsPath}")
                         testTargets.size
                     }
                     uniformSharding = UniformSharding().setNumShards(safeNumUniformShards)

--- a/test_runner/src/main/kotlin/ftl/gc/android/CreateAndroidInstrumentationTest.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/android/CreateAndroidInstrumentationTest.kt
@@ -7,6 +7,7 @@ import com.google.testing.model.ShardingOption
 import com.google.testing.model.TestTargetsForShard
 import com.google.testing.model.UniformSharding
 import ftl.args.ShardChunks
+import ftl.log.logLine
 import ftl.run.platform.android.AndroidTestConfig
 
 internal fun createAndroidInstrumentationTest(
@@ -43,7 +44,7 @@ internal fun AndroidInstrumentationTest.setupTestTargets(
                 if (numUniformShards != null) {
                     testTargets = testShards.flatten()
                     val safeNumUniformShards = if (testTargets.size > numUniformShards) numUniformShards else {
-                        println("WARNING: num-uniform-shards ($numUniformShards) is higher than number of test cases (${testTargets.size}) from ${testApk.gcsPath}")
+                        logLine("WARNING: num-uniform-shards ($numUniformShards) is higher than number of test cases (${testTargets.size}) from ${testApk.gcsPath}")
                         testTargets.size
                     }
                     uniformSharding = UniformSharding().setNumShards(safeNumUniformShards)

--- a/test_runner/src/main/kotlin/ftl/ios/xctest/common/FindTestsForTarget.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/xctest/common/FindTestsForTarget.kt
@@ -5,6 +5,7 @@ import com.dd.plist.NSDictionary
 import com.dd.plist.NSObject
 import com.dd.plist.NSString
 import com.google.common.annotations.VisibleForTesting
+import ftl.log.logLine
 import ftl.run.exception.FlankGeneralError
 import java.io.File
 import java.nio.file.Paths
@@ -28,7 +29,7 @@ private fun NSDictionary.findXcTestTargets(
 
 private fun NSObject.findBinaryTests(testRoot: String): List<String> {
     val binaryRoot = toString().replace("__TESTROOT__/", testRoot)
-    println("Found xctest: $binaryRoot")
+    logLine("Found xctest: $binaryRoot")
 
     val binaryName = File(binaryRoot).nameWithoutExtension
     val binaryPath = Paths.get(binaryRoot, binaryName).toString()

--- a/test_runner/src/main/kotlin/ftl/ios/xctest/common/FindTestsForTarget.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/xctest/common/FindTestsForTarget.kt
@@ -5,7 +5,7 @@ import com.dd.plist.NSDictionary
 import com.dd.plist.NSObject
 import com.dd.plist.NSString
 import com.google.common.annotations.VisibleForTesting
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankGeneralError
 import java.io.File
 import java.nio.file.Paths
@@ -29,7 +29,7 @@ private fun NSDictionary.findXcTestTargets(
 
 private fun NSObject.findBinaryTests(testRoot: String): List<String> {
     val binaryRoot = toString().replace("__TESTROOT__/", testRoot)
-    logLine("Found xctest: $binaryRoot")
+    logLn("Found xctest: $binaryRoot")
 
     val binaryName = File(binaryRoot).nameWithoutExtension
     val binaryPath = Paths.get(binaryRoot, binaryName).toString()

--- a/test_runner/src/main/kotlin/ftl/log/OutputLogger.kt
+++ b/test_runner/src/main/kotlin/ftl/log/OutputLogger.kt
@@ -1,0 +1,25 @@
+package ftl.log
+
+fun setLogLevel(logLevel: OutputLogLevel) {
+    minimumLogLevel = logLevel
+}
+
+private var minimumLogLevel: OutputLogLevel = OutputLogLevel.LOW
+
+fun log(message: Any) = print(message)
+
+fun logLine(message: Any = "") = println(message)
+
+fun logHigh(message: Any) {
+    if (minimumLogLevel >= OutputLogLevel.HIGH) print(message)
+}
+
+fun logLineHigh(message: Any = "") {
+    if (minimumLogLevel >= OutputLogLevel.HIGH)
+        println(message)
+}
+
+enum class OutputLogLevel {
+    LOW,
+    HIGH
+}

--- a/test_runner/src/main/kotlin/ftl/log/OutputLogger.kt
+++ b/test_runner/src/main/kotlin/ftl/log/OutputLogger.kt
@@ -4,13 +4,13 @@ fun setLogLevel(logLevel: OutputLogLevel) {
     minimumLogLevel = logLevel
 }
 
-fun log(message: Any, level: OutputLogLevel = OutputLogLevel.SIMPLE) =
+fun log(message: Any, level: OutputLogLevel = OutputLogLevel.SIMPLE) {
     if (minimumLogLevel >= level) print(message)
-    else Unit
+}
 
-fun logLn(message: Any = "", level: OutputLogLevel = OutputLogLevel.SIMPLE) =
+fun logLn(message: Any = "", level: OutputLogLevel = OutputLogLevel.SIMPLE) {
     if (minimumLogLevel >= level) println(message)
-    else Unit
+}
 
 private var minimumLogLevel: OutputLogLevel = OutputLogLevel.DETAILED
 

--- a/test_runner/src/main/kotlin/ftl/log/OutputLogger.kt
+++ b/test_runner/src/main/kotlin/ftl/log/OutputLogger.kt
@@ -4,17 +4,17 @@ fun setLogLevel(logLevel: OutputLogLevel) {
     minimumLogLevel = logLevel
 }
 
-fun log(message: Any, level: OutputLogLevel = OutputLogLevel.LOW) =
+fun log(message: Any, level: OutputLogLevel = OutputLogLevel.SIMPLE) =
     if (minimumLogLevel >= level) print(message)
     else Unit
 
-fun logLn(message: Any = "", level: OutputLogLevel = OutputLogLevel.LOW) =
+fun logLn(message: Any = "", level: OutputLogLevel = OutputLogLevel.SIMPLE) =
     if (minimumLogLevel >= level) println(message)
     else Unit
 
-private var minimumLogLevel: OutputLogLevel = OutputLogLevel.LOW
+private var minimumLogLevel: OutputLogLevel = OutputLogLevel.DETAILED
 
 enum class OutputLogLevel {
-    LOW,
-    All
+    SIMPLE,
+    DETAILED
 }

--- a/test_runner/src/main/kotlin/ftl/log/OutputLogger.kt
+++ b/test_runner/src/main/kotlin/ftl/log/OutputLogger.kt
@@ -4,22 +4,17 @@ fun setLogLevel(logLevel: OutputLogLevel) {
     minimumLogLevel = logLevel
 }
 
+fun log(message: Any, level: OutputLogLevel = OutputLogLevel.LOW) =
+    if (minimumLogLevel >= level) print(message)
+    else Unit
+
+fun logLn(message: Any = "", level: OutputLogLevel = OutputLogLevel.LOW) =
+    if (minimumLogLevel >= level) println(message)
+    else Unit
+
 private var minimumLogLevel: OutputLogLevel = OutputLogLevel.LOW
-
-fun log(message: Any) = print(message)
-
-fun logLine(message: Any = "") = println(message)
-
-fun logHigh(message: Any) {
-    if (minimumLogLevel >= OutputLogLevel.HIGH) print(message)
-}
-
-fun logLineHigh(message: Any = "") {
-    if (minimumLogLevel >= OutputLogLevel.HIGH)
-        println(message)
-}
 
 enum class OutputLogLevel {
     LOW,
-    HIGH
+    All
 }

--- a/test_runner/src/main/kotlin/ftl/reports/FullJUnitReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/FullJUnitReport.kt
@@ -3,6 +3,7 @@ package ftl.reports
 import ftl.args.IArgs
 import ftl.gc.GcStorage
 import ftl.json.MatrixMap
+import ftl.log.log
 import ftl.reports.util.IReport
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.xmlToString
@@ -13,7 +14,7 @@ object FullJUnitReport : IReport {
     override fun run(matrices: MatrixMap, result: JUnitTestResult?, printToStdout: Boolean, args: IArgs) {
         val output = result.xmlToString()
         if (printToStdout) {
-            print(output)
+            log(output)
         } else {
             write(matrices, output, args)
         }

--- a/test_runner/src/main/kotlin/ftl/reports/JUnitReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/JUnitReport.kt
@@ -3,6 +3,7 @@ package ftl.reports
 import ftl.args.IArgs
 import ftl.gc.GcStorage
 import ftl.json.MatrixMap
+import ftl.log.log
 import ftl.reports.util.IReport
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.xmlToString
@@ -16,7 +17,7 @@ object JUnitReport : IReport {
         val output = result.xmlToString()
 
         if (printToStdout) {
-            print(output)
+            log(output)
         } else {
             write(matrices, output, args)
         }

--- a/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
@@ -9,6 +9,7 @@ import ftl.json.isFailed
 import ftl.reports.util.IReport
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.json.asPrintableTable
+import ftl.log.log
 import ftl.util.println
 import java.io.StringWriter
 import java.text.DecimalFormat
@@ -70,7 +71,7 @@ object MatrixResultsReport : IReport {
 
     override fun run(matrices: MatrixMap, result: JUnitTestResult?, printToStdout: Boolean, args: IArgs) {
         val output = generate(matrices)
-        if (printToStdout) print(output)
+        if (printToStdout) log(output)
         write(matrices, output, args)
         GcStorage.uploadReportResult(output, args, fileName())
     }

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummary.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummary.kt
@@ -1,7 +1,7 @@
 package ftl.reports.outcome
 
 import com.google.api.services.toolresults.model.Environment
-import ftl.log.logLine
+import ftl.log.logLn
 
 fun TestOutcomeContext.createMatrixOutcomeSummary() = billableMinutes() to outcomeSummary()
 
@@ -11,7 +11,7 @@ private fun TestOutcomeContext.outcomeSummary() =
     if (environments.hasOutcome())
         createMatrixOutcomeSummaryUsingEnvironments()
     else {
-        if (steps.isEmpty()) logLine("No test results found, something went wrong. Try re-running the tests.")
+        if (steps.isEmpty()) logLn("No test results found, something went wrong. Try re-running the tests.")
         createMatrixOutcomeSummaryUsingSteps()
     }
 

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummary.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/CreateMatrixOutcomeSummary.kt
@@ -1,6 +1,7 @@
 package ftl.reports.outcome
 
 import com.google.api.services.toolresults.model.Environment
+import ftl.log.logLine
 
 fun TestOutcomeContext.createMatrixOutcomeSummary() = billableMinutes() to outcomeSummary()
 
@@ -10,7 +11,7 @@ private fun TestOutcomeContext.outcomeSummary() =
     if (environments.hasOutcome())
         createMatrixOutcomeSummaryUsingEnvironments()
     else {
-        if (steps.isEmpty()) println("No test results found, something went wrong. Try re-running the tests.")
+        if (steps.isEmpty()) logLine("No test results found, something went wrong. Try re-running the tests.")
         createMatrixOutcomeSummaryUsingSteps()
     }
 

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -10,6 +10,7 @@ import ftl.args.ShardChunks
 import ftl.gc.GcStorage
 import ftl.json.MatrixMap
 import ftl.json.isAllSuccessful
+import ftl.log.logLine
 import ftl.reports.CostReport
 import ftl.reports.FullJUnitReport
 import ftl.reports.HtmlErrorReport
@@ -43,7 +44,7 @@ object ReportManager {
     private fun getWebLink(matrices: MatrixMap, xmlFile: File): String =
         xmlFile.getMatrixPath(matrices.runPath)
             ?.findMatrixPath(matrices)
-            ?: "".also { println("WARNING: Matrix path not found in JSON.") }
+            ?: "".also { logLine("WARNING: Matrix path not found in JSON.") }
 
     private val deviceStringRgx = Regex("([^-]+-[^-]+-[^-]+-[^-]+).*")
 
@@ -213,7 +214,7 @@ object ReportManager {
     ) {
         val list = createShardEfficiencyList(oldResult, newResult, args, testShardChunks)
 
-        println(
+        logLine(
             "Actual shard times:\n" + list.joinToString("\n") {
                 "  ${it.shard}: Expected: ${it.expectedTime.roundToInt()}s, Actual: ${it.finalTime.roundToInt()}s, Diff: ${it.timeDiff.roundToInt()}s"
             } + "\n"
@@ -244,7 +245,7 @@ object ReportManager {
 private fun String.findMatrixPath(matrices: MatrixMap) = matrices.map.values
     .firstOrNull { savedMatrix -> savedMatrix.gcsPath.endsWithTextWithOptionalSlashAtTheEnd(this) }
     ?.webLink
-    ?: "".also { println("WARNING: Matrix path not found in JSON. $this") }
+    ?: "".also { logLine("WARNING: Matrix path not found in JSON. $this") }
 
 @VisibleForTesting
 internal fun String.endsWithTextWithOptionalSlashAtTheEnd(text: String) = "($text)/*$".toRegex().containsMatchIn(this)

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -10,7 +10,7 @@ import ftl.args.ShardChunks
 import ftl.gc.GcStorage
 import ftl.json.MatrixMap
 import ftl.json.isAllSuccessful
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.reports.CostReport
 import ftl.reports.FullJUnitReport
 import ftl.reports.HtmlErrorReport
@@ -44,7 +44,7 @@ object ReportManager {
     private fun getWebLink(matrices: MatrixMap, xmlFile: File): String =
         xmlFile.getMatrixPath(matrices.runPath)
             ?.findMatrixPath(matrices)
-            ?: "".also { logLine("WARNING: Matrix path not found in JSON.") }
+            ?: "".also { logLn("WARNING: Matrix path not found in JSON.") }
 
     private val deviceStringRgx = Regex("([^-]+-[^-]+-[^-]+-[^-]+).*")
 
@@ -214,7 +214,7 @@ object ReportManager {
     ) {
         val list = createShardEfficiencyList(oldResult, newResult, args, testShardChunks)
 
-        logLine(
+        logLn(
             "Actual shard times:\n" + list.joinToString("\n") {
                 "  ${it.shard}: Expected: ${it.expectedTime.roundToInt()}s, Actual: ${it.finalTime.roundToInt()}s, Diff: ${it.timeDiff.roundToInt()}s"
             } + "\n"
@@ -245,7 +245,7 @@ object ReportManager {
 private fun String.findMatrixPath(matrices: MatrixMap) = matrices.map.values
     .firstOrNull { savedMatrix -> savedMatrix.gcsPath.endsWithTextWithOptionalSlashAtTheEnd(this) }
     ?.webLink
-    ?: "".also { logLine("WARNING: Matrix path not found in JSON. $this") }
+    ?: "".also { logLn("WARNING: Matrix path not found in JSON. $this") }
 
 @VisibleForTesting
 internal fun String.endsWithTextWithOptionalSlashAtTheEnd(text: String) = "($text)/*$".toRegex().containsMatchIn(this)

--- a/test_runner/src/main/kotlin/ftl/run/CancelLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/CancelLastRun.kt
@@ -4,6 +4,7 @@ import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.gc.GcTestMatrix
 import ftl.json.SavedMatrix
+import ftl.log.logLine
 import ftl.run.common.getLastArgs
 import ftl.run.common.getLastMatrices
 import ftl.util.MatrixState
@@ -23,7 +24,7 @@ fun cancelLastRun(args: IArgs) {
 
 /** Cancel all in progress matrices in parallel **/
 suspend fun cancelMatrices(matrixMap: Map<String, SavedMatrix>, project: String) = coroutineScope {
-    println("CancelMatrices")
+    logLine("CancelMatrices")
 
     var matrixCount = 0
 
@@ -36,10 +37,10 @@ suspend fun cancelMatrices(matrixMap: Map<String, SavedMatrix>, project: String)
     }
 
     if (matrixCount == 0) {
-        println(FtlConstants.indent + "No matrices to cancel")
+        logLine(FtlConstants.indent + "No matrices to cancel")
     } else {
-        println(FtlConstants.indent + "Cancelling ${matrixCount}x matrices")
+        logLine(FtlConstants.indent + "Cancelling ${matrixCount}x matrices")
     }
 
-    println()
+    logLine()
 }

--- a/test_runner/src/main/kotlin/ftl/run/CancelLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/CancelLastRun.kt
@@ -4,7 +4,7 @@ import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.gc.GcTestMatrix
 import ftl.json.SavedMatrix
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.common.getLastArgs
 import ftl.run.common.getLastMatrices
 import ftl.util.MatrixState
@@ -24,7 +24,7 @@ fun cancelLastRun(args: IArgs) {
 
 /** Cancel all in progress matrices in parallel **/
 suspend fun cancelMatrices(matrixMap: Map<String, SavedMatrix>, project: String) = coroutineScope {
-    logLine("CancelMatrices")
+    logLn("CancelMatrices")
 
     var matrixCount = 0
 
@@ -37,10 +37,10 @@ suspend fun cancelMatrices(matrixMap: Map<String, SavedMatrix>, project: String)
     }
 
     if (matrixCount == 0) {
-        logLine(FtlConstants.indent + "No matrices to cancel")
+        logLn(FtlConstants.indent + "No matrices to cancel")
     } else {
-        logLine(FtlConstants.indent + "Cancelling ${matrixCount}x matrices")
+        logLn(FtlConstants.indent + "Cancelling ${matrixCount}x matrices")
     }
 
-    logLine()
+    logLn()
 }

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -52,7 +52,7 @@ fun saveShardChunks(
         Paths.get(shardFilePath),
         getGson(obfuscatedOutput).toJson(shards).toByteArray()
     )
-    logLn("Saved $size shards to $shardFilePath", OutputLogLevel.All)
+    logLn("Saved $size shards to $shardFilePath", OutputLogLevel.DETAILED)
 }
 
 private fun getGson(obfuscatedOutput: Boolean) = if (obfuscatedOutput) obfuscatePrettyPrinter else prettyPrint

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -3,7 +3,8 @@ package ftl.run
 import ftl.args.AndroidArgs
 import ftl.args.IosArgs
 import ftl.args.isInstrumentationTest
-import ftl.log.logLineHigh
+import ftl.log.OutputLogLevel
+import ftl.log.logLn
 import ftl.run.common.prettyPrint
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.model.AndroidMatrixTestShards
@@ -51,7 +52,7 @@ fun saveShardChunks(
         Paths.get(shardFilePath),
         getGson(obfuscatedOutput).toJson(shards).toByteArray()
     )
-    logLineHigh("Saved $size shards to $shardFilePath")
+    logLn("Saved $size shards to $shardFilePath", OutputLogLevel.All)
 }
 
 private fun getGson(obfuscatedOutput: Boolean) = if (obfuscatedOutput) obfuscatePrettyPrinter else prettyPrint

--- a/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
+++ b/test_runner/src/main/kotlin/ftl/run/DumpShards.kt
@@ -3,6 +3,7 @@ package ftl.run
 import ftl.args.AndroidArgs
 import ftl.args.IosArgs
 import ftl.args.isInstrumentationTest
+import ftl.log.logLineHigh
 import ftl.run.common.prettyPrint
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.model.AndroidMatrixTestShards
@@ -50,7 +51,7 @@ fun saveShardChunks(
         Paths.get(shardFilePath),
         getGson(obfuscatedOutput).toJson(shards).toByteArray()
     )
-    println("Saved $size shards to $shardFilePath")
+    logLineHigh("Saved $size shards to $shardFilePath")
 }
 
 private fun getGson(obfuscatedOutput: Boolean) = if (obfuscatedOutput) obfuscatePrettyPrinter else prettyPrint

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -6,7 +6,7 @@ import ftl.args.IosArgs
 import ftl.json.SavedMatrix
 import ftl.json.updateMatrixMap
 import ftl.json.validate
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.reports.util.ReportManager
 import ftl.run.common.fetchArtifacts
 import ftl.run.common.pollMatrices
@@ -21,7 +21,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 suspend fun IArgs.newTestRun() = withTimeoutOrNull(parsedTimeout) {
     val args: IArgs = this@newTestRun
-    logLine(args)
+    logLn(args)
     val (matrixMap, testShardChunks, ignoredTests) =
         cancelTestsOnTimeout(project) { runTests() }
 
@@ -30,7 +30,7 @@ suspend fun IArgs.newTestRun() = withTimeoutOrNull(parsedTimeout) {
         ReportManager.generate(matrixMap, args, testShardChunks, ignoredTests)
         cancelTestsOnTimeout(args.project, matrixMap.map) { fetchArtifacts(matrixMap, args) }
 
-        println()
+        logLn()
         matrixMap.printMatricesWebLinks(project)
 
         matrixMap.validate(ignoreFailedTests)

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -6,6 +6,7 @@ import ftl.args.IosArgs
 import ftl.json.SavedMatrix
 import ftl.json.updateMatrixMap
 import ftl.json.validate
+import ftl.log.logLine
 import ftl.reports.util.ReportManager
 import ftl.run.common.fetchArtifacts
 import ftl.run.common.pollMatrices
@@ -20,7 +21,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 suspend fun IArgs.newTestRun() = withTimeoutOrNull(parsedTimeout) {
     val args: IArgs = this@newTestRun
-    println(args)
+    logLine(args)
     val (matrixMap, testShardChunks, ignoredTests) =
         cancelTestsOnTimeout(project) { runTests() }
 

--- a/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
@@ -16,7 +16,7 @@ import ftl.args.ShardChunks
 import ftl.json.needsUpdate
 import ftl.json.updateWithMatrix
 import ftl.json.validate
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.util.MatrixState
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -41,7 +41,7 @@ suspend fun refreshLastRun(currentArgs: IArgs, testShardChunks: ShardChunks) {
 
 /** Refresh all in progress matrices in parallel **/
 private suspend fun refreshMatrices(matrixMap: MatrixMap, args: IArgs) = coroutineScope {
-    logLine("RefreshMatrices")
+    logLn("RefreshMatrices")
 
     val jobs = arrayListOf<Deferred<TestMatrix>>()
     val map = matrixMap.map
@@ -55,14 +55,14 @@ private suspend fun refreshMatrices(matrixMap: MatrixMap, args: IArgs) = corouti
     }
 
     if (matrixCount != 0) {
-        logLine(FtlConstants.indent + "Refreshing ${matrixCount}x matrices")
+        logLn(FtlConstants.indent + "Refreshing ${matrixCount}x matrices")
     }
 
     var dirty = false
     jobs.awaitAll().forEach { matrix ->
         val matrixId = matrix.testMatrixId
 
-        logLine(FtlConstants.indent + "${matrix.state} $matrixId")
+        logLn(FtlConstants.indent + "${matrix.state} $matrixId")
 
         if (map[matrixId]?.needsUpdate(matrix) == true) {
             map[matrixId]?.updateWithMatrix(matrix)?.let {
@@ -73,8 +73,8 @@ private suspend fun refreshMatrices(matrixMap: MatrixMap, args: IArgs) = corouti
     }
 
     if (dirty) {
-        logLine(FtlConstants.indent + "Updating matrix file")
+        logLn(FtlConstants.indent + "Updating matrix file")
         args.updateMatrixFile(matrixMap)
     }
-    logLine()
+    logLn()
 }

--- a/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/RefreshLastRun.kt
@@ -16,6 +16,7 @@ import ftl.args.ShardChunks
 import ftl.json.needsUpdate
 import ftl.json.updateWithMatrix
 import ftl.json.validate
+import ftl.log.logLine
 import ftl.util.MatrixState
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -40,7 +41,7 @@ suspend fun refreshLastRun(currentArgs: IArgs, testShardChunks: ShardChunks) {
 
 /** Refresh all in progress matrices in parallel **/
 private suspend fun refreshMatrices(matrixMap: MatrixMap, args: IArgs) = coroutineScope {
-    println("RefreshMatrices")
+    logLine("RefreshMatrices")
 
     val jobs = arrayListOf<Deferred<TestMatrix>>()
     val map = matrixMap.map
@@ -54,14 +55,14 @@ private suspend fun refreshMatrices(matrixMap: MatrixMap, args: IArgs) = corouti
     }
 
     if (matrixCount != 0) {
-        println(FtlConstants.indent + "Refreshing ${matrixCount}x matrices")
+        logLine(FtlConstants.indent + "Refreshing ${matrixCount}x matrices")
     }
 
     var dirty = false
     jobs.awaitAll().forEach { matrix ->
         val matrixId = matrix.testMatrixId
 
-        println(FtlConstants.indent + "${matrix.state} $matrixId")
+        logLine(FtlConstants.indent + "${matrix.state} $matrixId")
 
         if (map[matrixId]?.needsUpdate(matrix) == true) {
             map[matrixId]?.updateWithMatrix(matrix)?.let {
@@ -72,8 +73,8 @@ private suspend fun refreshMatrices(matrixMap: MatrixMap, args: IArgs) = corouti
     }
 
     if (dirty) {
-        println(FtlConstants.indent + "Updating matrix file")
+        logLine(FtlConstants.indent + "Updating matrix file")
         args.updateMatrixFile(matrixMap)
     }
-    println()
+    logLine()
 }

--- a/test_runner/src/main/kotlin/ftl/run/common/FetchArtifacts.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/FetchArtifacts.kt
@@ -5,9 +5,9 @@ import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.gc.GcStorage
 import ftl.json.MatrixMap
+import ftl.log.OutputLogLevel
 import ftl.log.log
-import ftl.log.logHigh
-import ftl.log.logLineHigh
+import ftl.log.logLn
 import ftl.util.Artifacts
 import ftl.util.MatrixState
 import kotlinx.coroutines.Dispatchers
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 
 // TODO needs refactor
 internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = coroutineScope {
-    logLineHigh("FetchArtifacts")
+    logLn("FetchArtifacts", OutputLogLevel.All)
     val fields = Storage.BlobListOption.fields(Storage.BlobField.NAME)
 
     var dirty = false
@@ -43,7 +43,7 @@ internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = corouti
             if (matched) {
                 val downloadFile = getDownloadPath(args, blobPath)
 
-                logHigh(".")
+                log(".", OutputLogLevel.All)
                 if (!downloadFile.toFile().exists()) {
                     val parentFile = downloadFile.parent.toFile()
                     parentFile.mkdirs()
@@ -56,12 +56,12 @@ internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = corouti
         filtered[index] = matrix.copy(downloaded = true)
         jobs
     }.joinAll()
-    logLineHigh()
+    logLn(level = OutputLogLevel.All)
 
     if (dirty) {
-        logLineHigh(FtlConstants.indent + "Updating matrix file")
+        logLn(FtlConstants.indent + "Updating matrix file", level = OutputLogLevel.All)
         args.updateMatrixFile(matrixMap)
-        logLineHigh()
+        logLn(level = OutputLogLevel.All)
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/common/FetchArtifacts.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/FetchArtifacts.kt
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 
 // TODO needs refactor
 internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = coroutineScope {
-    logLn("FetchArtifacts", OutputLogLevel.All)
+    logLn("FetchArtifacts", OutputLogLevel.DETAILED)
     val fields = Storage.BlobListOption.fields(Storage.BlobField.NAME)
 
     var dirty = false
@@ -43,7 +43,7 @@ internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = corouti
             if (matched) {
                 val downloadFile = getDownloadPath(args, blobPath)
 
-                log(".", OutputLogLevel.All)
+                log(".", OutputLogLevel.DETAILED)
                 if (!downloadFile.toFile().exists()) {
                     val parentFile = downloadFile.parent.toFile()
                     parentFile.mkdirs()
@@ -56,12 +56,12 @@ internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = corouti
         filtered[index] = matrix.copy(downloaded = true)
         jobs
     }.joinAll()
-    logLn(level = OutputLogLevel.All)
+    logLn(level = OutputLogLevel.DETAILED)
 
     if (dirty) {
-        logLn(FtlConstants.indent + "Updating matrix file", level = OutputLogLevel.All)
+        logLn(FtlConstants.indent + "Updating matrix file", level = OutputLogLevel.DETAILED)
         args.updateMatrixFile(matrixMap)
-        logLn(level = OutputLogLevel.All)
+        logLn(level = OutputLogLevel.DETAILED)
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/common/FetchArtifacts.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/FetchArtifacts.kt
@@ -5,6 +5,9 @@ import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.gc.GcStorage
 import ftl.json.MatrixMap
+import ftl.log.log
+import ftl.log.logHigh
+import ftl.log.logLineHigh
 import ftl.util.Artifacts
 import ftl.util.MatrixState
 import kotlinx.coroutines.Dispatchers
@@ -17,7 +20,7 @@ import java.nio.file.Paths
 
 // TODO needs refactor
 internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = coroutineScope {
-    println("FetchArtifacts")
+    logLineHigh("FetchArtifacts")
     val fields = Storage.BlobListOption.fields(Storage.BlobField.NAME)
 
     var dirty = false
@@ -27,7 +30,7 @@ internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = corouti
         finished && notDownloaded
     }.toMutableList()
 
-    print(FtlConstants.indent)
+    log(FtlConstants.indent)
     filtered.flatMapIndexed { index, matrix ->
         val prefix = Storage.BlobListOption.prefix(matrix.gcsPathWithoutRootBucket)
         val result = GcStorage.storage.list(matrix.gcsRootBucket, prefix, fields)
@@ -40,7 +43,7 @@ internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = corouti
             if (matched) {
                 val downloadFile = getDownloadPath(args, blobPath)
 
-                print(".")
+                logHigh(".")
                 if (!downloadFile.toFile().exists()) {
                     val parentFile = downloadFile.parent.toFile()
                     parentFile.mkdirs()
@@ -53,12 +56,12 @@ internal suspend fun fetchArtifacts(matrixMap: MatrixMap, args: IArgs) = corouti
         filtered[index] = matrix.copy(downloaded = true)
         jobs
     }.joinAll()
-    println()
+    logLineHigh()
 
     if (dirty) {
-        println(FtlConstants.indent + "Updating matrix file")
+        logLineHigh(FtlConstants.indent + "Updating matrix file")
         args.updateMatrixFile(matrixMap)
-        println()
+        logLineHigh()
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/common/GetLastMatrices.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/GetLastMatrices.kt
@@ -4,6 +4,7 @@ import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.json.MatrixMap
 import ftl.json.SavedMatrix
+import ftl.log.logLine
 import ftl.run.exception.FlankGeneralError
 import java.nio.file.Paths
 
@@ -11,7 +12,7 @@ import java.nio.file.Paths
 internal fun getLastMatrices(args: IArgs): MatrixMap {
     val lastRun = args.getLastGcsPath() ?: throw FlankGeneralError("no runs found in results/ folder")
 
-    println("Loading run $lastRun")
+    logLine("Loading run $lastRun")
     return matrixPathToObj(lastRun, args)
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/common/GetLastMatrices.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/GetLastMatrices.kt
@@ -4,7 +4,7 @@ import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.json.MatrixMap
 import ftl.json.SavedMatrix
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankGeneralError
 import java.nio.file.Paths
 
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 internal fun getLastMatrices(args: IArgs): MatrixMap {
     val lastRun = args.getLastGcsPath() ?: throw FlankGeneralError("no runs found in results/ folder")
 
-    logLine("Loading run $lastRun")
+    logLn("Loading run $lastRun")
     return matrixPathToObj(lastRun, args)
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/common/PollMatrices.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/PollMatrices.kt
@@ -5,6 +5,7 @@ package ftl.run.common
 import com.google.testing.model.TestMatrix
 import ftl.args.IArgs
 import ftl.gc.GcTestMatrix
+import ftl.log.logLn
 import ftl.run.status.TestMatrixStatusPrinter
 import ftl.util.MatrixState
 import kotlinx.coroutines.coroutineScope
@@ -34,7 +35,7 @@ suspend fun pollMatrices(
     }.fold(emptyMap<String, TestMatrix>()) { matrices, next ->
         matrices + (next.testMatrixId to next)
     }.values.also {
-        println()
+        logLn()
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
+++ b/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
@@ -2,7 +2,7 @@ package ftl.run.exception
 
 import ftl.config.FtlConstants
 import ftl.json.SavedMatrix
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.cancelMatrices
 import kotlinx.coroutines.runBlocking
 import kotlin.system.exitProcess
@@ -78,5 +78,5 @@ private val FlankException.messageOrUnavailable: String
 private fun printError(string: String?) = System.err.println(string)
 
 private fun SavedMatrix.logError() {
-    logLine("Matrix is $state")
+    logLn("Matrix is $state")
 }

--- a/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
+++ b/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
@@ -2,6 +2,7 @@ package ftl.run.exception
 
 import ftl.config.FtlConstants
 import ftl.json.SavedMatrix
+import ftl.log.logLine
 import ftl.run.cancelMatrices
 import kotlinx.coroutines.runBlocking
 import kotlin.system.exitProcess
@@ -77,5 +78,5 @@ private val FlankException.messageOrUnavailable: String
 private fun printError(string: String?) = System.err.println(string)
 
 private fun SavedMatrix.logError() {
-    println("Matrix is $state")
+    logLine("Matrix is $state")
 }

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -9,7 +9,7 @@ import ftl.gc.GcAndroidTestMatrix
 import ftl.gc.GcStorage
 import ftl.gc.GcToolResults
 import ftl.http.executeWithRetry
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.model.InstrumentationTestContext
 import ftl.run.model.TestResult
@@ -72,7 +72,7 @@ internal suspend fun AndroidArgs.runAndroidTests(): TestResult = coroutineScope 
 
     if (testMatrices.isEmpty()) throw FlankGeneralError("There are no tests to run.")
 
-    logLine(beforeRunMessage(allTestShardChunks))
+    logLn(beforeRunMessage(allTestShardChunks))
 
     TestResult(
         matrixMap = afterRunTests(testMatrices.awaitAll(), stopwatch),

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -9,6 +9,7 @@ import ftl.gc.GcAndroidTestMatrix
 import ftl.gc.GcStorage
 import ftl.gc.GcToolResults
 import ftl.http.executeWithRetry
+import ftl.log.logLine
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.model.InstrumentationTestContext
 import ftl.run.model.TestResult
@@ -71,7 +72,7 @@ internal suspend fun AndroidArgs.runAndroidTests(): TestResult = coroutineScope 
 
     if (testMatrices.isEmpty()) throw FlankGeneralError("There are no tests to run.")
 
-    println(beforeRunMessage(allTestShardChunks))
+    logLine(beforeRunMessage(allTestShardChunks))
 
     TestResult(
         matrixMap = afterRunTests(testMatrices.awaitAll(), stopwatch),

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunIosTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunIosTests.kt
@@ -8,7 +8,7 @@ import ftl.gc.GcStorage
 import ftl.gc.GcToolResults
 import ftl.http.executeWithRetry
 import ftl.ios.xctest.common.parseToNSDictionary
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
 import ftl.run.model.TestResult
@@ -51,7 +51,7 @@ internal suspend fun IosArgs.runIosTests(): TestResult = coroutineScope {
     // Upload only after parsing shards to detect missing methods early.
     val xcTestGcsPath = uploadIfNeeded(xctestrunZip.asFileReference()).gcs
 
-    logLine(beforeRunMessage(testShardChunks))
+    logLn(beforeRunMessage(testShardChunks))
 
     repeat(runCount) {
         jobs += testShardChunks.map { testTargets ->

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunIosTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunIosTests.kt
@@ -8,6 +8,7 @@ import ftl.gc.GcStorage
 import ftl.gc.GcToolResults
 import ftl.http.executeWithRetry
 import ftl.ios.xctest.common.parseToNSDictionary
+import ftl.log.logLine
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
 import ftl.run.model.TestResult
@@ -50,7 +51,7 @@ internal suspend fun IosArgs.runIosTests(): TestResult = coroutineScope {
     // Upload only after parsing shards to detect missing methods early.
     val xcTestGcsPath = uploadIfNeeded(xctestrunZip.asFileReference()).gcs
 
-    println(beforeRunMessage(testShardChunks))
+    logLine(beforeRunMessage(testShardChunks))
 
     repeat(runCount) {
         jobs += testShardChunks.map { testTargets ->

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
@@ -16,7 +16,7 @@ import ftl.args.CalculateShardsResult
 import ftl.config.FtlConstants
 import ftl.filter.TestFilter
 import ftl.filter.TestFilters
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.model.AndroidTestContext
 import ftl.run.model.InstrumentationTestContext
 import ftl.shard.createShardsByTestForShards
@@ -146,6 +146,6 @@ private fun List<AndroidTestContext>.dropEmptyInstrumentationTest(): List<Androi
 
 private fun printNoTests(testApks: List<InstrumentationTestContext>) {
     val testApkNames = testApks.joinToString(", ") { pathname -> File(pathname.test.local).name }
-    logLine("${FtlConstants.indent}No tests for $testApkNames")
-    logLine()
+    logLn("${FtlConstants.indent}No tests for $testApkNames")
+    logLn()
 }

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
@@ -16,6 +16,7 @@ import ftl.args.CalculateShardsResult
 import ftl.config.FtlConstants
 import ftl.filter.TestFilter
 import ftl.filter.TestFilters
+import ftl.log.logLine
 import ftl.run.model.AndroidTestContext
 import ftl.run.model.InstrumentationTestContext
 import ftl.shard.createShardsByTestForShards
@@ -145,6 +146,6 @@ private fun List<AndroidTestContext>.dropEmptyInstrumentationTest(): List<Androi
 
 private fun printNoTests(testApks: List<InstrumentationTestContext>) {
     val testApkNames = testApks.joinToString(", ") { pathname -> File(pathname.test.local).name }
-    println("${FtlConstants.indent}No tests for $testApkNames")
-    println()
+    logLine("${FtlConstants.indent}No tests for $testApkNames")
+    logLine()
 }

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/AfterRunTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/AfterRunTests.kt
@@ -6,7 +6,7 @@ import ftl.config.FtlConstants
 import ftl.gc.GcTestMatrix
 import ftl.json.MatrixMap
 import ftl.json.createSavedMatrix
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.common.updateMatrixFile
 import ftl.util.StopWatch
 import ftl.util.isInvalid
@@ -28,11 +28,11 @@ internal suspend fun IArgs.afterRunTests(
     updateMatrixFile(matrixMap)
     saveConfigFile(matrixMap)
 
-    logLine(FtlConstants.indent + "${matrixMap.map.size} matrix ids created in ${stopwatch.check()}")
+    logLn(FtlConstants.indent + "${matrixMap.map.size} matrix ids created in ${stopwatch.check()}")
     val gcsBucket = "https://console.developers.google.com/storage/browser/" +
             resultsBucket + "/" + matrixMap.runPath
-    logLine(FtlConstants.indent + gcsBucket)
-    logLine()
+    logLn(FtlConstants.indent + gcsBucket)
+    logLn()
     matrixMap.printMatricesWebLinks(project)
 }
 
@@ -49,13 +49,13 @@ private fun IArgs.saveConfigFile(matrixMap: MatrixMap) {
 }
 
 internal suspend inline fun MatrixMap.printMatricesWebLinks(project: String) = coroutineScope {
-    logLine("Matrices webLink")
+    logLn("Matrices webLink")
     map.values.map {
         launch(Dispatchers.IO) {
-            logLine("${FtlConstants.indent}${it.matrixId} ${getOrUpdateWebLink(it.webLink, project, it.matrixId)}")
+            logLn("${FtlConstants.indent}${it.matrixId} ${getOrUpdateWebLink(it.webLink, project, it.matrixId)}")
         }
     }.joinAll()
-    logLine()
+    logLn()
 }
 
 private tailrec suspend fun getOrUpdateWebLink(link: String, project: String, matrixId: String): String =

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/AfterRunTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/AfterRunTests.kt
@@ -6,6 +6,7 @@ import ftl.config.FtlConstants
 import ftl.gc.GcTestMatrix
 import ftl.json.MatrixMap
 import ftl.json.createSavedMatrix
+import ftl.log.logLine
 import ftl.run.common.updateMatrixFile
 import ftl.util.StopWatch
 import ftl.util.isInvalid
@@ -27,11 +28,11 @@ internal suspend fun IArgs.afterRunTests(
     updateMatrixFile(matrixMap)
     saveConfigFile(matrixMap)
 
-    println(FtlConstants.indent + "${matrixMap.map.size} matrix ids created in ${stopwatch.check()}")
+    logLine(FtlConstants.indent + "${matrixMap.map.size} matrix ids created in ${stopwatch.check()}")
     val gcsBucket = "https://console.developers.google.com/storage/browser/" +
             resultsBucket + "/" + matrixMap.runPath
-    println(FtlConstants.indent + gcsBucket)
-    println()
+    logLine(FtlConstants.indent + gcsBucket)
+    logLine()
     matrixMap.printMatricesWebLinks(project)
 }
 
@@ -48,13 +49,13 @@ private fun IArgs.saveConfigFile(matrixMap: MatrixMap) {
 }
 
 internal suspend inline fun MatrixMap.printMatricesWebLinks(project: String) = coroutineScope {
-    println("Matrices webLink")
+    logLine("Matrices webLink")
     map.values.map {
         launch(Dispatchers.IO) {
-            println("${FtlConstants.indent}${it.matrixId} ${getOrUpdateWebLink(it.webLink, project, it.matrixId)}")
+            logLine("${FtlConstants.indent}${it.matrixId} ${getOrUpdateWebLink(it.webLink, project, it.matrixId)}")
         }
     }.joinAll()
-    println()
+    logLine()
 }
 
 private tailrec suspend fun getOrUpdateWebLink(link: String, project: String, matrixId: String): String =

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunTests.kt
@@ -5,12 +5,13 @@ import ftl.config.FtlConstants
 import ftl.gc.GcStorage
 import ftl.gc.GcTesting
 import ftl.gc.GcToolResults
+import ftl.log.logLine
 import ftl.run.exception.FlankGeneralError
 import ftl.util.StopWatch
 import java.io.File
 
 internal fun IArgs.beforeRunTests() = StopWatch().also { watch ->
-    println("\nRunTests")
+    logLine("\nRunTests")
     assertMockUrl()
 
     watch.start()

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunTests.kt
@@ -5,13 +5,13 @@ import ftl.config.FtlConstants
 import ftl.gc.GcStorage
 import ftl.gc.GcTesting
 import ftl.gc.GcToolResults
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankGeneralError
 import ftl.util.StopWatch
 import java.io.File
 
 internal fun IArgs.beforeRunTests() = StopWatch().also { watch ->
-    logLine("\nRunTests")
+    logLn("\nRunTests")
     assertMockUrl()
 
     watch.start()

--- a/test_runner/src/main/kotlin/ftl/run/status/ExecutionStatusPrinter.kt
+++ b/test_runner/src/main/kotlin/ftl/run/status/ExecutionStatusPrinter.kt
@@ -66,7 +66,7 @@ internal class MultiLinePrinter(
 @VisibleForTesting
 internal object VerbosePrinter : (List<ExecutionStatus.Change>) -> Unit {
     override fun invoke(changes: List<ExecutionStatus.Change>) {
-        changes.map(ExecutionStatus.Change::views).flatten().forEach { logLn(it, OutputLogLevel.All) }
+        changes.map(ExecutionStatus.Change::views).flatten().forEach { logLn(it, OutputLogLevel.DETAILED) }
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/status/ExecutionStatusPrinter.kt
+++ b/test_runner/src/main/kotlin/ftl/run/status/ExecutionStatusPrinter.kt
@@ -3,6 +3,8 @@ package ftl.run.status
 import com.google.common.annotations.VisibleForTesting
 import ftl.args.IArgs
 import ftl.config.FtlConstants
+import ftl.log.log
+import ftl.log.logLineHigh
 import org.fusesource.jansi.Ansi
 import org.fusesource.jansi.AnsiConsole
 
@@ -12,6 +14,7 @@ fun createExecutionStatusPrinter(
     OutputStyle.Multi -> MultiLinePrinter()
     OutputStyle.Single -> SingleLinePrinter()
     OutputStyle.Verbose -> VerbosePrinter
+    OutputStyle.Compact -> VerbosePrinter
 }
 
 @VisibleForTesting
@@ -32,7 +35,7 @@ internal class SingleLinePrinter : (List<ExecutionStatus.Change>) -> Unit {
             print("\r" + (0..previousLineSize).joinToString("") { " " })
             val output = "${FtlConstants.indent}$time Test executions status: $statusCounts"
             previousLineSize = output.length
-            print("\r$output")
+            log("\r$output")
         }
     }
 }
@@ -48,7 +51,7 @@ internal class MultiLinePrinter(
     private val output = LinkedHashMap<String, ExecutionStatus.View>()
     override fun invoke(changes: List<ExecutionStatus.Change>) {
         repeat(output.size) {
-            print(ansi().cursorUpLine().eraseLine().toString())
+            log(ansi().cursorUpLine().eraseLine().toString())
         }
         output += changes.map { change ->
             change.views.takeLast(1)
@@ -62,7 +65,7 @@ internal class MultiLinePrinter(
 @VisibleForTesting
 internal object VerbosePrinter : (List<ExecutionStatus.Change>) -> Unit {
     override fun invoke(changes: List<ExecutionStatus.Change>) {
-        changes.map(ExecutionStatus.Change::views).flatten().forEach(::println)
+        changes.map(ExecutionStatus.Change::views).flatten().forEach(::logLineHigh)
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/status/ExecutionStatusPrinter.kt
+++ b/test_runner/src/main/kotlin/ftl/run/status/ExecutionStatusPrinter.kt
@@ -3,8 +3,9 @@ package ftl.run.status
 import com.google.common.annotations.VisibleForTesting
 import ftl.args.IArgs
 import ftl.config.FtlConstants
+import ftl.log.OutputLogLevel
 import ftl.log.log
-import ftl.log.logLineHigh
+import ftl.log.logLn
 import org.fusesource.jansi.Ansi
 import org.fusesource.jansi.AnsiConsole
 
@@ -65,7 +66,7 @@ internal class MultiLinePrinter(
 @VisibleForTesting
 internal object VerbosePrinter : (List<ExecutionStatus.Change>) -> Unit {
     override fun invoke(changes: List<ExecutionStatus.Change>) {
-        changes.map(ExecutionStatus.Change::views).flatten().forEach(::logLineHigh)
+        changes.map(ExecutionStatus.Change::views).flatten().forEach { logLn(it, OutputLogLevel.All) }
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/run/status/OutputStyle.kt
+++ b/test_runner/src/main/kotlin/ftl/run/status/OutputStyle.kt
@@ -2,7 +2,7 @@ package ftl.run.status
 
 import ftl.run.exception.FlankConfigurationError
 
-enum class OutputStyle { Verbose, Single, Multi }
+enum class OutputStyle { Verbose, Single, Multi, Compact }
 
 fun String.asOutputStyle() = capitalize().let { capitalized ->
     OutputStyle.values().find { style -> style.name == capitalized }

--- a/test_runner/src/main/kotlin/ftl/run/status/TestMatrixStatusPrinter.kt
+++ b/test_runner/src/main/kotlin/ftl/run/status/TestMatrixStatusPrinter.kt
@@ -4,6 +4,7 @@ import com.google.testing.model.TestExecution
 import com.google.testing.model.TestMatrix
 import ftl.args.IArgs
 import ftl.config.FtlConstants
+import ftl.log.logLine
 import ftl.util.MatrixState
 import ftl.util.StopWatch
 
@@ -29,10 +30,10 @@ class TestMatrixStatusPrinter(
 
     private fun printTestMatrixStatusList(time: String) {
         if (args.outputStyle == OutputStyle.Single) {
-            println()
+            logLine()
         }
         cache.forEach { (id, state) ->
-            println("${FtlConstants.indent}$time $id $state")
+            logLine("${FtlConstants.indent}$time $id $state")
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/run/status/TestMatrixStatusPrinter.kt
+++ b/test_runner/src/main/kotlin/ftl/run/status/TestMatrixStatusPrinter.kt
@@ -4,7 +4,7 @@ import com.google.testing.model.TestExecution
 import com.google.testing.model.TestMatrix
 import ftl.args.IArgs
 import ftl.config.FtlConstants
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.util.MatrixState
 import ftl.util.StopWatch
 
@@ -30,10 +30,10 @@ class TestMatrixStatusPrinter(
 
     private fun printTestMatrixStatusList(time: String) {
         if (args.outputStyle == OutputStyle.Single) {
-            logLine()
+            logLn()
         }
         cache.forEach { (id, state) ->
-            logLine("${FtlConstants.indent}$time $id $state")
+            logLn("${FtlConstants.indent}$time $id $state")
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/shard/CacheReport.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/CacheReport.kt
@@ -1,6 +1,6 @@
 package ftl.shard
 
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.util.FlankTestMethod
 import kotlin.math.roundToInt
 
@@ -8,8 +8,8 @@ fun printCacheInfo(testsToRun: List<FlankTestMethod>, previousMethodDurations: M
     val allTestCount = testsToRun.size
     val cacheHit = cacheHit(allTestCount, calculateCacheMiss(testsToRun, previousMethodDurations))
     val cachePercent = cachePercent(allTestCount, cacheHit)
-    logLine()
-    logLine(" Smart Flank cache hit: ${cachePercent.roundToInt()}% ($cacheHit / $allTestCount)")
+    logLn()
+    logLn(" Smart Flank cache hit: ${cachePercent.roundToInt()}% ($cacheHit / $allTestCount)")
 }
 
 private fun cacheHit(allTestCount: Int, cacheMiss: Int) = allTestCount - cacheMiss

--- a/test_runner/src/main/kotlin/ftl/shard/CacheReport.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/CacheReport.kt
@@ -1,5 +1,6 @@
 package ftl.shard
 
+import ftl.log.logLine
 import ftl.util.FlankTestMethod
 import kotlin.math.roundToInt
 
@@ -7,8 +8,8 @@ fun printCacheInfo(testsToRun: List<FlankTestMethod>, previousMethodDurations: M
     val allTestCount = testsToRun.size
     val cacheHit = cacheHit(allTestCount, calculateCacheMiss(testsToRun, previousMethodDurations))
     val cachePercent = cachePercent(allTestCount, cacheHit)
-    println()
-    println(" Smart Flank cache hit: ${cachePercent.roundToInt()}% ($cacheHit / $allTestCount)")
+    logLine()
+    logLine(" Smart Flank cache hit: ${cachePercent.roundToInt()}% ($cacheHit / $allTestCount)")
 }
 
 private fun cacheHit(allTestCount: Int, cacheMiss: Int) = allTestCount - cacheMiss

--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -3,7 +3,7 @@ package ftl.shard
 import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.run.exception.FlankConfigurationError
 import ftl.util.FlankTestMethod
@@ -101,7 +101,7 @@ private fun matchNumberOfShardsWithTestCount(maxShards: Int, testCount: Int) =
 private val IArgs.platformName get() = if (this is IosArgs) "ios" else "android"
 
 private fun printShardsInfo(shards: List<TestShard>) {
-    logLine("  Shard times: " + shards.joinToString(", ") { "${it.time.roundToInt()}s" } + "\n")
+    logLn("  Shard times: " + shards.joinToString(", ") { "${it.time.roundToInt()}s" } + "\n")
 }
 
 private fun createShardsForTestCases(

--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -3,6 +3,7 @@ package ftl.shard
 import ftl.args.AndroidArgs
 import ftl.args.IArgs
 import ftl.args.IosArgs
+import ftl.log.logLine
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.run.exception.FlankConfigurationError
 import ftl.util.FlankTestMethod
@@ -100,7 +101,7 @@ private fun matchNumberOfShardsWithTestCount(maxShards: Int, testCount: Int) =
 private val IArgs.platformName get() = if (this is IosArgs) "ios" else "android"
 
 private fun printShardsInfo(shards: List<TestShard>) {
-    println("  Shard times: " + shards.joinToString(", ") { "${it.time.roundToInt()}s" } + "\n")
+    logLine("  Shard times: " + shards.joinToString(", ") { "${it.time.roundToInt()}s" } + "\n")
 }
 
 private fun createShardsForTestCases(

--- a/test_runner/src/main/kotlin/ftl/util/Bash.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Bash.kt
@@ -1,13 +1,14 @@
 package ftl.util
 
 import ftl.config.FtlConstants
+import ftl.log.logLine
 import ftl.run.exception.FlankGeneralError
 import java.lang.ProcessBuilder.Redirect.PIPE
 
 object Bash {
 
     fun execute(cmd: String): String {
-        println(cmd)
+        logLine(cmd)
 
         val bashPath = if (FtlConstants.isWindows) "bash.exe" else "/bin/bash"
 

--- a/test_runner/src/main/kotlin/ftl/util/Bash.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Bash.kt
@@ -1,14 +1,14 @@
 package ftl.util
 
 import ftl.config.FtlConstants
-import ftl.log.logLine
+import ftl.log.logLn
 import ftl.run.exception.FlankGeneralError
 import java.lang.ProcessBuilder.Redirect.PIPE
 
 object Bash {
 
     fun execute(cmd: String): String {
-        logLine(cmd)
+        logLn(cmd)
 
         val bashPath = if (FtlConstants.isWindows) "bash.exe" else "/bin/bash"
 

--- a/test_runner/src/main/kotlin/ftl/util/ProgressBar.kt
+++ b/test_runner/src/main/kotlin/ftl/util/ProgressBar.kt
@@ -11,12 +11,12 @@ class ProgressBar {
     private val timer = Timer(true)
 
     fun start(msg: String) {
-        log("  $msg ", OutputLogLevel.All)
+        log("  $msg ", OutputLogLevel.DETAILED)
         timer.scheduleAtFixedRate(task, 0, 10_000)
     }
 
     fun stop() {
-        logLn(level = OutputLogLevel.All)
+        logLn(level = OutputLogLevel.DETAILED)
         timer.cancel()
         task.cancel()
     }
@@ -24,7 +24,7 @@ class ProgressBar {
 
 private class ProgressBarTask : TimerTask() {
     override fun run() {
-        log(".", OutputLogLevel.All)
+        log(".", OutputLogLevel.DETAILED)
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/util/ProgressBar.kt
+++ b/test_runner/src/main/kotlin/ftl/util/ProgressBar.kt
@@ -1,7 +1,8 @@
 package ftl.util
 
-import ftl.log.logHigh
-import ftl.log.logLineHigh
+import ftl.log.OutputLogLevel
+import ftl.log.log
+import ftl.log.logLn
 import java.util.Timer
 import java.util.TimerTask
 
@@ -10,12 +11,12 @@ class ProgressBar {
     private val timer = Timer(true)
 
     fun start(msg: String) {
-        logHigh("  $msg ")
+        log("  $msg ", OutputLogLevel.All)
         timer.scheduleAtFixedRate(task, 0, 10_000)
     }
 
     fun stop() {
-        logLineHigh()
+        logLn(level = OutputLogLevel.All)
         timer.cancel()
         task.cancel()
     }
@@ -23,7 +24,7 @@ class ProgressBar {
 
 private class ProgressBarTask : TimerTask() {
     override fun run() {
-        logHigh(".")
+        log(".", OutputLogLevel.All)
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/util/ProgressBar.kt
+++ b/test_runner/src/main/kotlin/ftl/util/ProgressBar.kt
@@ -1,5 +1,7 @@
 package ftl.util
 
+import ftl.log.logHigh
+import ftl.log.logLineHigh
 import java.util.Timer
 import java.util.TimerTask
 
@@ -8,12 +10,12 @@ class ProgressBar {
     private val timer = Timer(true)
 
     fun start(msg: String) {
-        print("  $msg ")
+        logHigh("  $msg ")
         timer.scheduleAtFixedRate(task, 0, 10_000)
     }
 
     fun stop() {
-        println()
+        logLineHigh()
         timer.cancel()
         task.cancel()
     }
@@ -21,7 +23,7 @@ class ProgressBar {
 
 private class ProgressBarTask : TimerTask() {
     override fun run() {
-        print(".")
+        logHigh(".")
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/util/StopWatchMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/util/StopWatchMatrix.kt
@@ -1,11 +1,12 @@
 package ftl.util
 
 import ftl.config.FtlConstants
+import ftl.log.logLine
 
 class StopWatchMatrix(private val stopwatch: StopWatch, private val matrixId: String) {
 
     fun puts(msg: String) {
         val timestamp = stopwatch.check(alignSeconds = true)
-        println("${FtlConstants.indent}$timestamp $matrixId $msg")
+        logLine("${FtlConstants.indent}$timestamp $matrixId $msg")
     }
 }

--- a/test_runner/src/main/kotlin/ftl/util/StopWatchMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/util/StopWatchMatrix.kt
@@ -1,12 +1,12 @@
 package ftl.util
 
 import ftl.config.FtlConstants
-import ftl.log.logLine
+import ftl.log.logLn
 
 class StopWatchMatrix(private val stopwatch: StopWatch, private val matrixId: String) {
 
     fun puts(msg: String) {
         val timestamp = stopwatch.check(alignSeconds = true)
-        logLine("${FtlConstants.indent}$timestamp $matrixId $msg")
+        logLn("${FtlConstants.indent}$timestamp $matrixId $msg")
     }
 }

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -14,8 +14,8 @@ fun main() {
         ?: "YOUR PROJECT ID"
 
     val quantity = "single"
-    val type = "gameloop"
-    val extra = "ios"
+    val type = "success"
+//    val extra = "ios"
 
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151
@@ -24,14 +24,14 @@ fun main() {
 //            "--debug",
             "firebase",
             "test",
-            "ios",
+            "android",
             "run",
 //            "--dry",
 //            "--dump-shards",
             "--output-style=single",
 //            "--full-junit-result",
 //            "--legacy-junit-result",
-            "-c=test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type-$extra.yml",
+            "-c=test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
             "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"
         )

--- a/test_runner/src/test/kotlin/Debug.kt
+++ b/test_runner/src/test/kotlin/Debug.kt
@@ -15,7 +15,7 @@ fun main() {
 
     val quantity = "single"
     val type = "success"
-//    val extra = "ios"
+    val extra = "ios"
 
     // Bugsnag keeps the process alive so we must call exitProcess
     // https://github.com/bugsnag/bugsnag-java/issues/151
@@ -31,7 +31,7 @@ fun main() {
             "--output-style=single",
 //            "--full-junit-result",
 //            "--legacy-junit-result",
-            "-c=test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type.yml",
+            "-c=test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-$quantity-$type-$extra.yml",
             "--project=$projectId"
 //            "--client-details=key1=value1,key2=value2"
         )

--- a/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-success.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-success.yml
@@ -1,6 +1,6 @@
 gcloud:
-  app: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
-  test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk
+  app: ./test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
+  test: ./test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk
 
 flank:
   disable-sharding: true

--- a/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-success.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-success.yml
@@ -1,6 +1,6 @@
 gcloud:
-  app: ./test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
-  test: ./test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk
+  app: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
+  test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk
 
 flank:
   disable-sharding: true

--- a/test_runner/src/test/kotlin/ftl/log/OutputLoggerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/log/OutputLoggerTest.kt
@@ -1,0 +1,45 @@
+package ftl.log
+
+import com.google.common.truth.Truth
+import ftl.test.util.TestHelper.normalizeLineEnding
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.contrib.java.lang.system.SystemOutRule
+
+class OutputLoggerTest {
+
+    @Rule
+    @JvmField
+    val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    private val simpleMessage = "print for simple"
+    private val detailedMessage = "print for detailed"
+
+    @After
+    fun afterTest() {
+        setLogLevel(OutputLogLevel.DETAILED)
+    }
+
+    @Test
+    fun `should print messages from all output levels if log level set to detailed`() {
+        setLogLevel(OutputLogLevel.DETAILED)
+
+        logLn(simpleMessage)
+        logLn(detailedMessage, OutputLogLevel.DETAILED)
+
+        Truth.assertThat(systemOutRule.log.normalizeLineEnding()).contains(simpleMessage)
+        Truth.assertThat(systemOutRule.log.normalizeLineEnding()).contains(detailedMessage)
+    }
+
+    @Test
+    fun `should print messages only simple output level if log level not set`() {
+        setLogLevel(OutputLogLevel.SIMPLE)
+
+        logLn(simpleMessage)
+        logLn(detailedMessage, OutputLogLevel.DETAILED)
+
+        Truth.assertThat(systemOutRule.log.normalizeLineEnding()).contains(simpleMessage)
+        Truth.assertThat(systemOutRule.log.normalizeLineEnding()).doesNotContain(detailedMessage)
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/util/ProgressBarTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/ProgressBarTest.kt
@@ -20,7 +20,7 @@ class ProgressBarTest {
 
     @Before
     fun beforeTest() {
-        setLogLevel(OutputLogLevel.All)
+        setLogLevel(OutputLogLevel.DETAILED)
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/util/ProgressBarTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/ProgressBarTest.kt
@@ -1,10 +1,13 @@
 package ftl.util
 
 import com.google.common.truth.Truth.assertThat
+import ftl.log.OutputLogLevel
+import ftl.log.setLogLevel
 import ftl.test.util.TestHelper.normalizeLineEnding
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemOutRule
@@ -14,6 +17,11 @@ class ProgressBarTest {
     @Rule
     @JvmField
     val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @Before
+    fun beforeTest() {
+        setLogLevel(OutputLogLevel.All)
+    }
 
     @Test
     fun `progress start stop`() {


### PR DESCRIPTION
Fixes #1306 

## Test Plan
> How do we know the code works?

1. When using ```single```, ```verbose```, ```multi``` output style, the output should not change.
1. Set output style to ```compact``` (I'm not sure it's the best name for that, feel free to suggest other)
1. In this output style we should print: ```yaml```, ```count of test and shards```, ```link to firebase and matrix web links```, ```matrix and cost reports```, ```table with results``` 

## Output example

```

WARNING: disable-sharding enabled with max-test-shards = 1, Flank will ignore max-test-shard and disable sharding.
AndroidArgs
    gcloud:
      results-bucket: test-lab-v9cn46bb990nx-kz69ymd4nm9aq
      results-dir: 2020-12-04_16-34-33.963626_WvMf
      record-video: false
      timeout: 15m
      async: false
      client-details:
      network-profile: null
      results-history-name: null
      # Android gcloud
      app: /Users/adamfilipowicz/Repos/flank/test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
      test: /Users/adamfilipowicz/Repos/flank/test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk
      additional-apks:
      auto-google-login: false
      use-orchestrator: true
      directories-to-pull:
      grant-permissions: all
      type: null
      other-files:
      scenario-numbers:
      scenario-labels:
      obb-files:
      obb-names:
      performance-metrics: false
      num-uniform-shards: null
      test-runner-class: null
      test-targets:
      robo-directives:
      robo-script: null
      device:
        - model: NexusLowRes
          version: 28
          locale: en
          orientation: portrait
      num-flaky-test-attempts: 0
      test-targets-for-shard:
      fail-fast: false

    flank:
      max-test-shards: 1
      shard-time: -1
      num-test-runs: 1
      smart-flank-gcs-path: 
      smart-flank-disable-upload: false
      default-test-time: 120.0
      use-average-test-time-for-new-tests: false
      files-to-download:
      test-targets-always-run:
      disable-sharding: true
      project: flank-open-source
      local-result-dir: results
      full-junit-result: false
      # Android Flank Yml
      keep-file-path: false
      additional-app-test-apks:
      run-timeout: -1
      legacy-junit-result: false
      ignore-failed-tests: false
      output-style: compact
      disable-results-upload: false
      default-class-test-time: 240.0

RunTests
  1 test / 1 shard

  1 matrix ids created in 0m 18s
  https://console.developers.google.com/storage/browser/test-lab-v9cn46bb990nx-kz69ymd4nm9aq/2020-12-04_16-34-33.963626_WvMf

Matrices webLink
  matrix-1wl88r1wuwgov https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/4778909069129894447/executions/bs.b22378a05c11ef79

  3m 46s matrix-1wl88r1wuwgov FINISHED

CostReport
  Virtual devices
    $0.02 for 1m

MatrixResultsReport
  1 / 1 (100.00%)
┌─────────┬──────────────────────┬────────────────────────────┬────────────────────────────────┐
│ OUTCOME │      MATRIX ID       │      TEST AXIS VALUE       │          TEST DETAILS          │
├─────────┼──────────────────────┼────────────────────────────┼────────────────────────────────┤
│ success │ matrix-1wl88r1wuwgov │ NexusLowRes-28-en-portrait │ 1 test cases passed, 1 skipped │
└─────────┴──────────────────────┴────────────────────────────┴────────────────────────────────┘
  
Matrices webLink
  matrix-1wl88r1wuwgov https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.da0c237aaa33732/matrices/4778909069129894447/executions/bs.b22378a05c11ef79


Process finished with exit code 0

```
## Checklist

- [X] Documented
- [X] Unit tested
- [X] Integration tests passes
