### PR TITLE
ci: Use pointer workflows to preserve run date

### DIFF
--- a/.github/workflows/full_suite_integration_tests.yml
+++ b/.github/workflows/full_suite_integration_tests.yml
@@ -158,3 +158,18 @@ jobs:
             Build scan ${{ needs.run-it-full-suite.outputs.build-scan-url }}
             Workflow run https://github.com/Flank/flank/actions/runs/${{ github.run_id }}
           reactions: '+1'
+
+  trigger-pointer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.FLANK_RELEASE_APP_ID }}
+          private_key: ${{ secrets.FLANK_RELEASE_PRIVATE_KEY }}
+
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          event-type: integration-pointer

--- a/.github/workflows/integration_tests_pointer.yml
+++ b/.github/workflows/integration_tests_pointer.yml
@@ -1,0 +1,13 @@
+# Workflow is unable to retrieve data about previous workflows (the same file).
+# This workflow is a way to preserve last run date for full_suite_integration_tests.yml workflow
+# which is available from within that workflow
+name: Integration Tests Pointer
+on:
+  repository_dispatch:
+    types: [ integration-pointer]
+jobs:
+  point:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Integration tests pointer updated: $(date +'%Y-%m-%d')"

--- a/.github/workflows/update_dependencies_and_client.yml
+++ b/.github/workflows/update_dependencies_and_client.yml
@@ -115,3 +115,18 @@ jobs:
           flankScripts shell firebase checkForSdkUpdate \
           --github-token=${{ secrets.GITHUB_TOKEN }} \
           --zenhub-token=${{ secrets.ZENHUB_API_KEY }}
+
+  trigger-pointer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.FLANK_RELEASE_APP_ID }}
+          private_key: ${{ secrets.FLANK_RELEASE_PRIVATE_KEY }}
+
+      - name: Dispatch repository event
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          event-type: dependencies-pointer

--- a/.github/workflows/update_dependencies_pointer.yml
+++ b/.github/workflows/update_dependencies_pointer.yml
@@ -1,0 +1,13 @@
+# Workflow is unable to retrieve data about previous workflows (the same file).
+# This workflow is a way to preserve last run date for update_dependencies_and_client.yml workflow
+# which is available from within that workflow
+name: Dependencies Update Pointer
+on:
+  repository_dispatch:
+    types: [ dependencies-pointer ]
+jobs:
+  point:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Dependencies pointer updated: $(date +'%Y-%m-%d')"

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -28,7 +28,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.3.2"
+version = "1.3.3"
 group = "com.github.flank"
 
 application {

--- a/flank-scripts/src/main/kotlin/flank/scripts/integration/WorkflowSummary.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/integration/WorkflowSummary.kt
@@ -4,5 +4,5 @@ import flank.scripts.github.commons.getLastWorkflowRunDate
 
 suspend fun getLastITWorkflowRunDate(token: String) = getLastWorkflowRunDate(
     token = token,
-    workflowFileName = "full_suite_integration_tests.yml"
+    workflowFileName = "integration_tests_pointer.yml"
 )

--- a/flank-scripts/src/main/kotlin/flank/scripts/shell/firebase/sdk/LastSDKUpdateRun.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/shell/firebase/sdk/LastSDKUpdateRun.kt
@@ -4,5 +4,5 @@ import flank.scripts.github.commons.getLastWorkflowRunDate
 
 suspend fun getLastSDKUpdateRunDate(token: String) = getLastWorkflowRunDate(
     token = token,
-    workflowFileName = "update_dependencies_and_client.yml"
+    workflowFileName = "update_dependencies_pointer.yml"
 )


### PR DESCRIPTION
Due to GH API limitation workflow is unable to fetch info about itself. Dates of previous runs are used in scripts. An empty array is returned instead.
As a workaround to overcome those limitations two new workflows are introduced.
Their intention is "just to be triggered" and therefore preserve the date which is used in dependencies and IT workflows.

## Test Plan
> How do we know the code works?

There is no easy way to test the implementation. This PR introduced 2 new workflows which can be triggered after the merge to master.
