### PR TITLE
fix: cancelCommandRuns should works independent

### DIFF
--- a/test_runner/src/test/kotlin/ftl/cli/firebase/CancelCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/CancelCommandTest.kt
@@ -43,7 +43,6 @@ class CancelCommandTest {
 
     @Test
     fun cancelCommandRuns() {
-        CancelCommand().run()
         val runCmd = AndroidRunCommand()
         runCmd.configPath = "./src/test/kotlin/ftl/fixtures/simple-android-flank.yml"
         runCmd.run()


### PR DESCRIPTION
Fixes #1403 

## Test Plan
> How do we know the code works?

### I case

1. If exist remove ```test_runner/results```
1. run only ```CancelCommandTest.cancelCommandRuns``` test
1. Test should pass

### II case

1. If exist remove ```test_runner/results```
1. run ```./gradlew check```
1. Test should pass

### III case

1. You should have ```test_runner/results``` with some subdirectories with test results
1. Check ```test_runner/results``` contains ```a``` directory without ```matrix_ids.json```. This directory cause problem on Ubuntu workflow. Remove rest of directories (```test_runner/results``` should contain only ```a``` directory)
1. run only ```CancelCommandTest.cancelCommandRuns``` test
1. Test should pass

- [x] Ubuntu workflow should pass