### PR TITLE
feat: Filtering test configurations (iOS TestPlans)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,9 +21,7 @@ plugins {
 tasks {
     "lintKotlinMain"(LintTask::class) {
         exclude(
-            "**/*Generated.kt",
-            "**/*Test.kt",
-            "**/Test*.kt" // we can expand this list
+            "**/*Generated.kt" // we can expand this list
         )
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,9 @@ plugins {
 tasks {
     "lintKotlinMain"(LintTask::class) {
         exclude(
-            "**/*Generated.kt" // we can expand this list
+            "**/*Generated.kt",
+            "**/*Test.kt",	
+            "**/Test*.kt" // we can expand this list
         )
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ tasks {
     "lintKotlinMain"(LintTask::class) {
         exclude(
             "**/*Generated.kt",
-            "**/*Test.kt",	
+            "**/*Test.kt",
             "**/Test*.kt" // we can expand this list
         )
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -325,6 +325,20 @@ flank:
   ## Disable sending usage statistics (without sensitive data) to the analytic tool.
   ## Default: false
   # disable-usage-statistics: false
+
+  ### Only Test Configuration
+  ## Constrains a test action to only test a specified test configuration within a test plan and exclude all other test configurations.
+  ## Flank can combine multiple constraint options, but -only-test-configuration has precedence over -skip-test-configuration. 
+  ## Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive.
+  ## Default: null (run all test configurations)
+  # only-test-configuration: en
+
+  ### Skip Test Configuration
+  ## Constrains a test action to skip a specified test configuration and include all other test configurations.
+  ## Flank can combine multiple constraint options, but -only-test-configuration has precedence over -skip-test-configuration. 
+  ## Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive.
+  ## Default: null (run all test configurations)
+  # skip-test-configuration: en
 ```
 
 ### Android example

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -256,3 +256,17 @@ flank:
   ## Disable sending usage statistics (without sensitive data) to the analytic tool.
   ## Default: false
   # disable-usage-statistics: false
+
+  ### Only Test Configuration
+  ## Constrains a test action to only test a specified test configuration within a test plan and exclude all other test configurations.
+  ## Flank can combine multiple constraint options, but -only-test-configuration has precedence over -skip-test-configuration.
+  ## Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive.
+  ## Default: null (run all test configurations)
+  # only-test-configuration: en
+
+  ### Skip Test Configuration
+  ## Constrains a test action to skip a specified test configuration and include all other test configurations.
+  ## Flank can combine multiple constraint options, but -only-test-configuration has precedence over -skip-test-configuration.
+  ## Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive.
+  ## Default: null (run all test configurations)
+  # skip-test-configuration: en

--- a/test_runner/src/main/kotlin/ftl/args/CreateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateIosArgs.kt
@@ -33,7 +33,9 @@ private fun createIosArgs(
     testTargets = flank.testTargets?.filterNotNull().orEmpty(),
     obfuscateDumpShards = obfuscate,
     app = gcloud.app?.normalizeFilePath().orEmpty(),
-    testSpecialEntitlements = gcloud.testSpecialEntitlements ?: false
+    testSpecialEntitlements = gcloud.testSpecialEntitlements ?: false,
+    onlyTestConfiguration = flank.onlyTestConfiguration,
+    skipTestConfiguration = flank.skipTestConfiguration
 )
 
 private fun convertToShardCount(inputValue: Int) =

--- a/test_runner/src/main/kotlin/ftl/args/CreateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateIosArgs.kt
@@ -34,8 +34,8 @@ private fun createIosArgs(
     obfuscateDumpShards = obfuscate,
     app = gcloud.app?.normalizeFilePath().orEmpty(),
     testSpecialEntitlements = gcloud.testSpecialEntitlements ?: false,
-    onlyTestConfiguration = flank.onlyTestConfiguration,
-    skipTestConfiguration = flank.skipTestConfiguration
+    onlyTestConfiguration = flank.onlyTestConfiguration.orEmpty(),
+    skipTestConfiguration = flank.skipTestConfiguration.orEmpty()
 )
 
 private fun convertToShardCount(inputValue: Int) =

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -95,7 +95,7 @@ IosArgs
       default-class-test-time: $defaultClassTestTime
       disable-usage-statistics: $disableUsageStatistics
       only-test-configuration: $onlyTestConfiguration
-      skipTestConfiguration: $skipTestConfiguration
+      skip-test-configuration: $skipTestConfiguration
         """.trimIndent()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -31,10 +31,10 @@ data class IosArgs(
     val testSpecialEntitlements: Boolean?,
 
     @property:AnonymizeInStatistics
-    val onlyTestConfiguration: String?,
+    val onlyTestConfiguration: String,
 
     @property:AnonymizeInStatistics
-    val skipTestConfiguration: String?
+    val skipTestConfiguration: String
 ) : IArgs by commonArgs {
 
     override val useLegacyJUnitResult = true

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -28,7 +28,13 @@ data class IosArgs(
 
     @property:AnonymizeInStatistics
     val app: String,
-    val testSpecialEntitlements: Boolean?
+    val testSpecialEntitlements: Boolean?,
+
+    @property:AnonymizeInStatistics
+    val onlyTestConfiguration: String?,
+
+    @property:AnonymizeInStatistics
+    val skipTestConfiguration: String?
 ) : IArgs by commonArgs {
 
     override val useLegacyJUnitResult = true
@@ -88,6 +94,8 @@ IosArgs
       disable-results-upload: $disableResultsUpload
       default-class-test-time: $defaultClassTestTime
       disable-usage-statistics: $disableUsageStatistics
+      only-test-configuration: $onlyTestConfiguration
+      skipTestConfiguration: $skipTestConfiguration
         """.trimIndent()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -102,9 +102,12 @@ private fun IosArgs.validType() {
 }
 
 private fun IosArgs.assertXcTestRunVersion() {
-    if (onlyTestConfiguration.isNotBlank() or skipTestConfiguration.isNotBlank())
-        if (xcTestRunData.version == XcTestRunVersion.V1) throw FlankConfigurationError("Specified [xctestrun-file] doesn't contain test plans. Options: [only-test-configuration] or [skip-test-configuration] are not valid for this [xctestrun-file]")
+    if (filterTestConfiguration && xcTestRunData.version == XcTestRunVersion.V1)
+        throw FlankConfigurationError("Specified [xctestrun-file] doesn't contain test plans. Options: [only-test-configuration] or [skip-test-configuration] are not valid for this [xctestrun-file]")
 }
+
+private val IosArgs.filterTestConfiguration
+    get() = onlyTestConfiguration.isNotBlank() or skipTestConfiguration.isNotBlank()
 
 private fun IosArgs.assertXcTestRunData() =
     takeIf { isXcTest && !disableSharding && testTargets.isNotEmpty() }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -5,6 +5,7 @@ import ftl.args.yml.Type
 import ftl.ios.IosCatalog
 import ftl.ios.IosCatalog.getSupportedVersionId
 import ftl.ios.xctest.XcTestRunData
+import ftl.ios.xctest.common.XcTestRunVersion
 import ftl.ios.xctest.common.mapToRegex
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
@@ -20,6 +21,7 @@ fun IosArgs.validate() = apply {
     checkResultsDirUnique()
     assertAdditionalIpas()
     validType()
+    assertXcTestRunVersion()
     assertGameloop()
     assertXcTestRunData()
 }
@@ -97,6 +99,12 @@ private fun IosArgs.validType() {
     val validIosTypes = arrayOf(Type.GAMELOOP, Type.XCTEST)
     if (commonArgs.type !in validIosTypes)
         throw FlankConfigurationError("Type should be one of ${validIosTypes.joinToString(",")}")
+}
+
+private fun IosArgs.assertXcTestRunVersion() {
+    if (!onlyTestConfiguration.isNullOrEmpty() or !skipTestConfiguration.isNullOrEmpty())
+        if (xcTestRunData.version == XcTestRunVersion.V1) throw FlankConfigurationError("Specified [xctestrun-file] doesn't contain test plans. Options: [only-test-configuration] or [skip-test-configuration] are not valid for this [xctestrun-file]")
+
 }
 
 private fun IosArgs.assertXcTestRunData() =

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -102,7 +102,7 @@ private fun IosArgs.validType() {
 }
 
 private fun IosArgs.assertXcTestRunVersion() {
-    if (!onlyTestConfiguration.isNullOrEmpty() or !skipTestConfiguration.isNullOrEmpty())
+    if (onlyTestConfiguration.isNotBlank() or skipTestConfiguration.isNotBlank())
         if (xcTestRunData.version == XcTestRunVersion.V1) throw FlankConfigurationError("Specified [xctestrun-file] doesn't contain test plans. Options: [only-test-configuration] or [skip-test-configuration] are not valid for this [xctestrun-file]")
 }
 

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -104,7 +104,6 @@ private fun IosArgs.validType() {
 private fun IosArgs.assertXcTestRunVersion() {
     if (!onlyTestConfiguration.isNullOrEmpty() or !skipTestConfiguration.isNullOrEmpty())
         if (xcTestRunData.version == XcTestRunVersion.V1) throw FlankConfigurationError("Specified [xctestrun-file] doesn't contain test plans. Options: [only-test-configuration] or [skip-test-configuration] are not valid for this [xctestrun-file]")
-
 }
 
 private fun IosArgs.assertXcTestRunData() =

--- a/test_runner/src/main/kotlin/ftl/config/ios/IosFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/ios/IosFlankConfig.kt
@@ -25,16 +25,42 @@ data class IosFlankConfig @JsonIgnore constructor(
     @set:JsonProperty("test-targets")
     var testTargets: List<String?>? by data
 
+    @set:CommandLine.Option(
+        names = ["--only-test-configuration"],
+        description = [
+            "Constrains a test action to only test a specified test configuration within a test plan " +
+                    "and exclude all other test configurations. (default: run all test configurations)." +
+                    "Flank can  combine  multiple  constraint options, but -only-test-configuration has precedence over -skip-test-configuration. " +
+                    "Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive."
+        ]
+    )
+    @set:JsonProperty("only-test-configuration")
+    var onlyTestConfiguration: String? by data
+
+    @set:CommandLine.Option(
+        names = ["--skip-test-configuration"],
+        description = [
+            "-skip-test-configuration constrains a test action to skip a specified test configuration " +
+                    "and include all other test configurations. (default: run all test configurations). " +
+                    "Flank can combine  multiple constraint options, but -only-test-configuration has precedence over -skip-test-configuration. " +
+                    "Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive."
+        ]
+    )
+    @set:JsonProperty("skip-test-configuration")
+    var skipTestConfiguration: String? by data
+
     constructor() : this(mutableMapOf<String, Any?>().withDefault { null })
 
     companion object : IYmlKeys {
 
         override val group = IYmlKeys.Group.FLANK
 
-        override val keys = listOf("test-targets")
+        override val keys = listOf("test-targets", "only-test-configuration", "skip-test-configuration")
 
         fun default() = IosFlankConfig().apply {
             testTargets = emptyList()
+            onlyTestConfiguration = null
+            skipTestConfiguration = null
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/config/ios/IosFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/ios/IosFlankConfig.kt
@@ -29,9 +29,9 @@ data class IosFlankConfig @JsonIgnore constructor(
         names = ["--only-test-configuration"],
         description = [
             "Constrains a test action to only test a specified test configuration within a test plan " +
-                    "and exclude all other test configurations. (default: run all test configurations)." +
-                    "Flank can  combine  multiple  constraint options, but -only-test-configuration has precedence over -skip-test-configuration. " +
-                    "Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive."
+                "and exclude all other test configurations. (default: run all test configurations)." +
+                "Flank can  combine  multiple  constraint options, but -only-test-configuration has precedence over -skip-test-configuration. " +
+                "Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive."
         ]
     )
     @set:JsonProperty("only-test-configuration")
@@ -41,9 +41,9 @@ data class IosFlankConfig @JsonIgnore constructor(
         names = ["--skip-test-configuration"],
         description = [
             "Constrains a test action to skip a specified test configuration " +
-                    "and include all other test configurations. (default: run all test configurations). " +
-                    "Flank can combine  multiple constraint options, but -only-test-configuration has precedence over -skip-test-configuration. " +
-                    "Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive."
+                "and include all other test configurations. (default: run all test configurations). " +
+                "Flank can combine  multiple constraint options, but -only-test-configuration has precedence over -skip-test-configuration. " +
+                "Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive."
         ]
     )
     @set:JsonProperty("skip-test-configuration")

--- a/test_runner/src/main/kotlin/ftl/config/ios/IosFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/ios/IosFlankConfig.kt
@@ -40,7 +40,7 @@ data class IosFlankConfig @JsonIgnore constructor(
     @set:CommandLine.Option(
         names = ["--skip-test-configuration"],
         description = [
-            "-skip-test-configuration constrains a test action to skip a specified test configuration " +
+            "Constrains a test action to skip a specified test configuration " +
                     "and include all other test configurations. (default: run all test configurations). " +
                     "Flank can combine  multiple constraint options, but -only-test-configuration has precedence over -skip-test-configuration. " +
                     "Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive."

--- a/test_runner/src/main/kotlin/ftl/ios/xctest/XcTestData.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/xctest/XcTestData.kt
@@ -56,9 +56,10 @@ private fun emptyXcTestRunData() = XcTestRunData(
 )
 private fun IosArgs.filterTestConfigurationsIfNeeded(
     configurations: Map<String, Map<String, List<String>>>
-): Map<String, Map<String, List<String>>> {
-    val only = onlyTestConfiguration ?: return configurations.filterKeys { it != skipTestConfiguration }
-    return configurations.filterKeys { it == only }
+): Map<String, Map<String, List<String>>> = when {
+    onlyTestConfiguration != null -> configurations.filterKeys { it == onlyTestConfiguration }
+    skipTestConfiguration != null -> configurations.filterKeys { it != skipTestConfiguration }
+    else -> configurations
 }
 
 private fun IosArgs.calculateConfigurationShards(

--- a/test_runner/src/main/kotlin/ftl/ios/xctest/XcTestData.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/xctest/XcTestData.kt
@@ -54,15 +54,23 @@ private fun emptyXcTestRunData() = XcTestRunData(
     nsDict = NSDictionary(),
     version = V1
 )
+private fun IosArgs.filterTestConfigurationsIfNeeded(
+    configurations: Map<String, Map<String, List<String>>>
+): Map<String, Map<String, List<String>>> {
+    val only = onlyTestConfiguration ?: return configurations.filterKeys { it != skipTestConfiguration }
+    return configurations.filterKeys { it == only }
+}
 
 private fun IosArgs.calculateConfigurationShards(
     xcTestRoot: String,
     xcTestNsDictionary: NSDictionary,
     regexList: List<Regex>
 ): Map<String, Pair<List<Chunk>, List<XctestrunMethods>>> =
-    findXcTestNames(
-        xcTestRoot = xcTestRoot,
-        xcTestNsDictionary = xcTestNsDictionary
+    filterTestConfigurationsIfNeeded(
+        findXcTestNames(
+            xcTestRoot = xcTestRoot,
+            xcTestNsDictionary = xcTestNsDictionary
+        )
     ).mapValues { (_, targets: Map<String, List<String>>) ->
         calculateConfigurationShards(targets, regexList)
     }

--- a/test_runner/src/main/kotlin/ftl/ios/xctest/XcTestData.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/xctest/XcTestData.kt
@@ -57,8 +57,8 @@ private fun emptyXcTestRunData() = XcTestRunData(
 private fun IosArgs.filterTestConfigurationsIfNeeded(
     configurations: Map<String, Map<String, List<String>>>
 ): Map<String, Map<String, List<String>>> = when {
-    onlyTestConfiguration != null -> configurations.filterKeys { it == onlyTestConfiguration }
-    skipTestConfiguration != null -> configurations.filterKeys { it != skipTestConfiguration }
+    onlyTestConfiguration.isNotBlank() -> configurations.filterKeys { it == onlyTestConfiguration }
+    skipTestConfiguration.isNotBlank() -> configurations.filterKeys { it != skipTestConfiguration }
     else -> configurations
 }
 

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -282,7 +282,7 @@ IosArgs
       default-class-test-time: 30.0
       disable-usage-statistics: false
       only-test-configuration: pl
-      skip-test-configuration: null
+      skip-test-configuration: 
             """.trimIndent()
         )
     }
@@ -344,8 +344,8 @@ IosArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
-      only-test-configuration: null
-      skip-test-configuration: null
+      only-test-configuration: 
+      skip-test-configuration: 
             """.trimIndent(),
             args.toString()
         )
@@ -388,8 +388,8 @@ IosArgs
             // IosFlankYml
             assert(testTargets, empty)
             assert(runTimeout, "-1")
-            assert(onlyTestConfiguration, null)
-            assert(skipTestConfiguration, null)
+            assert(onlyTestConfiguration, "")
+            assert(skipTestConfiguration, "")
         }
     }
 

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -42,7 +42,6 @@ class IosArgsTest {
         "./src/test/kotlin/ftl/fixtures/tmp/ios/EarlGreyExample/EarlGreyExampleSwiftTests.xctestrun"
     private val invalidApp = "../test_projects/android/apks/invalid.apk"
     private val xctestrunFileAbsolutePath = xctestrunFile.absolutePath()
-
     private val testPlansPath = "./src/test/kotlin/ftl/fixtures/tmp/ios/FlankTestPlansExample/FlankTestPlansExample.zip"
     private val testPlansXctestrun = "./src/test/kotlin/ftl/fixtures/tmp/ios/FlankTestPlansExample/AllTests.xctestrun"
     private val testAbsolutePath = testPath.absolutePath()

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -282,7 +282,7 @@ IosArgs
       default-class-test-time: 30.0
       disable-usage-statistics: false
       only-test-configuration: pl
-      skipTestConfiguration: null
+      skip-test-configuration: null
             """.trimIndent()
         )
     }
@@ -345,7 +345,7 @@ IosArgs
       default-class-test-time: 240.0
       disable-usage-statistics: false
       only-test-configuration: null
-      skipTestConfiguration: null
+      skip-test-configuration: null
             """.trimIndent(),
             args.toString()
         )

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -42,6 +42,9 @@ class IosArgsTest {
         "./src/test/kotlin/ftl/fixtures/tmp/ios/EarlGreyExample/EarlGreyExampleSwiftTests.xctestrun"
     private val invalidApp = "../test_projects/android/apks/invalid.apk"
     private val xctestrunFileAbsolutePath = xctestrunFile.absolutePath()
+
+    private val testPlansPath = "./src/test/kotlin/ftl/fixtures/tmp/ios/FlankTestPlansExample/FlankTestPlansExample.zip"
+    private val testPlansXctestrun = "./src/test/kotlin/ftl/fixtures/tmp/ios/FlankTestPlansExample/AllTests.xctestrun"
     private val testAbsolutePath = testPath.absolutePath()
     private val testIpa1 = "./src/test/kotlin/ftl/fixtures/tmp/test.ipa"
     private val testIpa2 = "./src/test/kotlin/ftl/fixtures/tmp/test2.ipa"
@@ -1254,6 +1257,54 @@ IosArgs
           results-dir: test
           type: game-loop
           app: $testPath
+        """.trimIndent()
+        IosArgs.load(yaml).validate()
+    }
+
+    @Test(expected = FlankConfigurationError::class)
+    fun `should throw exception when only-test-configuration is specified for xctestrun v1`() {
+        val yaml = """
+        gcloud:
+          test: $testPath
+          xctestrun-file: $xctestrunFile
+        flank:
+          only-test-configuration: pl
+        """.trimIndent()
+        IosArgs.load(yaml).validate()
+    }
+
+    @Test(expected = FlankConfigurationError::class)
+    fun `should throw exception when skip-test-configuration is specified for xctestrun v1`() {
+        val yaml = """
+        gcloud:
+          test: $testPath
+          xctestrun-file: $xctestrunFile
+        flank:
+          skip-test-configuration: pl
+        """.trimIndent()
+        IosArgs.load(yaml).validate()
+    }
+
+    @Test
+    fun `should not throw exception when only-test-configuration is specified for xctestrun v2`() {
+        val yaml = """
+        gcloud:
+          test: $testPlansPath
+          xctestrun-file: $testPlansXctestrun
+        flank:
+          only-test-configuration: pl
+        """.trimIndent()
+        IosArgs.load(yaml).validate()
+    }
+
+    @Test
+    fun `should not throw exception when skip-test-configuration is specified for xctestrun v2`() {
+        val yaml = """
+        gcloud:
+          test: $testPlansPath
+          xctestrun-file: $testPlansXctestrun
+        flank:
+          skip-test-configuration: pl
         """.trimIndent()
         IosArgs.load(yaml).validate()
     }

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -103,6 +103,7 @@ class IosArgsTest {
           output-style: single
           disable-results-upload: true
           default-class-test-time: 30.0
+          only-test-configuration: pl
         """
 
     @get:Rule
@@ -278,6 +279,8 @@ IosArgs
       disable-results-upload: true
       default-class-test-time: 30.0
       disable-usage-statistics: false
+      only-test-configuration: pl
+      skipTestConfiguration: null
             """.trimIndent()
         )
     }
@@ -339,6 +342,8 @@ IosArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
+      only-test-configuration: null
+      skipTestConfiguration: null
             """.trimIndent(),
             args.toString()
         )
@@ -381,6 +386,8 @@ IosArgs
             // IosFlankYml
             assert(testTargets, empty)
             assert(runTimeout, "-1")
+            assert(onlyTestConfiguration, null)
+            assert(skipTestConfiguration, null)
         }
     }
 

--- a/test_runner/src/test/kotlin/ftl/fixtures/ios_test_plan.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/ios_test_plan.yml
@@ -1,7 +1,8 @@
 gcloud:
-  test: "./src/test/kotlin/ftl/fixtures/tmp/earlgrey_example.zip"
-  xctestrun-file: "./src/test/kotlin/ftl/fixtures/tmp/ios/multi_test_targets/AllTests_AllTests_iphoneos13.7-arm64e.xctestrun"
+  test: "./src/test/kotlin/ftl/fixtures/tmp/ios/FlankTestPlansExample/FlankTestPlansExample.zip"
+  xctestrun-file: "./src/test/kotlin/ftl/fixtures/tmp/ios/FlankTestPlansExample/AllTests.xctestrun"
 
 flank:
   disable-sharding: false
   max-test-shards: 3
+  only-test-configuration: pl

--- a/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-only-test-configuration-ios.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-single-only-test-configuration-ios.yml
@@ -1,0 +1,7 @@
+gcloud:
+  test: "./src/test/kotlin/ftl/fixtures/tmp/ios/FlankTestPlansExample/FlankTestPlansExample.zip"
+  xctestrun-file: "./src/test/kotlin/ftl/fixtures/tmp/ios/FlankTestPlansExample/AllTests.xctestrun"
+flank:
+  max-test-shards: 1
+  repeatTests: 1
+  only-test-configuration: en

--- a/test_runner/src/test/kotlin/ftl/ios/xctest/XcTestDataTest.kt
+++ b/test_runner/src/test/kotlin/ftl/ios/xctest/XcTestDataTest.kt
@@ -1,0 +1,50 @@
+package ftl.ios.xctest
+
+import flank.common.isWindows
+import ftl.args.IosArgs
+import ftl.args.validate
+import ftl.cli.firebase.test.ios.IosRunCommand
+import org.junit.Assume
+import org.junit.Test
+import java.io.StringReader
+
+class XcTestDataTest {
+
+    private val testPlansPath = "./src/test/kotlin/ftl/fixtures/tmp/ios/FlankTestPlansExample/FlankTestPlansExample.zip"
+    private val testPlansXctestrun = "./src/test/kotlin/ftl/fixtures/tmp/ios/FlankTestPlansExample/AllTests.xctestrun"
+
+    @Test
+    fun testSkipTestConfiguration() {
+        Assume.assumeFalse(isWindows)
+
+        val yaml = """
+        gcloud:
+          test: $testPlansPath
+          xctestrun-file: $testPlansXctestrun
+        flank:
+          skip-test-configuration: pl
+        """.trimIndent()
+        val xcTestRunData = IosArgs.load(yaml).validate().xcTestRunData
+        assert(xcTestRunData.shardTargets.entries.map { it.key }.contains("pl").not())
+        assert(xcTestRunData.shardTargets.entries.map { it.key }.contains("en"))
+    }
+
+    @Test
+    fun testOnlyTestConfiguration() {
+        Assume.assumeFalse(isWindows)
+
+        val yaml = """
+        gcloud:
+          test: $testPlansPath
+          xctestrun-file: $testPlansXctestrun
+        flank:
+          only-test-configuration: pl
+        """.trimIndent()
+        val xcTestRunData = IosArgs.load(yaml).validate().xcTestRunData
+        assert(xcTestRunData.shardTargets.entries.map { it.key }.contains("pl"))
+        assert(xcTestRunData.shardTargets.entries.map { it.key }.contains("en").not())
+    }
+}
+
+private fun IosArgs.Companion.load(yamlData: String, cli: IosRunCommand? = null): IosArgs =
+    load(StringReader(yamlData), cli)


### PR DESCRIPTION
Fixes #1379 

This PR adds to new options for flank: 
- `skip-test-configuration`
- `only-test-configuration`

Flank users can filter test configurations (inside of a test plan).

## Test Plan
> How do we know the code works?

From project root:
```
. .env
cd ./test_runner/
flankScripts shell buildFlank 
flank ios run -c ./src/test/kotlin/ftl/fixtures/ios_test_plan.yml
```
additionally, edit `os_test_plan.yml` for testing different configurations.

## Checklist

- [x] Documented - updated main docs 
- [x] Unit tested 
