### PR TITLE
fix: Print args when iOS tests are not found

### DIFF
--- a/integration_tests/src/test/kotlin/integration/AllTestFilteredIT.kt
+++ b/integration_tests/src/test/kotlin/integration/AllTestFilteredIT.kt
@@ -3,7 +3,6 @@ package integration
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assume.assumeFalse
-import org.junit.Ignore
 import run
 import org.junit.Test
 
@@ -30,7 +29,6 @@ class AllTestFilteredIT {
     }
 
     @Test
-    @Ignore("Should be fixed in https://github.com/Flank/flank/issues/1388")
     fun `filter all tests - ios`() {
         assumeFalse(isWindows)
         val name = "$name-ios"
@@ -43,7 +41,7 @@ class AllTestFilteredIT {
             testSuite = name
         )
 
-        assertExitCode(result, 0)
+        assertExitCode(result, 1)
 
         val resOutput = result.output.removeUnicode()
         assertThat(resOutput).containsMatch(findInCompare(name))

--- a/integration_tests/src/test/resources/compare/AllTestFilteredIT-ios-compare
+++ b/integration_tests/src/test/resources/compare/AllTestFilteredIT-ios-compare
@@ -56,25 +56,5 @@ Found xctest: [0-9a-zA-Z\/_.-]*/test_runner/src/test/kotlin/ftl/fixtures/tmp/ios
 isMacOS = true \(mac os x\)
 nm -U "[0-9a-zA-Z\/_.-]*/test_runner/src/test/kotlin/ftl/fixtures/tmp/ios/EarlGreyExample/Debug-iphoneos/EarlGreyExampleSwift.app/PlugIns/EarlGreyExampleSwiftTests.xctest/EarlGreyExampleSwiftTests"
 nm -gU "[0-9a-zA-Z\/_.-]*/test_runner/src/test/kotlin/ftl/fixtures/tmp/ios/EarlGreyExample/Debug-iphoneos/EarlGreyExampleSwift.app/PlugIns/EarlGreyExampleSwiftTests.xctest/EarlGreyExampleSwiftTests" | xargs -s 262144 xcrun swift-demangle
-Saved 0 shards to ios_shards.json
-  Uploading ios_shards.json \.*
-  Uploading earlgrey_example.zip \*.
-  0 test / 0 shard
 
-  0 matrix ids created in \d{1,2}m \d{1,2}s
-  https://console.developers.google.com/storage/browser/test-lab-[a-zA-Z0-9_-]*/[.a-zA-Z0-9_-]*
-
-Matrices webLink
-
-
-CostReport
-  No cost. 0m
-
-  Uploading CostReport.txt \.*
-MatrixResultsReport
-  0 / 0 \(NaN\%\)
-  Uploading MatrixResultsReport.txt \.*
-FetchArtifacts
-
-
-Matrices webLink
+Empty shards. Cannot match any method to \[.*\]

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -4,6 +4,7 @@ import ftl.args.yml.Type
 import ftl.config.Device
 import ftl.config.common.CommonFlankConfig.Companion.defaultLocalResultsDir
 import ftl.log.OutputLogLevel
+import ftl.log.logLn
 import ftl.run.status.OutputStyle
 import ftl.util.timeoutToMils
 
@@ -87,6 +88,10 @@ interface IArgs {
 val IArgs.logLevel
     get() = if (outputStyle == OutputStyle.Compact) OutputLogLevel.SIMPLE else OutputLogLevel.DETAILED
 
-fun IArgs.setupLogLevel() = also {
+fun <T : IArgs> T.setupLogLevel() = also {
     ftl.log.setLogLevel(logLevel)
+}
+
+fun <T : IArgs> T.logArgs() = also {
+    logLn(this)
 }

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -4,7 +4,6 @@ import ftl.args.yml.Type
 import ftl.config.Device
 import ftl.config.common.CommonFlankConfig.Companion.defaultLocalResultsDir
 import ftl.log.OutputLogLevel
-import ftl.log.logLn
 import ftl.run.status.OutputStyle
 import ftl.util.timeoutToMils
 
@@ -88,10 +87,6 @@ interface IArgs {
 val IArgs.logLevel
     get() = if (outputStyle == OutputStyle.Compact) OutputLogLevel.SIMPLE else OutputLogLevel.DETAILED
 
-fun <T : IArgs> T.setupLogLevel() = also {
+fun IArgs.setupLogLevel() = also {
     ftl.log.setLogLevel(logLevel)
-}
-
-fun <T : IArgs> T.logArgs() = also {
-    logLn(this)
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateCommonArgs.kt
@@ -77,6 +77,6 @@ fun IArgs.checkResultsDirUnique() {
 }
 
 fun IArgs.checkDisableSharding() {
-    if (disableSharding && maxTestShards > 0)
+    if (disableSharding && maxTestShards > 1)
         logLn("WARNING: disable-sharding enabled with max-test-shards = $maxTestShards, Flank will ignore max-test-shard and disable sharding.")
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -3,7 +3,6 @@ package ftl.args
 import ftl.args.yml.Type
 import ftl.ios.IosCatalog
 import ftl.ios.IosCatalog.getSupportedVersionId
-import ftl.ios.xctest.common.mapToRegex
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.IncompatibleTestDimensionError
 
@@ -18,7 +17,6 @@ fun IosArgs.validate() = apply {
     assertAdditionalIpas()
     validType()
     assertGameloop()
-    assertXcTestRunData()
 }
 
 private fun IosArgs.assertGameloop() {
@@ -85,32 +83,4 @@ private fun IosArgs.validType() {
     val validIosTypes = arrayOf(Type.GAMELOOP, Type.XCTEST)
     if (commonArgs.type !in validIosTypes)
         throw FlankConfigurationError("Type should be one of ${validIosTypes.joinToString(",")}")
-}
-
-private fun IosArgs.assertXcTestRunData() {
-    if (!disableSharding && testTargets.isNotEmpty()) {
-        val filteredMethods = xcTestRunData
-            .shardTargets.values
-            .flatten()
-            .flatMap { it.values }
-            .flatten()
-
-        if (filteredMethods.isEmpty()) throw FlankConfigurationError(
-            "Empty shards. Cannot match any method to $testTargets"
-        )
-
-        if (filteredMethods.size < testTargets.size) {
-            val regexList = testTargets.mapToRegex()
-
-            val notMatched = testTargets.filter {
-                filteredMethods.all { method ->
-                    regexList.any { regex ->
-                        regex.matches(method)
-                    }
-                }
-            }
-
-            println("WARNING: cannot match test_targets: $notMatched")
-        }
-    }
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -3,7 +3,10 @@ package ftl.args
 import ftl.args.yml.Type
 import ftl.ios.IosCatalog
 import ftl.ios.IosCatalog.getSupportedVersionId
+import ftl.ios.xctest.common.mapToRegex
+import ftl.log.logLn
 import ftl.run.exception.FlankConfigurationError
+import ftl.run.exception.FlankGeneralError
 import ftl.run.exception.IncompatibleTestDimensionError
 
 fun IosArgs.validate() = apply {
@@ -17,6 +20,7 @@ fun IosArgs.validate() = apply {
     assertAdditionalIpas()
     validType()
     assertGameloop()
+    assertXcTestRunData()
 }
 
 private fun IosArgs.assertGameloop() {
@@ -83,4 +87,32 @@ private fun IosArgs.validType() {
     val validIosTypes = arrayOf(Type.GAMELOOP, Type.XCTEST)
     if (commonArgs.type !in validIosTypes)
         throw FlankConfigurationError("Type should be one of ${validIosTypes.joinToString(",")}")
+}
+
+private fun IosArgs.assertXcTestRunData() {
+    if (!disableSharding && testTargets.isNotEmpty()) {
+        val filteredMethods = xcTestRunData
+            .shardTargets.values
+            .flatten()
+            .flatMap { it.values }
+            .flatten()
+
+        if (filteredMethods.isEmpty()) throw FlankGeneralError(
+            "Empty shards. Cannot match any method to $testTargets"
+        )
+
+        if (filteredMethods.size < testTargets.size) {
+            val regexList = testTargets.mapToRegex()
+
+            val notMatched = testTargets.filter {
+                filteredMethods.all { method ->
+                    regexList.any { regex ->
+                        regex.matches(method)
+                    }
+                }
+            }
+
+            logLn("WARNING: cannot match test_targets: $notMatched")
+        }
+    }
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -1,12 +1,12 @@
 package ftl.cli.firebase.test.android
 
 import ftl.args.AndroidArgs
+import ftl.args.logArgs
 import ftl.args.setupLogLevel
 import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyAndroidConfig
-import ftl.log.logLn
 import ftl.mock.MockServer
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.dumpShards
@@ -48,7 +48,7 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
             MockServer.start()
         }
 
-        AndroidArgs.load(Paths.get(configPath), cli = this).logArgs().validate().run {
+        AndroidArgs.load(Paths.get(configPath), cli = this).setupLogLevel().logArgs().validate().run {
             runBlocking {
                 if (dumpShards) dumpShards()
                 else newTestRun()
@@ -63,7 +63,3 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
     var dumpShards: Boolean = false
 }
 
-private fun AndroidArgs.logArgs() = also {
-    setupLogLevel()
-    logLn(this)
-}

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -1,12 +1,12 @@
 package ftl.cli.firebase.test.android
 
 import ftl.args.AndroidArgs
-import ftl.args.logArgs
 import ftl.args.setupLogLevel
 import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyAndroidConfig
+import ftl.log.logLn
 import ftl.mock.MockServer
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.dumpShards
@@ -48,7 +48,10 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
             MockServer.start()
         }
 
-        AndroidArgs.load(Paths.get(configPath), cli = this).setupLogLevel().logArgs().validate().run {
+        AndroidArgs.load(Paths.get(configPath), cli = this).apply {
+            setupLogLevel()
+            logLn(this)
+        }.validate().run {
             runBlocking {
                 if (dumpShards) dumpShards()
                 else newTestRun()

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -6,6 +6,7 @@ import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyAndroidConfig
+import ftl.log.logLn
 import ftl.mock.MockServer
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.dumpShards
@@ -47,8 +48,7 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
             MockServer.start()
         }
 
-        AndroidArgs.load(Paths.get(configPath), cli = this).validate().run {
-            setupLogLevel()
+        AndroidArgs.load(Paths.get(configPath), cli = this).logArgs().validate().run {
             runBlocking {
                 if (dumpShards) dumpShards()
                 else newTestRun()
@@ -61,4 +61,9 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         description = ["Measures test shards from given test apks and writes them into $ANDROID_SHARD_FILE file instead of executing."]
     )
     var dumpShards: Boolean = false
+}
+
+private fun AndroidArgs.logArgs() = also {
+    setupLogLevel()
+    logLn(this)
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -1,12 +1,12 @@
 package ftl.cli.firebase.test.ios
 
 import ftl.args.IosArgs
-import ftl.args.logArgs
 import ftl.args.setupLogLevel
 import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyIosConfig
+import ftl.log.logLn
 import ftl.mock.MockServer
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
@@ -48,7 +48,10 @@ class IosRunCommand : CommonRunCommand(), Runnable {
             MockServer.start()
         }
 
-        IosArgs.load(Paths.get(configPath), cli = this).setupLogLevel().logArgs().validate().run {
+        IosArgs.load(Paths.get(configPath), cli = this).apply {
+            setupLogLevel()
+            logLn(this)
+        }.validate().run {
             if (dumpShards) dumpShards()
             else runBlocking { newTestRun() }
         }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -1,12 +1,12 @@
 package ftl.cli.firebase.test.ios
 
 import ftl.args.IosArgs
+import ftl.args.logArgs
 import ftl.args.setupLogLevel
 import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyIosConfig
-import ftl.log.logLn
 import ftl.mock.MockServer
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
@@ -48,7 +48,7 @@ class IosRunCommand : CommonRunCommand(), Runnable {
             MockServer.start()
         }
 
-        IosArgs.load(Paths.get(configPath), cli = this).logArgs().validate().run {
+        IosArgs.load(Paths.get(configPath), cli = this).setupLogLevel().logArgs().validate().run {
             if (dumpShards) dumpShards()
             else runBlocking { newTestRun() }
         }
@@ -59,9 +59,4 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         description = ["Measures test shards from given test apks and writes them into $IOS_SHARD_FILE file instead of executing."]
     )
     var dumpShards: Boolean = false
-}
-
-private fun IosArgs.logArgs() = also {
-    setupLogLevel()
-    logLn(this)
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -6,6 +6,7 @@ import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
 import ftl.config.emptyIosConfig
+import ftl.log.logLn
 import ftl.mock.MockServer
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
@@ -47,8 +48,7 @@ class IosRunCommand : CommonRunCommand(), Runnable {
             MockServer.start()
         }
 
-        IosArgs.load(Paths.get(configPath), cli = this).validate().run {
-            setupLogLevel()
+        IosArgs.load(Paths.get(configPath), cli = this).logArgs().validate().run {
             if (dumpShards) dumpShards()
             else runBlocking { newTestRun() }
         }
@@ -59,4 +59,9 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         description = ["Measures test shards from given test apks and writes them into $IOS_SHARD_FILE file instead of executing."]
     )
     var dumpShards: Boolean = false
+}
+
+private fun IosArgs.logArgs() = also {
+    setupLogLevel()
+    logLn(this)
 }

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 suspend fun IArgs.newTestRun() = withTimeoutOrNull(parsedTimeout) {
     val args: IArgs = this@newTestRun
-    logLn(args)
     val (matrixMap, testShardChunks, ignoredTests) =
         cancelTestsOnTimeout(project) { runTests() }
 

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunIosTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunIosTests.kt
@@ -7,11 +7,13 @@ import ftl.gc.GcIosTestMatrix
 import ftl.gc.GcStorage
 import ftl.gc.GcToolResults
 import ftl.http.executeWithRetry
+import ftl.ios.xctest.common.mapToRegex
 import ftl.log.logLn
 import ftl.ios.xctest.flattenShardChunks
 import ftl.ios.xctest.xcTestRunFlow
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
+import ftl.run.exception.FlankGeneralError
 import ftl.run.model.TestResult
 import ftl.run.platform.android.uploadAdditionalIpas
 import ftl.run.platform.android.uploadOtherFiles
@@ -45,9 +47,11 @@ internal suspend fun IosArgs.runIosTests(): TestResult =
         val otherGcsFiles = uploadOtherFiles()
         val additionalIpasGcsFiles = uploadAdditionalIpas()
 
-    dumpShards()
-    if (disableResultsUpload.not())
-        GcStorage.upload(IOS_SHARD_FILE, resultsBucket, resultsDir)
+        dumpShards()
+        if (disableResultsUpload.not())
+            GcStorage.upload(IOS_SHARD_FILE, resultsBucket, resultsDir)
+
+        args.validateXcTestRunData()
 
         // Upload only after parsing shards to detect missing methods early.
         val xcTestGcsPath = uploadIfNeeded(xctestrunZip.asFileReference()).gcs
@@ -81,3 +85,31 @@ internal suspend fun IosArgs.runIosTests(): TestResult =
             shardChunks = testShardChunks.testCases
         )
     }
+
+private fun IosArgs.validateXcTestRunData() {
+    if (!disableSharding && testTargets.isNotEmpty()) {
+        val filteredMethods = xcTestRunData
+            .shardTargets.values
+            .flatten()
+            .flatMap { it.values }
+            .flatten()
+
+        if (filteredMethods.isEmpty()) throw FlankGeneralError(
+            "Empty shards. Cannot match any method to $testTargets"
+        )
+
+        if (filteredMethods.size < testTargets.size) {
+            val regexList = testTargets.mapToRegex()
+
+            val notMatched = testTargets.filter {
+                filteredMethods.all { method ->
+                    regexList.any { regex ->
+                        regex.matches(method)
+                    }
+                }
+            }
+
+            logLn("WARNING: cannot match test_targets: $notMatched")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1388 

## Test Plan
> How do we know the code works?

1. run ios test with config

```
gcloud:
  test: [path to zip]
  xctestrun-file: [path to xctestrun]
flank:
  test-targets:
    - nonExisting/Class
```

1. Flank should print args before any validation (ios and android)
1. Exit code should be 1
1. Integration tests should works

## Checklist

- [X] Integration tests works
