### PR TITLE
ci: 1411 implement version

### DIFF
--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -3,6 +3,7 @@ import com.jfrog.bintray.gradle.BintrayExtension
 import java.util.*
 import java.nio.file.Paths
 import java.io.ByteArrayOutputStream
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     application
@@ -28,7 +29,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.2.1"
+version = "1.2.2"
 group = "com.github.flank"
 
 application {
@@ -121,6 +122,7 @@ detekt {
 tasks["check"].dependsOn(tasks["detekt"])
 
 dependencies {
+    implementation(gradleApi())
     implementation(kotlin("stdlib", org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION)) // or "stdlib-jdk8"
     implementation(Dependencies.KOTLIN_SERIALIZATION)
     implementation(Dependencies.Fuel.CORE)
@@ -142,7 +144,12 @@ dependencies {
     testImplementation(Dependencies.SYSTEM_RULES)
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+        freeCompilerArgs = listOf("-Xinline-classes")
+    }
+}
 
 val prepareJar by tasks.registering(Copy::class) {
     dependsOn("shadowJar")

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -3,7 +3,6 @@ import com.jfrog.bintray.gradle.BintrayExtension
 import java.util.*
 import java.nio.file.Paths
 import java.io.ByteArrayOutputStream
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     application
@@ -122,7 +121,6 @@ detekt {
 tasks["check"].dependsOn(tasks["detekt"])
 
 dependencies {
-    implementation(gradleApi())
     implementation(kotlin("stdlib", org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION)) // or "stdlib-jdk8"
     implementation(Dependencies.KOTLIN_SERIALIZATION)
     implementation(Dependencies.Fuel.CORE)
@@ -144,12 +142,7 @@ dependencies {
     testImplementation(Dependencies.SYSTEM_RULES)
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "1.8"
-        freeCompilerArgs = listOf("-Xinline-classes")
-    }
-}
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
 
 val prepareJar by tasks.registering(Copy::class) {
     dependsOn("shadowJar")

--- a/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/DependenciesResultCheck.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/DependenciesResultCheck.kt
@@ -1,5 +1,6 @@
 package flank.scripts.dependencies.update
 
+import flank.scripts.utils.Version
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -13,7 +14,7 @@ data class DependenciesResultCheck(
 @Serializable
 data class Dependency(
     val group: String,
-    val version: String,
+    val version: Version,
     val name: String? = null,
     @SerialName("available") val availableVersion: AvailableVersion? = null
 )
@@ -25,7 +26,7 @@ data class Dependencies(
 
 @Serializable
 data class AvailableVersion(
-    val release: String?,
-    val milestone: String?,
-    val integration: String?
+    val release: Version?,
+    val milestone: Version?,
+    val integration: Version?
 )

--- a/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/DependencyExtensions.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/DependencyExtensions.kt
@@ -8,4 +8,4 @@ val Dependency.versionToUpdate
         ?: availableVersion?.integration
         ?: version
 
-fun GradleDependency.needsUpdate() = (running.version != current.version) || (running.version != releaseCandidate.version)
+fun GradleDependency.needsUpdate() = running.version < current.version || running.version < releaseCandidate.version

--- a/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/DependencyUpdate.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/DependencyUpdate.kt
@@ -1,8 +1,10 @@
 package flank.scripts.dependencies.update
 
+import flank.scripts.utils.Version
+
 data class DependencyUpdate(
     val name: String,
     val valName: String,
-    val oldVersion: String,
-    val newVersion: String
+    val oldVersion: Version,
+    val newVersion: Version
 )

--- a/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/GradleDependency.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/GradleDependency.kt
@@ -1,18 +1,19 @@
 package flank.scripts.dependencies.update
 
+import flank.scripts.utils.Version
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class GradleDependency(
-    val current: GradleVersion,
-    val nightly: GradleVersion,
-    val releaseCandidate: GradleVersion,
-    val running: GradleVersion
+    val current: GradleReleaseChannel,
+    val nightly: GradleReleaseChannel,
+    val releaseCandidate: GradleReleaseChannel,
+    val running: GradleReleaseChannel
 )
 
 @Serializable
-data class GradleVersion(
-    val version: String,
+data class GradleReleaseChannel(
+    val version: Version,
     val reason: String,
     val isUpdateAvailable: Boolean,
     val isFailure: Boolean

--- a/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/UpdateGradle.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/UpdateGradle.kt
@@ -14,12 +14,9 @@ private fun updateGradleWrapper(gradleDependency: GradleDependency, gradleWrappe
     findAllGradleWrapperPropertiesFiles(gradleWrapperPropertiesPath)
         .forEach {
             val from = gradleDependency.running.version
-            val to = if (gradleDependency.releaseCandidate.isUpdateAvailable)
-                gradleDependency.releaseCandidate.version
-            else
-                gradleDependency.current.version
+            val to = maxOf(gradleDependency.releaseCandidate.version, gradleDependency.current.version)
             println("Update gradle wrapper $from to $to in file ${it.path}")
-            it.updateGradleWrapperPropertiesFile(from, to)
+            it.updateGradleWrapperPropertiesFile(from.toString(), to.toString())
         }
 }
 
@@ -28,8 +25,6 @@ private fun findAllGradleWrapperPropertiesFiles(gradleWrapperPropertiesPath: Str
         .filter { it.fileName.toString() == GRADLE_WRAPPER_PROPERTIES_FILE }
         .map { it.toFile() }
 
-private fun File.updateGradleWrapperPropertiesFile(from: String, to: String) {
-    writeText(readText().replace(from, to))
-}
+private fun File.updateGradleWrapperPropertiesFile(from: String, to: String) = writeText(readText().replace(from, to))
 
 private const val GRADLE_WRAPPER_PROPERTIES_FILE = "gradle-wrapper.properties"

--- a/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/UpdateVersionsInFile.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/dependencies/update/UpdateVersionsInFile.kt
@@ -17,7 +17,7 @@ private fun String.getInsertLine(
     .find { containsValDeclaration(it) }
     ?.let {
         println("Updated dependency ${it.name} from ${it.oldVersion} to ${it.newVersion}")
-        replaceFirst(it.oldVersion, it.newVersion)
+        replaceFirst(it.oldVersion.toString(), it.newVersion.toString())
     }
     ?: this
 

--- a/flank-scripts/src/main/kotlin/flank/scripts/utils/Version.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/utils/Version.kt
@@ -1,15 +1,31 @@
 package flank.scripts.utils
 
-class Version constructor(
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object VersionSerializer : KSerializer<Version> {
+    override val descriptor = PrimitiveSerialDescriptor("Version", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Version = parseToVersion(decoder.decodeString())
+
+    override fun serialize(encoder: Encoder, value: Version) = encoder.encodeString(value.toString())
+}
+
+@Serializable(with = VersionSerializer::class)
+data class Version(
     private val major: Int? = null,
     private val minor: Int? = null,
     private val micro: Int? = null,
     private val patch: Int? = null,
     private val qualifier: String? = null
-) {
+) : Comparable<Version> {
     private val hasSuffix = major != null && qualifier != null
 
-    operator fun compareTo(other: Version): Int = when {
+    override operator fun compareTo(other: Version): Int = when {
         major differs other.major -> compareValuesBy(major, other.major, { it ?: 0 })
         minor differs other.minor -> compareValuesBy(minor, other.minor, { it ?: 0 })
         micro differs other.micro -> compareValuesBy(micro, other.micro, { it ?: 0 })

--- a/flank-scripts/src/main/kotlin/flank/scripts/utils/Version.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/utils/Version.kt
@@ -1,0 +1,36 @@
+package flank.scripts.utils
+
+class Version constructor(
+    private val major: Int? = null,
+    private val minor: Int? = null,
+    private val micro: Int? = null,
+    private val patch: Int? = null,
+    private val qualifier: String? = null
+) {
+    private val hasSuffix = major != null && qualifier != null
+
+    operator fun compareTo(other: Version): Int = when {
+        major differs other.major -> compareValuesBy(major, other.major, { it ?: 0 })
+        minor differs other.minor -> compareValuesBy(minor, other.minor, { it ?: 0 })
+        micro differs other.micro -> compareValuesBy(micro, other.micro, { it ?: 0 })
+        patch differs other.patch -> compareValuesBy(patch, other.patch, { it ?: 0 })
+        else -> nullsLast<String>().compare(qualifier, other.qualifier)
+    }
+
+    private infix fun Int?.differs(other: Int?) = (this ?: 0) != (other ?: 0)
+
+    override fun toString(): String = listOfNotNull(major, minor, micro, patch)
+        .joinToString(".") + "${if (hasSuffix) "-" else ""}${qualifier ?: ""}"
+}
+
+fun parseToVersion(versionString: String): Version {
+    val groups = "(\\d*)\\.?(\\d*)\\.?(\\d*)\\.?(\\d*)[-.]?([a-zA-Z0-9_.-]*)".toRegex().find(versionString)?.groupValues
+    return if (groups == null) Version(qualifier = versionString)
+    else Version(
+        major = groups[1].toIntOrNull(),
+        minor = groups[2].toIntOrNull(),
+        micro = groups[3].toIntOrNull(),
+        patch = groups[4].toIntOrNull(),
+        qualifier = if (groups[5].isNotBlank()) groups[5] else null
+    )
+}

--- a/flank-scripts/src/test/kotlin/flank/scripts/dependencies/update/DependencyExtensionsTest.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/dependencies/update/DependencyExtensionsTest.kt
@@ -1,5 +1,8 @@
 package flank.scripts.dependencies.update
 
+import flank.scripts.utils.toAvailableVersion
+import flank.scripts.utils.toDependency
+import flank.scripts.utils.toGradleReleaseChannel
 import org.junit.Test
 
 import org.junit.Assert.assertEquals
@@ -11,7 +14,7 @@ class DependencyExtensionsTest {
     @Test
     fun `should return group with name`() {
         // given
-        val dependency = Dependency(
+        val dependency = toDependency(
             "group",
             "1.0",
             "name"
@@ -26,11 +29,11 @@ class DependencyExtensionsTest {
 
     @Test
     fun `should get version to update if release available`() {
-        val dependency = Dependency(
+        val dependency = toDependency(
             "group",
             "1.0",
             "name",
-            AvailableVersion(
+            toAvailableVersion(
                 "1.1", null, null
             )
         )
@@ -44,11 +47,11 @@ class DependencyExtensionsTest {
 
     @Test
     fun `should get version to update if milestone available`() {
-        val dependency = Dependency(
+        val dependency = toDependency(
             "group",
             "1.0",
             "name",
-            AvailableVersion(null, "1.1", null)
+            toAvailableVersion(null, "1.1", null)
         )
 
         // when
@@ -60,11 +63,11 @@ class DependencyExtensionsTest {
 
     @Test
     fun `should get version to update if integration available`() {
-        val dependency = Dependency(
+        val dependency = toDependency(
             "group",
             "1.0",
             "name",
-            AvailableVersion(null, null, "1.1")
+            toAvailableVersion(null, null, "1.1")
         )
 
         // when
@@ -76,7 +79,7 @@ class DependencyExtensionsTest {
 
     @Test
     fun `should get current version to update if no update`() {
-        val dependency = Dependency(
+        val dependency = toDependency(
             "group",
             "1.0",
             "name",
@@ -94,22 +97,22 @@ class DependencyExtensionsTest {
     fun `should properly check if gradle needs update`() {
         // given
         val gradleWhichNeedsUpdate = GradleDependency(
-            current = GradleVersion("1.1", "test", false, false),
-            nightly = GradleVersion("1.3", "test", false, false),
-            releaseCandidate = GradleVersion("1.2rc", "test", false, false),
-            running = GradleVersion("1", "test", false, false),
+            current = toGradleReleaseChannel("1.1", "test", false, false),
+            nightly = toGradleReleaseChannel("1.3", "test", false, false),
+            releaseCandidate = toGradleReleaseChannel("1.2rc", "test", false, false),
+            running = toGradleReleaseChannel("1", "test", false, false),
         )
         val gradleWhichNeedsUpdateRc = GradleDependency(
-            current = GradleVersion("1.1", "test", false, false),
-            nightly = GradleVersion("1.3", "test", false, false),
-            releaseCandidate = GradleVersion("1.2rc", "test", false, false),
-            running = GradleVersion("1.1", "test", false, false),
+            current = toGradleReleaseChannel("1.1", "test", false, false),
+            nightly = toGradleReleaseChannel("1.3", "test", false, false),
+            releaseCandidate = toGradleReleaseChannel("1.2rc", "test", false, false),
+            running = toGradleReleaseChannel("1.1", "test", false, false),
         )
         val gradleWhichDoesNotNeedUpdate = GradleDependency(
-            current = GradleVersion("1.1", "test", false, false),
-            nightly = GradleVersion("1.3", "test", false, false),
-            releaseCandidate = GradleVersion("1.1", "test", false, false),
-            running = GradleVersion("1.1", "test", false, false),
+            current = toGradleReleaseChannel("1.1", "test", false, false),
+            nightly = toGradleReleaseChannel("1.3", "test", false, false),
+            releaseCandidate = toGradleReleaseChannel("1.1", "test", false, false),
+            running = toGradleReleaseChannel("1.1", "test", false, false),
         )
 
 

--- a/flank-scripts/src/test/kotlin/flank/scripts/dependencies/update/UpdateVersionsInFileTest.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/dependencies/update/UpdateVersionsInFileTest.kt
@@ -1,5 +1,6 @@
 package flank.scripts.dependencies.update
 
+import flank.scripts.utils.toDependencyUpdate
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import skipIfWindows
@@ -19,11 +20,11 @@ class UpdateVersionsInFileTest {
         val expectedFileAfterChanged =
             File("src/test/kotlin/flank/scripts/dependencies/update/testfiles/ExpectedTestVersionsAfterUpdateVersion")
         val dependenciesToUpdate = listOf(
-            DependencyUpdate("DD_PLIST", "DD_PLIST", "1.23", "3.21"),
-            DependencyUpdate("DETEKT", "DETEKT", "1.11.0", "0.11.1"),
-            DependencyUpdate("PICOCLI", "PICOCLI", "4.4.0", "0.4.4"),
-            DependencyUpdate("JACKSON", "JACKSON", "2.11.0", "0.11.2"),
-            DependencyUpdate("LOGBACK", "LOGBACK", "1.2.3", "3.2.1")
+            toDependencyUpdate("DD_PLIST", "DD_PLIST", "1.23", "3.21"),
+            toDependencyUpdate("DETEKT", "DETEKT", "1.11.0", "0.11.1"),
+            toDependencyUpdate("PICOCLI", "PICOCLI", "4.4.0", "0.4.4"),
+            toDependencyUpdate("JACKSON", "JACKSON", "2.11.0", "0.11.2"),
+            toDependencyUpdate("LOGBACK", "LOGBACK", "1.2.3", "3.2.1")
         )
 
         // when

--- a/flank-scripts/src/test/kotlin/flank/scripts/dependencies/update/testfiles/expected_gradle-wrapper.properties_RC.test
+++ b/flank-scripts/src/test/kotlin/flank/scripts/dependencies/update/testfiles/expected_gradle-wrapper.properties_RC.test
@@ -1,5 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists

--- a/flank-scripts/src/test/kotlin/flank/scripts/utils/TestParsers.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/utils/TestParsers.kt
@@ -1,0 +1,33 @@
+package flank.scripts.utils
+
+import flank.scripts.dependencies.update.AvailableVersion
+import flank.scripts.dependencies.update.Dependency
+import flank.scripts.dependencies.update.DependencyUpdate
+import flank.scripts.dependencies.update.GradleReleaseChannel
+
+fun toGradleReleaseChannel(
+    version: String,
+    reason: String,
+    isUpdateAvailable: Boolean,
+    isFailure: Boolean
+) = GradleReleaseChannel(parseToVersion(version), reason, isUpdateAvailable, isFailure)
+
+fun toDependency(
+    group: String,
+    version: String,
+    name: String? = null,
+    availableVersion: AvailableVersion? = null
+) = Dependency(group, parseToVersion(version), name, availableVersion)
+
+fun toDependencyUpdate(
+    name: String,
+    valName: String,
+    oldVersion: String,
+    newVersion: String
+) = DependencyUpdate(name, valName, parseToVersion(oldVersion), parseToVersion(newVersion))
+
+fun toAvailableVersion(
+    release: String?,
+    milestone: String?,
+    integration: String?
+) = AvailableVersion(release?.let(::parseToVersion), milestone?.let(::parseToVersion), integration?.let(::parseToVersion))

--- a/flank-scripts/src/test/kotlin/flank/scripts/utils/VersionParseTest.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/utils/VersionParseTest.kt
@@ -1,0 +1,53 @@
+package flank.scripts.utils
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class VersionParseTest(
+    private val left: String,
+    private val right: String,
+    private val expectedResult: Compare
+) {
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "compare {0} and {1} with result {2}")
+        fun inputs() = listOf(
+            arrayOf("6.6.1", "6.7", Smaller),
+            arrayOf("1", "2", Smaller),
+            arrayOf("2.0.0", "1.9.9.9", Greater),
+            arrayOf("2.0.0", "2.0.0-rc-1", Greater),
+            arrayOf("2.0.0-rc-1", "2.0", Smaller),
+            arrayOf("6.7.1", "6.8-rc-1", Smaller),
+            arrayOf("v1beta3-rev20201029-1.30.10", "v1beta3-rev20201028-1.30.10", Greater),
+            arrayOf("v1beta3-rev20201029-1.30.10", "v1beta3-rev20201228-1.30.10", Smaller),
+            arrayOf("1.2.3", "1.2.3.0", Equal),
+            arrayOf("1.2.3.0", "1.2.3", Equal),
+            arrayOf("6.8.1-rc-1", "6.8.1-rc-2", Smaller),
+        )
+    }
+
+    @Test
+    fun `compare versions`() {
+        // We do not use > operator to test equality
+        val result = parseToVersion(left).compareTo(parseToVersion(right))
+        assertTrue(
+            "$left should be evaluated as ${expectedResult.name()} $right: result = $result",
+            expectedResult(result)
+        )
+    }
+}
+
+sealed class Compare(private val lambda: (Int) -> Boolean) {
+    operator fun invoke(int: Int) = lambda(int)
+    fun name() = this::class.simpleName?.toUpperCase() ?: ""
+    override fun toString() = name()
+}
+
+private object Greater : Compare({ it > 0 })
+private object Smaller : Compare({ it < 0 })
+private object Equal : Compare({ it == 0 })
+

--- a/flank-scripts/src/test/kotlin/flank/scripts/utils/VersionToStringTest.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/utils/VersionToStringTest.kt
@@ -1,0 +1,33 @@
+package flank.scripts.utils
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class VersionToStringTest(
+    private val left: String,
+) {
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters
+        fun inputs() = listOf(
+            "6.6.1",
+            "1",
+            "2.0.0",
+            "2.0.0-rc-1",
+            "2.0",
+            "6.8-rc-1",
+            "v1beta3-rev20201029-1.30.10",
+            "1.2.3.0",
+            "1.10.3-jdk8"
+        ).map { arrayOf(it) }
+    }
+
+    @Test
+    fun `compare strings`() {
+        Assert.assertEquals(left, parseToVersion(left).toString())
+    }
+}


### PR DESCRIPTION
Fixes #1411 

Implement `Version` class (and related logic) to handle dependencies versioning

## Test Plan
> How do we know the code works?

1. run 
   ```
    git checkout master &&\
      ./gradlew clean assemble &&\
      ./gradlew dependencyUpdates -DoutputFormatter=json -DoutputDir=. &&\
      java -jar ./flank-scripts/build/libs/flank-scripts.jar  dependencies update &&\
      git diff >> dep_master
   ```
1. run
    ```
    git checkout . &&\
      git checkout 1411-implement-version &&\
      ./gradlew clean assemble &&\
      ./gradlew dependencyUpdates -DoutputFormatter=json -DoutputDir=. &&\
      java -jar ./flank-scripts/build/libs/flank-scripts.jar  dependencies update &&\
      git diff >> dep_version
    ```
1. compare dep files
    ```
    diff dep_master dep_version
    ```
1. there should be no differences (nothing is printed to the console, exit code = 0)

## Checklist

- [x] Unit tested
