### PR TITLE
fix: Fix incorrect method usage on master

### DIFF
--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -28,7 +28,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.4.0"
+version = "1.4.1"
 group = "com.github.flank"
 
 application {

--- a/flank-scripts/src/main/kotlin/flank/scripts/github/commons/LastWorkflowRunDate.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/github/commons/LastWorkflowRunDate.kt
@@ -24,7 +24,7 @@ suspend fun getLastWorkflowRunDate(
         workflowRuns
             .filter { it.status != "in_progress" }
             .filter { it.conclusion != "cancelled" }
-            .getOrNull(0)
+            .getOrNull(1)
             .logRun()
             ?.createdAt.run { DateTimeFormatter.ISO_INSTANT.format(Instant.parse(this)) }
     } ?: run {

--- a/test_runner/src/main/kotlin/ftl/run/common/SaveSessionId.kt
+++ b/test_runner/src/main/kotlin/ftl/run/common/SaveSessionId.kt
@@ -2,8 +2,8 @@ package ftl.run.common
 
 import ftl.args.IArgs
 import ftl.util.sessionId
-import java.nio.file.Path
+import java.nio.file.Paths
 
 const val SESSION_ID_FILE = "session_id.txt"
 
-fun IArgs.saveSessionId() = Path.of(localResultDir, SESSION_ID_FILE).toFile().writeText(sessionId)
+fun IArgs.saveSessionId() = Paths.get(localResultDir, SESSION_ID_FILE).toFile().writeText(sessionId)


### PR DESCRIPTION
`SaveSessionId` is using `Path.of` which is available since java 11. This PR changes logic to use `Paths.get` (available in java 8)