### PR TITLE
fix: Fix NPE and logging

### DIFF
--- a/common/src/main/kotlin/flank/common/PathHelper.kt
+++ b/common/src/main/kotlin/flank/common/PathHelper.kt
@@ -8,8 +8,11 @@ val currentPath = Paths.get("")
 val rootDirectoryPath = goToRoot(currentPath)
 val rootDirectoryPathString = rootDirectoryPath.toString()
 
-fun goToRoot(startPath: Path): Path =
-    if (startPath.isRoot()) startPath.toAbsolutePath() else goToRoot(startPath.toAbsolutePath().parent)
+tailrec fun goToRoot(startPath: Path): Path = when {
+    startPath.isRoot() -> startPath.toAbsolutePath()
+    startPath.toAbsolutePath().parent == null -> startPath.toAbsolutePath()
+    else -> goToRoot(startPath.toAbsolutePath().parent)
+}
 
 fun Path.isRoot() = Files.exists(Paths.get(toString(), "settings.gradle.kts"))
 

--- a/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
+++ b/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
@@ -75,8 +75,8 @@ internal fun withGlobalExceptionHandling(block: () -> Int, exitProcessFunction: 
             // We need to cover the case where some component in the call stack starts a non-daemon
             // thread, and then throws an Error that kills the main thread. This is extra safe implementation
             else -> {
-                t.report()
                 t.printStackTrace()
+                t.report()
                 exitProcessFunction(UNEXPECTED_ERROR)
             }
         }

--- a/test_runner/src/main/kotlin/ftl/util/CrashReporter.kt
+++ b/test_runner/src/main/kotlin/ftl/util/CrashReporter.kt
@@ -1,7 +1,6 @@
 package ftl.util
 
 import flank.common.config.isTest
-import ftl.log.setDebugLogging
 import io.sentry.Sentry
 import java.io.File
 import java.util.UUID
@@ -50,7 +49,6 @@ private fun initializeCrashReportWrapper() {
     Sentry.init {
         it.dsn = FLANK_API_KEY
         it.release = readRevision()
-        setDebugLogging(true)
     }
     setCrashReportTag(
         SESSION_ID to sessionId,


### PR DESCRIPTION
Fixes #

What was done?
* Fix NPE that was causing initialization error and flank crash as a result
    ```
    Exception in thread "main" java.lang.NoClassDefFoundError: Could not initialize class flank.common.config.FlankPropertiesKt
	at ftl.util.CrashReporterKt.report(CrashReporter.kt:31)
	at ftl.run.exception.ExceptionHandlerKt.withGlobalExceptionHandling(ExceptionHandler.kt:78)
	at ftl.run.exception.ExceptionHandlerKt.withGlobalExceptionHandling(ExceptionHandler.kt:12)
	at ftl.Main$Companion.main(Main.kt:54)
	at ftl.Main.main(Main.kt)
    ```
* `GoogleApiLogger` (all actually) was incorrectly enabled during Sentry client initialization. As result, output was flooded with logs if at least one FTL `IOException` was thrown
    ```
    Jan 20, 2021 8:40:28 PM com.google.api.client.http.HttpRequest execute
    CONFIG: -------------- REQUEST  --------------
    POST https://oauth2.googleapis.com/token
    Accept-Encoding: gzip
    User-Agent: Google-HTTP-Java-Client/1.38.1 (gzip)
    Content-Type: application/x-www-form-urlencoded; charset=UTF-8
    Content-Length: 234

    Jan 20, 2021 8:40:28 PM com.google.api.client.http.HttpRequest execute
    CONFIG: curl -v --compressed -X POST -H 'Accept-Encoding: gzip' -H 'User-Agent: Google-HTTP-Java-Client/1.38.1 
    (gzip)' -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' -d '@-' -- 
    'https://oauth2.googleapis.com/token' << $$$
    Jan 20, 2021 8:40:28 PM com.google.api.client.util.LoggingByteArrayOutputStream close
    CONFIG: Total: 234 bytes
    Jan 20, 2021 8:40:28 PM com.google.api.client.util.LoggingByteArrayOutputStream close
    CONFIG: 
    (and lots of more)
    ```

## Test Plan
> How do we know the code works?

1. Run `./gradlew clean flankFullRun`
2. There should be no errors
3. Start flank run but from outside the project directory (use flank fat jar)
4. Run should proceed normally
