### PR TITLE
ci: trigger integration tests from pr comment

### DIFF
--- a/.github/workflows/full_suite_integration_tests.yml
+++ b/.github/workflows/full_suite_integration_tests.yml
@@ -4,10 +4,61 @@ on:
   schedule:
     - cron: '0 0 * * 1-5' # At 00:00 on every day-of-week from Monday through Friday
   workflow_dispatch:      # or manually
+  issue_comment:
+    types: [created]      # or by comment
 
 jobs:
+  should_run_it:
+    runs-on: ubuntu-latest
+    outputs:
+      run_integration_tests: ${{ steps.should-run-step.outputs.should_run }}
+      pr_number: ${{ steps.pr_number.outputs.number }}
+    steps:
+      - name: Get PR number
+        id: pr_number
+        if: ${{ github.event_name == 'issue_comment'}}
+        run: |
+          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_NUMBER=${PR_URL##*/}
+          echo "::set-output name=number::$PR_NUMBER"
+      - uses: khan/pull-request-comment-trigger@master
+        if: ${{ github.event_name == 'issue_comment'}}
+        id: check_issue_comment
+        with:
+          trigger: '@flank-it'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Check if integrations tests should run
+        id: should-run-step
+        env:
+          run_it: ${{ (steps.check_issue_comment.outputs.triggered == 'true'|| github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+        run : |
+          echo "event name: ${{ github.event_name }}"
+          echo "issue command found: ${{ steps.check_issue_comment.outputs.triggered == 'true' }}"
+          echo '::set-output name=should_run::${{ env.run_it }}'
+  integration-tests-post-link:
+    runs-on: ubuntu-latest
+    needs: [ should_run_it ]
+    if: github.event_name == 'issue_comment' && needs.should_run_it.outputs.run_integration_tests == 'true'
+    steps:
+      - name: Get current time
+        uses: 1466587594/get-current-time@v2
+        id: current-time
+        with:
+          format: 'YYYY-MM-DD HH:mm:ss'
+          utcOffset: "+00:00"
+      - name: Create comment that tests were triggered
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ needs.should_run_it.outputs.pr_number }}
+          body: |
+            **Integration tests were triggered, you could track them [here](https://github.com/Flank/flank/actions/runs/${{ github.run_id }})**
+            ${{ steps.current-time.outputs.formattedTime }}
+    
   run-it-full-suite:
-    if: github.ref == 'refs/heads/master' # for now we want this workflow to run only on master, to be removed once support for different branches is implemented
+    needs: [ should_run_it ]
+    if: github.event_name == 'issue_comment' && needs.should_run_it.outputs.run_integration_tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
@@ -17,8 +68,13 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          submodules: true
+
+      - name: Checkout Pull Request
+        if: github.event_name == 'issue_comment'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr checkout ${{ needs.should_run_it.outputs.pr_number }}
 
       - name: Download flankScripts and add it to PATH
         run: |
@@ -59,7 +115,7 @@ jobs:
           arguments: "integrationTests"
 
       - name: Process IT results
-        if: always()
+        if: always() && github.event_name != 'issue_comment'
         run: |
           flankScripts integration processResults \
             --result ${{ job.status }} \

--- a/.github/workflows/full_suite_integration_tests.yml
+++ b/.github/workflows/full_suite_integration_tests.yml
@@ -8,7 +8,16 @@ on:
     types: [created]      # or by comment
 
 jobs:
+  cancel_previous:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        if: ${{ github.event_name != 'issue_comment'}}
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: '${{ secrets.GITHUB_TOKEN }}'
   should_run_it:
+    needs: [ cancel_previous ]
     runs-on: ubuntu-latest
     outputs:
       run_integration_tests: ${{ steps.should-run-step.outputs.should_run }}
@@ -26,13 +35,13 @@ jobs:
         id: check_issue_comment
         with:
           trigger: '@flank-it'
-          reaction: rocket
+          reaction: eyes
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - name: Check if integrations tests should run
         id: should-run-step
         env:
-          run_it: ${{ (steps.check_issue_comment.outputs.triggered == 'true'|| github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+          run_it: ${{ steps.check_issue_comment.outputs.triggered == 'true'|| github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
         run : |
           echo "event name: ${{ github.event_name }}"
           echo "issue command found: ${{ steps.check_issue_comment.outputs.triggered == 'true' }}"
@@ -41,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ should_run_it ]
     if: github.event_name == 'issue_comment' && needs.should_run_it.outputs.run_integration_tests == 'true'
+    outputs:
+      comment_id: ${{ steps.couc.outputs.comment-id }}
     steps:
       - name: Get current time
         uses: 1466587594/get-current-time@v2
@@ -50,22 +61,21 @@ jobs:
           utcOffset: "+00:00"
       - name: Create comment that tests were triggered
         uses: peter-evans/create-or-update-comment@v1
+        id: couc
         with:
           issue-number: ${{ needs.should_run_it.outputs.pr_number }}
           body: |
-            **Integration tests were triggered, you could track them [here](https://github.com/Flank/flank/actions/runs/${{ github.run_id }})**
-            ${{ steps.current-time.outputs.formattedTime }}
+            **Integration tests were triggered at ${{ steps.current-time.outputs.formattedTime }}, you could track them [here](https://github.com/Flank/flank/actions/runs/${{ github.run_id }})**
+          reactions: rocket
     
   run-it-full-suite:
     needs: [ should_run_it ]
-    if: github.event_name == 'issue_comment' && needs.should_run_it.outputs.run_integration_tests == 'true'
+    if: needs.should_run_it.outputs.run_integration_tests == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      job_status: ${{ job.status }}
+      build-scan-url: ${{ steps.run-it.outputs.build-scan-url }}
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.5.0
-        with:
-          access_token: '${{ secrets.GITHUB_TOKEN }}'
-
       - name: Checkout code
         uses: actions/checkout@v2
 
@@ -75,11 +85,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr checkout ${{ needs.should_run_it.outputs.pr_number }}
-
-      - name: Download flankScripts and add it to PATH
-        run: |
-          ./gradlew :flank-scripts:download
-          echo "./flank-scripts/bash" >> $GITHUB_PATH
 
       - uses: actions/cache@v2
         with:
@@ -96,15 +101,6 @@ jobs:
           mkdir -p "$GCLOUD_DIR"
           echo "$GCLOUD_KEY" | base64 --decode > "$GCLOUD_DIR/application_default_credentials.json"
 
-      - name: Gradle clean build
-        uses: eskatos/gradle-command-action@v1
-        id: build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REF: ${{ github.ref }}
-        with:
-          arguments: "clean build"
-
       - name: Gradle integration tests
         uses: eskatos/gradle-command-action@v1
         id: run-it
@@ -114,11 +110,45 @@ jobs:
         with:
           arguments: "integrationTests"
 
+  process-results:
+    needs: [ run-it-full-suite ]
+    runs-on: ubuntu-latest
+    if: always() && github.event_name != 'issue_comment'
+    steps:
+      - name: Download flankScripts and add it to PATH
+        run: |
+          ./gradlew :flank-scripts:download
+          echo "./flank-scripts/bash" >> $GITHUB_PATH
+
       - name: Process IT results
-        if: always() && github.event_name != 'issue_comment'
         run: |
           flankScripts integration processResults \
-            --result ${{ job.status }} \
-            --url ${{ steps.run-it.outputs.build-scan-url }} \
-            --github-token ${{ secrets.GITHUB_TOKEN }} \
-            --run-id ${{ github.run_id }}
+          --result ${{ needs.run-it-full-suite.outputs.job_status }} \
+          --url ${{ needs.run-it-full-suite.outputs.build-scan-url }} \
+          --github-token ${{ secrets.GITHUB_TOKEN }} \
+          --run-id ${{ github.run_id }}
+
+  post-comment_with_results:
+    needs: [ run-it-full-suite, integration-tests-post-link ]
+    runs-on: ubuntu-latest
+    if: always() && github.event_name == 'issue_comment'
+    steps:
+      - name: Update comment on failure
+        if: ${{ needs.run-it-full-suite.outputs.job_status == 'failure' }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ needs.integration-tests-post-link.outputs.comment_id }}
+          edit-mode: replace
+          body: |
+            **Integration tests failed, you could see results [here](https://github.com/Flank/flank/actions/runs/${{ github.run_id }})**
+          reactions: '-1'
+
+      - name: Update comment on success
+        if: ${{ needs.run-it-full-suite.outputs.job_status == 'success' }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ needs.integration-tests-post-link.outputs.comment_id }}
+          edit-mode: replace
+          body: |
+            **Integration tests succeed, you could see results [here](https://github.com/Flank/flank/actions/runs/${{ github.run_id }})**
+          reactions: '+1'

--- a/.github/workflows/full_suite_integration_tests.yml
+++ b/.github/workflows/full_suite_integration_tests.yml
@@ -9,15 +9,15 @@ on:
 
 jobs:
   cancel_previous:
+    if: ${{ github.event_name != 'issue_comment'}}
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        if: ${{ github.event_name != 'issue_comment'}}
         uses: styfle/cancel-workflow-action@0.6.0
         with:
           access_token: '${{ secrets.GITHUB_TOKEN }}'
+
   should_run_it:
-    needs: [ cancel_previous ]
     runs-on: ubuntu-latest
     outputs:
       run_integration_tests: ${{ steps.should-run-step.outputs.should_run }}

--- a/.github/workflows/full_suite_integration_tests.yml
+++ b/.github/workflows/full_suite_integration_tests.yml
@@ -115,6 +115,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && github.event_name != 'issue_comment'
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Download flankScripts and add it to PATH
         run: |
           ./gradlew :flank-scripts:download

--- a/integration_tests/build.gradle.kts
+++ b/integration_tests/build.gradle.kts
@@ -72,3 +72,8 @@ val compileTestKotlin: KotlinCompile by tasks
 compileTestKotlin.kotlinOptions {
     freeCompilerArgs = listOf("-Xinline-classes")
 }
+// Locally you should have flank builded on CI we need to build it
+if(System.getenv("CI") != null) {
+    tasks["integrationTests"].dependsOn(":test_runner:build")
+}
+

--- a/integration_tests/build.gradle.kts
+++ b/integration_tests/build.gradle.kts
@@ -72,8 +72,7 @@ val compileTestKotlin: KotlinCompile by tasks
 compileTestKotlin.kotlinOptions {
     freeCompilerArgs = listOf("-Xinline-classes")
 }
-// Locally you should have flank builded on CI we need to build it
+// Locally you should have flank built already, on CI we need to build it
 if(System.getenv("CI") != null) {
     tasks["integrationTests"].dependsOn(":test_runner:build")
 }
-


### PR DESCRIPTION
Fixes #1349


## Test Plan
> How do we know the code works?

Current flows:
1. Schedule and manual trigger
- should cancel other builds in progress
- should run full integration tests on master branch
- should process results using flank scripts
2. Comment trigger
- should get pr number
- should post an issue comment
- should run full integration tests on PR branch
- should update comment based on test results

Integration tests run:
1. Integration tests build flank when the environmental variable `CI` is set to true
2. Integration tests do not build flank locally( when variable `CI` is set to false)

Comment trigger
1. Integration tests full suite is triggered by posting comment `@flank-it`
2. When Github action started 👀  are displayed under user comment
![image](https://user-images.githubusercontent.com/65554637/102468260-95854580-4051-11eb-99ee-a5b4271cbf75.png)
3. When Integration tests started comment is posted with a link to the integration test and timestamp (and a 🚀  )
![image](https://user-images.githubusercontent.com/65554637/102467043-1a6f5f80-4050-11eb-8bbd-91773ae4e033.png)
4. After tests finished, comment from the previous step is replaced to result description and reaction(👍 :success, 👎 :failure)
![image](https://user-images.githubusercontent.com/65554637/102467212-51457580-4050-11eb-94bf-03c4a36469d6.png)


[Fork playground](https://github.com/piotradamczyk5/flank/pull/2)
- integration tests failed, because of missing service account

## Checklist

- [x] Add comment trigger
- [x] Show status on PR
- [x] Integration tests should depend on build for CI builds
