### PR TITLE
fix: Fix flaky FilesTest

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ object Versions {
     // https://github.com/getsentry/sentry-java/releases
     const val SENTRY = "3.2.1"
 
-    //https://github.com/mixpanel/mixpanel-java/releases
+    // https://github.com/mixpanel/mixpanel-java/releases
     const val MIXPANEL = "1.5.0"
 
     // https://github.com/3breadt/dd-plist/releases

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -28,7 +28,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.4.5"
+version = "1.4.6"
 group = "com.github.flank"
 
 application {

--- a/flank-scripts/src/test/kotlin/flank/common/FilesTest.kt
+++ b/flank-scripts/src/test/kotlin/flank/common/FilesTest.kt
@@ -1,20 +1,27 @@
 package flank.common
 
+import flank.scripts.FuelTestRunner
 import org.junit.Assert
 import org.junit.Assume
+import org.junit.Rule
 import org.junit.Test
-import java.io.File
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
 import java.nio.file.Files
 import java.nio.file.Paths
 
+@RunWith(FuelTestRunner::class)
 internal class FilesTest {
+
+    @get:Rule
+    val root = TemporaryFolder()
 
     @Test
     fun `Should create symbolic file at desired location`() {
         Assume.assumeFalse(isWindows)
         // given
-        val testFile = File.createTempFile("test", "file").toPath()
-        val expectedDestination = Paths.get(Files.createTempDirectory("temp").toString(), "test.link")
+        val testFile = root.newFile("test.file").toPath()
+        val expectedDestination = Paths.get(root.newFolder("temp").toString(), "test.link")
 
         // when
         createSymbolicLinkToFile(expectedDestination, testFile)
@@ -30,8 +37,8 @@ internal class FilesTest {
     @Test
     fun `Should download file and store it and destination`() {
         // given
-        val testSource = "https://github.com/Flank/flank/blob/master/settings.gradle.kts"
-        val testDestination = Paths.get(Files.createTempDirectory("temp").toString(), "settings.gradle.kts")
+        val testSource = "https://path.com/to/test/settings.gradle.kts"
+        val testDestination = Paths.get(root.newFolder("temp").toString(), "settings.gradle.kts")
 
         // when
         downloadFile(testSource, testDestination)
@@ -44,7 +51,7 @@ internal class FilesTest {
     @Test
     fun `Should check if directory contains all needed files`() {
         // given
-        val testDirectory = Files.createTempDirectory("test")
+        val testDirectory = root.newFolder("test").toPath()
         val testFiles = listOf(
             Paths.get(testDirectory.toString(), "testFile1"),
             Paths.get(testDirectory.toString(), "testFile2"),

--- a/flank-scripts/src/test/kotlin/flank/common/FilesTest.kt
+++ b/flank-scripts/src/test/kotlin/flank/common/FilesTest.kt
@@ -1,16 +1,13 @@
 package flank.common
 
-import flank.scripts.FuelTestRunner
 import org.junit.Assert
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
 import java.nio.file.Files
 import java.nio.file.Paths
 
-@RunWith(FuelTestRunner::class)
 internal class FilesTest {
 
     @get:Rule
@@ -32,20 +29,6 @@ internal class FilesTest {
         // clean
         testFile.toFile().delete()
         expectedDestination.toFile().delete()
-    }
-
-    @Test
-    fun `Should download file and store it and destination`() {
-        // given
-        val testSource = "https://path.com/to/test/settings.gradle.kts"
-        val testDestination = Paths.get(root.newFolder("temp").toString(), "settings.gradle.kts")
-
-        // when
-        downloadFile(testSource, testDestination)
-
-        // then
-        Assert.assertTrue(testDestination.toFile().exists())
-        Assert.assertTrue(testDestination.toFile().length() > 0)
     }
 
     @Test

--- a/flank-scripts/src/test/kotlin/flank/scripts/FuelMockServer.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/FuelMockServer.kt
@@ -12,6 +12,7 @@ class FuelMockServer : Client {
         return when {
             url.startsWith("https://api.github.com/repos/flank/flank/", ignoreCase = true) -> handleGithubMockRequest(url, request)
             url.startsWith(ZENHUB_BASE_URL) -> handleZenhubMockRequest(url, request)
+            url == "https://path.com/to/test/settings.gradle.kts" -> request.buildResponse("not empty", 200)
             else -> Response(request.url)
         }
     }

--- a/flank-scripts/src/test/kotlin/flank/scripts/FuelMockServer.kt
+++ b/flank-scripts/src/test/kotlin/flank/scripts/FuelMockServer.kt
@@ -12,7 +12,6 @@ class FuelMockServer : Client {
         return when {
             url.startsWith("https://api.github.com/repos/flank/flank/", ignoreCase = true) -> handleGithubMockRequest(url, request)
             url.startsWith(ZENHUB_BASE_URL) -> handleZenhubMockRequest(url, request)
-            url == "https://path.com/to/test/settings.gradle.kts" -> request.buildResponse("not empty", 200)
             else -> Response(request.url)
         }
     }


### PR DESCRIPTION
What was done?
* remove `Should download file and store it and destination` test (it tests `downloadFile` which is actually a wrapper for fuel's download functionality)
* use `TemporaryFolder`

## Test Plan
> How do we know the code works?

All workflows should finish without any error (especially `ubuntu-workflow`)


