### PR TITLE
refactor: Update picocli to latest version

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -26,7 +26,7 @@ object Versions {
     const val KOTLIN_COROUTINES = "1.4.2"
 
     // https://github.com/remkop/picocli/releases
-    const val PICOCLI = "4.5.2"
+    const val PICOCLI = "4.6.1"
 
     // https://search.maven.org/search?q=a:google-api-services-toolresults%20g:com.google.apis
     const val GOOGLE_API_TOOLRESULTS = "v1beta3-rev20201029-1.30.10"

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/CommonRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/CommonRunCommand.kt
@@ -3,10 +3,23 @@ package ftl.cli.firebase.test
 import ftl.config.Config
 import ftl.config.android.AndroidGcloudConfig
 import ftl.config.asDevice
+import ftl.config.common.CommonFlankConfig
+import ftl.config.common.CommonGcloudConfig
 import ftl.config.common.addDevice
 import picocli.CommandLine
 
 abstract class CommonRunCommand {
+
+    @CommandLine.Mixin
+    private val commonGcloudConfig = CommonGcloudConfig()
+
+    @CommandLine.Mixin
+    private val commonFlankConfig = CommonFlankConfig()
+
+    val commonConfig = Config.Partial(
+        gcloud = commonGcloudConfig,
+        flank = commonFlankConfig
+    )
 
     abstract val config: Config.Platform<*, *>
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -6,7 +6,9 @@ import ftl.args.setupLogLevel
 import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
-import ftl.config.emptyAndroidConfig
+import ftl.config.android.AndroidFlankConfig
+import ftl.config.android.AndroidGcloudConfig
+import ftl.config.createConfiguration
 import ftl.mock.MockServer
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.dumpShards
@@ -37,7 +39,12 @@ Configuration is read from flank.yml
 class AndroidRunCommand : CommonRunCommand(), Runnable {
 
     @CommandLine.Mixin
-    override val config = emptyAndroidConfig()
+    private val androidGcloudConfig = AndroidGcloudConfig()
+
+    @CommandLine.Mixin
+    private val androidFlankConfig = AndroidFlankConfig()
+
+    override val config by createConfiguration(androidGcloudConfig, androidFlankConfig)
 
     init {
         configPath = FtlConstants.defaultAndroidConfig

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -6,7 +6,9 @@ import ftl.args.setupLogLevel
 import ftl.args.validate
 import ftl.cli.firebase.test.CommonRunCommand
 import ftl.config.FtlConstants
-import ftl.config.emptyIosConfig
+import ftl.config.createConfiguration
+import ftl.config.ios.IosFlankConfig
+import ftl.config.ios.IosGcloudConfig
 import ftl.mock.MockServer
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
@@ -37,7 +39,12 @@ Configuration is read from flank.yml
 class IosRunCommand : CommonRunCommand(), Runnable {
 
     @CommandLine.Mixin
-    override val config = emptyIosConfig()
+    private val iosGcloudConfig = IosGcloudConfig()
+
+    @CommandLine.Mixin
+    private val iosFlankConfig = IosFlankConfig()
+
+    override val config by createConfiguration(iosGcloudConfig, iosFlankConfig)
 
     init {
         configPath = FtlConstants.defaultIosConfig

--- a/test_runner/src/main/kotlin/ftl/config/Create.kt
+++ b/test_runner/src/main/kotlin/ftl/config/Create.kt
@@ -1,11 +1,14 @@
 package ftl.config
 
+import ftl.cli.firebase.test.android.AndroidRunCommand
+import ftl.cli.firebase.test.ios.IosRunCommand
 import ftl.config.android.AndroidFlankConfig
 import ftl.config.android.AndroidGcloudConfig
 import ftl.config.common.CommonFlankConfig
 import ftl.config.common.CommonGcloudConfig
 import ftl.config.ios.IosFlankConfig
 import ftl.config.ios.IosGcloudConfig
+import kotlin.properties.ReadOnlyProperty
 
 fun defaultAndroidConfig() = AndroidConfig(
     common = Config.Partial(
@@ -29,24 +32,28 @@ fun defaultIosConfig() = IosConfig(
     )
 )
 
-fun emptyAndroidConfig() = AndroidConfig(
-    common = Config.Partial(
-        gcloud = CommonGcloudConfig(),
-        flank = CommonFlankConfig()
-    ),
-    platform = Config.Partial(
-        gcloud = AndroidGcloudConfig(),
-        flank = AndroidFlankConfig()
+fun createConfiguration(
+    gcloudConfig: IosGcloudConfig,
+    flankConfig: IosFlankConfig
+) = ReadOnlyProperty<IosRunCommand, IosConfig> { iosRunCommand, _ ->
+    IosConfig(
+        common = iosRunCommand.commonConfig,
+        platform = Config.Partial(
+            gcloud = gcloudConfig,
+            flank = flankConfig
+        )
     )
-)
+}
 
-fun emptyIosConfig() = IosConfig(
-    common = Config.Partial(
-        gcloud = CommonGcloudConfig(),
-        flank = CommonFlankConfig()
-    ),
-    platform = Config.Partial(
-        gcloud = IosGcloudConfig(),
-        flank = IosFlankConfig()
+fun createConfiguration(
+    gcloudConfig: AndroidGcloudConfig,
+    flankConfig: AndroidFlankConfig
+) = ReadOnlyProperty<AndroidRunCommand, AndroidConfig> { androidRunCommand, _ ->
+    AndroidConfig(
+        common = androidRunCommand.commonConfig,
+        platform = Config.Partial(
+            gcloud = gcloudConfig,
+            flank = flankConfig
+        )
     )
-)
+}


### PR DESCRIPTION
Fixes #1452 
Picocli latest version causes that Flank does not work, it was caused by breaking changes that prevent the class to contain nested `@Mixin` annotated configuration classes.
It turns out that we do not need to change our logic of reading data in `mutableMap<String, Any?>`

## Test Plan
> How do we know the code works?

All tests passed.
Flank works normally

## Checklist

- [x] Version update
- [x] Refactor of reading configuration
