### PR TITLE
fix: Add attempts to performance test

### DIFF
--- a/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
+++ b/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
@@ -19,8 +19,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.concurrent.TimeUnit
-import kotlin.system.measureNanoTime
 import kotlin.system.measureTimeMillis
 
 @RunWith(FlankTestRunner::class)
@@ -103,14 +101,14 @@ class ShardTest {
             copy(commonArgs = commonArgs.copy(maxTestShards = 4))
         }
 
+        // The test occasionally fails on GH Actions' machines, we need to retry to exclude flakiness
         val maxAttempts = 5
         val maxMs = 5000
 
         var attempt = 0
         var ms = Long.MAX_VALUE
 
-        while (attempt < maxAttempts && ms >= maxMs) {
-            attempt++
+        while (attempt++ < maxAttempts && ms >= maxMs) {
             ms = measureTimeMillis {
                 createShardsByShardCount(testsToRun, JUnitTestResult(null), arg)
             }

--- a/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
+++ b/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
@@ -21,6 +21,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.TimeUnit
 import kotlin.system.measureNanoTime
+import kotlin.system.measureTimeMillis
 
 @RunWith(FlankTestRunner::class)
 class ShardTest {
@@ -102,13 +103,20 @@ class ShardTest {
             copy(commonArgs = commonArgs.copy(maxTestShards = 4))
         }
 
-        val nano = measureNanoTime {
-            createShardsByShardCount(testsToRun, JUnitTestResult(null), arg)
-        }
+        val maxAttempts = 5
+        val maxMs = 5000
 
-        val ms = TimeUnit.NANOSECONDS.toMillis(nano)
-        println("Shards calculated in $ms ms")
-        assertThat(ms).isLessThan(5000)
+        var attempt = 0
+        var ms = Long.MAX_VALUE
+
+        while (attempt < maxAttempts && ms >= maxMs) {
+            attempt++
+            ms = measureTimeMillis {
+                createShardsByShardCount(testsToRun, JUnitTestResult(null), arg)
+            }
+            println("Shards calculated in $ms ms, attempt: $attempt")
+        }
+        assertThat(ms).isLessThan(maxMs)
     }
 
     @Test(expected = FlankConfigurationError::class)


### PR DESCRIPTION
This is another fix for the test issue https://github.com/Flank/flank/runs/1576759651?check_suite_focus=true, |
because the previous one (https://github.com/Flank/flank/pull/1413) was not enough.

The UT `performance calculateShardsByTime` seems to be flaky because the results depend on CPU performance and usage. 

My proposition is to rerun shards calculation if run time in ms grater than expected or attempt number not reached max value.