### PR TITLE
fix: Fix problem with test-runner-class

### DIFF
--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -84,7 +84,6 @@ private fun AndroidArgs.assertType() = type?.let {
     if (appApk == null) throw FlankGeneralError("A valid AppApk must be defined if Type parameter is used.")
     if (it == Type.INSTRUMENTATION) {
         if (testApk == null) throw FlankGeneralError("Instrumentation tests require a valid testApk defined.")
-        if (testRunnerClass == null) throw FlankGeneralError("Instrumentation tests require a valid test-runner-class defined.")
     }
 }
 

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -1999,22 +1999,6 @@ AndroidArgs
         AndroidArgs.load(yaml).validate()
     }
 
-    @Test(expected = FlankGeneralError::class)
-    fun `should throw exception if correct type requested instrumental but no test runner set`() {
-        val yaml = """
-        gcloud:
-          app: $appApk
-          test: $testApk
-          device:
-            - model: Nexus6
-              version: 25
-              locale: en
-              orientation: portrait
-          type: instrumentation
-        """.trimIndent()
-        AndroidArgs.load(yaml).validate()
-    }
-
     @Test
     fun `should Not throw exception if correct type requested robo`() {
         val yaml = """


### PR DESCRIPTION
Fixes #1444

`test-runner-class` has a default value (the last name extracted from the APK manifest), so it is not needed to fast fail if this option is not specified

## Test Plan
> How do we know the code works?

1. Set `gcloud.type: instrumentation` to your `flank.yml`.
2. Run `flank run android`
3. Do not set `test-runner-class`
4. Tests do not fast fail

## Checklist

- [x] Unit tested
