### PR TITLE
fix: Fix NPE

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -237,6 +237,7 @@ flank:
 
   ### Smart Flank GCS Paths
   ## Google cloud storage path to store the JUnit XML results from the last run.
+  ## NOTE: Empty results will not be uploaded
   # smart-flank-gcs-path: gs://tmp_flank/flank/test_app_ios.xml
 
   ### Smart Flank Disable Upload flag
@@ -574,6 +575,7 @@ flank:
 
   ### Smart Flank GCS Path
   ## Google cloud storage path where the JUnit XML results from the last run is stored.
+  ## NOTE: Empty results will not be uploaded
   # smart-flank-gcs-path: gs://tmp_flank/tmp/JUnitReport.xml
 
   ### Smart Flank Upload Disable flag

--- a/docs/smart_flank.md
+++ b/docs/smart_flank.md
@@ -8,7 +8,7 @@ At the start of a run, Flank checks to see if there's a JUnit XML with timing in
 
 After each test run, the aggregated JUnit XML from the new run is merged with the old run. Any tests not in the new run are discarded. Tests that were skipped, errored, failed, or empty are discarded. The test time value of successful tests is set using the time from the latest run. If a test failed in the new run and passed in the old run, the timing info from the old run is carried over.
 
-The merged XML is uploaded to the user defined `smartFlankGcsPath`. If `smartFlankGcsPath` is not defined, then the smart flank feature will not activate.
+The merged XML is uploaded to the user defined `smartFlankGcsPath`. If `smartFlankGcsPath` is not defined, then the smart flank feature will not activate. Empty results are not uploaded.
 
 Example:
 

--- a/test_runner/.gitignore
+++ b/test_runner/.gitignore
@@ -6,6 +6,7 @@ EarlGreyExample/
 xctestrun/
 src/test/kotlin/ftl/fixtures/error_result/*.xml
 src/test/kotlin/ftl/fixtures/success_result/*.xml
+src/test/kotlin/ftl/fixtures/empty_result/*.xml
 *.json
 *-describe.adoc
 should_exists.txt

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -226,7 +226,7 @@ object ReportManager {
         args: IArgs,
         testShardChunks: ShardChunks
     ) {
-        if (newTestResult == null) return
+        if (newTestResult == null || newTestResult.testsuites.isNullOrEmpty()) return
 
         val oldTestResult = GcStorage.downloadJunitXml(args)
 

--- a/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
@@ -55,6 +55,11 @@ fun parseAllSuitesXml(path: File): JUnitTestResult {
     return parseAllSuitesXml(path.toPath())
 }
 
-fun parseAllSuitesXml(data: String): JUnitTestResult {
-    return xmlMapper.readValue(fixHtmlCodes(data), JUnitTestResult::class.java)
-}
+fun parseAllSuitesXml(data: String): JUnitTestResult =
+    // This is workaround for flank being unable to parse <testsuites/> into JUnitTesResults
+    // We need to preserve configure(EMPTY_ELEMENT_AS_NULL, true) to skip empty elements
+    // Once better solution is found, this should be fixed
+    if (data.contains("<testsuites/>"))
+        JUnitTestResult(null)
+    else
+        xmlMapper.readValue(fixHtmlCodes(data), JUnitTestResult::class.java)

--- a/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestResult.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestResult.kt
@@ -1,5 +1,6 @@
 package ftl.reports.xml.model
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
 
@@ -8,8 +9,9 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
  * .xctestrun file may contain multiple test bundles (each one is a testsuite) */
 @JacksonXmlRootElement(localName = "testsuites")
 data class JUnitTestResult(
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JacksonXmlProperty(localName = "testsuite")
-    var testsuites: MutableList<JUnitTestSuite>?
+    var testsuites: MutableList<JUnitTestSuite>? = null
 ) {
     fun successful(): Boolean {
         var successful = true

--- a/test_runner/src/test/kotlin/ftl/fixtures/empty_result/.gitignore
+++ b/test_runner/src/test/kotlin/ftl/fixtures/empty_result/.gitignore
@@ -1,0 +1,3 @@
+*.txt
+*.html
+*.csv

--- a/test_runner/src/test/kotlin/ftl/fixtures/empty_result/JUnitReport.xml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/empty_result/JUnitReport.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<testsuites/>

--- a/test_runner/src/test/kotlin/ftl/fixtures/empty_result/matrix_ids.json
+++ b/test_runner/src/test/kotlin/ftl/fixtures/empty_result/matrix_ids.json
@@ -7,13 +7,6 @@
     "downloaded": false,
     "billableVirtualMinutes": 1,
     "billablePhysicalMinutes": 0,
-    "outcome": "success",
-    "testAxises": [
-      {
-        "device": "NexusLowRes-28-en-portrait",
-        "outcome": "success",
-        "details": "2 test cases passed"
-      }
-    ]
+    "outcome": "inconclusive"
   }
 }

--- a/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
@@ -42,6 +42,15 @@ class JUnitXmlTest {
     }
 
     @Test
+    fun `empty testcase -- infrastructure error result`() {
+        val xml = "<testsuites/>"
+
+        parseAllSuitesXml(xml).run {
+            assertThat(testsuites).isNull()
+        }
+    }
+
+    @Test
     fun `merge android`() {
         val mergedXml = parseOneSuiteXml(androidPassXml).merge(parseOneSuiteXml(androidFailXml))
         val merged = mergedXml.xmlToString().normalizeLineEnding()


### PR DESCRIPTION
Fixes #1382 

TLDR;
* fix NPE when `<testsuites/>` was deserialized (a workaround was needed though)
* prevent XML results from being uploaded (for smart flank) if contain no results

When an infrastructure error occurs result matrix is empty which leads to empty `JUnitTestResult`being created. Flank should not upload empty results to prevent old data corruption. 

Flank should also handle XML results with a self-closed root element (XML results for smart flank can be also uploaded manually). That could be easily fixed by changing `EMPTY_ELEMENT_AS_NULL` to false but flank uses this configuration quite extensively (ex skipped tag), so it's not an option. A small workaround was implemented: when the XML file is parsed flank checks if the string contains `<testsuites/>`. If does, an empty `JUnitTestResult` object is returned.

## Test Plan
> How do we know the code works?

Unfortunately, I did not come up with any way of testing it (no idea how to simulate infrastructure error). I covered it in unit test (with mocks)

## Checklist

- [x] Documented
- [x] Unit tested
