### PR TITLE
ci: Added CLA assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,4 +20,4 @@ jobs:
           path-to-signatures: 'cla/v1/signatures.json'
           path-to-document: 'https://github.com/Flank/flank/blob/cla_signatures/cla.md'
           branch: 'cla_signatures'
-          allowlist: bootstraponline,jan-gogo,pawelpasterz,adamfilipow92,piotradamczyk5,Sloox,axelzuziak-gogo,bot*
+          allowlist: bootstraponline,jan-gogo,pawelpasterz,adamfilipow92,Sloox,axelzuziak-gogo,bot*

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,23 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+    steps:
+      - name: "CLA Assistant"
+        # Alpha Release
+        uses: cla-assistant/github-action@v2.0.2-alpha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'cla/v1/signatures.json'
+          path-to-document: 'https://github.com/Flank/flank/blob/cla_signatures/cla.md'
+          branch: 'cla_signatures'
+          allowlist: bootstraponline,jan-gogo,pawelpasterz,adamfilipow92,piotradamczyk5,Sloox,axelzuziak-gogo,bot*

--- a/contributing.md
+++ b/contributing.md
@@ -46,3 +46,4 @@ Run `./gradlew check` to fix lint issues
 ## CLA
 
 A CLA is required to contribute to flank. Google's open source policy [explains why CLAs are commonly used](https://opensource.google.com/docs/cla/policy/)
+To sign CLA follow instructions on pull request which needs CLA to be signed. 


### PR DESCRIPTION
Fixes #638

Added Github action which requires the contributor to sign CLA agreement by making a comment `I have read the CLA Document and I hereby sign the CLA`
Flank organization members do not need to sign contribution, as well as bots


## Test Plan
> How do we know the code works?

1. User create Pull request
1. CLA assistant make a comment that User needs to sign CLA
  
<img width="917" alt="Zrzut ekranu 2021-01-4 o 17 12 50" src="https://user-images.githubusercontent.com/65554637/103557162-0f6f5880-4eb3-11eb-90f0-8ccc0ded7e32.png">

3. User sign CLA by posting a comment `I have read the CLA Document and I hereby sign the CLA`
<img width="932" alt="Zrzut ekranu 2021-01-4 o 17 13 11" src="https://user-images.githubusercontent.com/65554637/103557218-2615af80-4eb3-11eb-928d-12e75d1a93a9.png">

4. User signature is stored in `cla/v1/signatures.json` on `cla_signatures` branch
5. CLA assistant make a comment that all committers signed CLA
  
<img width="942" alt="Zrzut ekranu 2021-01-4 o 17 13 41" src="https://user-images.githubusercontent.com/65554637/103557241-2f068100-4eb3-11eb-8051-2124b7d3a37e.png">

**The real testing scenario will be done in the next PR to make sure that everything works correctly!!!**

## Checklist

- [x] Documented
