### PR TITLE
feat: Add storing output as json

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -340,10 +340,10 @@ flank:
   ## Default: null (run all test configurations)
   # skip-test-configuration: en
 
-  ### Enable output report flag
-  ## Saves output results as parsable json file and optionally upload it to Gcloud..
-  ## Default: false
-  # enable-output-report: false
+ ### Enable output report with set type
+ ## Saves output results as parsable file and optionally upload it to Gcloud..
+ ## Default: none
+ # output-report: none
 ```
 
 ### Android example
@@ -696,10 +696,10 @@ flank:
   ## Default: false
   # disable-usage-statistics: false
 
-  ### Enable output report flag
-  ## Saves output results as parsable json file and optionally upload it to Gcloud..
-  ## Default: false
-  # enable-output-report: false
+  ### Enable output report with set type
+  ## Saves output results as parsable file and optionally upload it to Gcloud. Possible values are [none, json].
+  ## Default: none
+  # output-report: none
 ```
 
 ## Android code coverage

--- a/docs/index.md
+++ b/docs/index.md
@@ -339,6 +339,11 @@ flank:
   ## Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive.
   ## Default: null (run all test configurations)
   # skip-test-configuration: en
+
+  ### Enable output report flag
+  ## Saves output results as parsable json file and optionally upload it to Gcloud..
+  ## Default: false
+  # enable-output-report: false
 ```
 
 ### Android example
@@ -690,6 +695,11 @@ flank:
   ## Disable sending usage statistics (without sensitive data) to the analytic tool.
   ## Default: false
   # disable-usage-statistics: false
+
+  ### Enable output report flag
+  ## Saves output results as parsable json file and optionally upload it to Gcloud..
+  ## Default: false
+  # enable-output-report: false
 ```
 
 ## Android code coverage

--- a/integration_tests/src/test/resources/compare/AllTestFilteredIT-android-compare
+++ b/integration_tests/src/test/resources/compare/AllTestFilteredIT-android-compare
@@ -62,6 +62,7 @@ AndroidArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
+      enable-output-report: false
 
 RunTests
   No tests for app-single-success-debug-androidTest.apk

--- a/integration_tests/src/test/resources/compare/AllTestFilteredIT-android-compare
+++ b/integration_tests/src/test/resources/compare/AllTestFilteredIT-android-compare
@@ -62,7 +62,7 @@ AndroidArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
-      enable-output-report: false
+      output-report: none
 
 RunTests
   No tests for app-single-success-debug-androidTest.apk

--- a/integration_tests/src/test/resources/compare/AllTestFilteredIT-ios-compare
+++ b/integration_tests/src/test/resources/compare/AllTestFilteredIT-ios-compare
@@ -53,7 +53,7 @@ IosArgs
       disable-usage-statistics: false
       only-test-configuration:\s
       skip-test-configuration:\s
-      enable-output-report: false
+      output-report: none
 Found xctest: [0-9a-zA-Z\/_.-]*\/test_runner\/src\/test\/kotlin\/ftl\/fixtures\/tmp\/ios\/EarlGreyExample\/Debug-iphoneos\/EarlGreyExampleSwift.app\/PlugIns\/EarlGreyExampleSwiftTests.xctest
 isMacOS = (true \(mac os x\)|false \(linux\))
 (PATH=~\/.flank\s)?nm -U "[0-9a-zA-Z\/_.-]*\/test_runner\/src\/test\/kotlin\/ftl\/fixtures\/tmp\/ios\/EarlGreyExample\/Debug-iphoneos\/EarlGreyExampleSwift.app\/PlugIns\/EarlGreyExampleSwiftTests.xctest\/EarlGreyExampleSwiftTests"

--- a/integration_tests/src/test/resources/compare/AllTestFilteredIT-ios-compare
+++ b/integration_tests/src/test/resources/compare/AllTestFilteredIT-ios-compare
@@ -53,6 +53,7 @@ IosArgs
       disable-usage-statistics: false
       only-test-configuration:\s
       skip-test-configuration:\s
+      enable-output-report: false
 Found xctest: [0-9a-zA-Z\/_.-]*\/test_runner\/src\/test\/kotlin\/ftl\/fixtures\/tmp\/ios\/EarlGreyExample\/Debug-iphoneos\/EarlGreyExampleSwift.app\/PlugIns\/EarlGreyExampleSwiftTests.xctest
 isMacOS = (true \(mac os x\)|false \(linux\))
 (PATH=~\/.flank\s)?nm -U "[0-9a-zA-Z\/_.-]*\/test_runner\/src\/test\/kotlin\/ftl\/fixtures\/tmp\/ios\/EarlGreyExample\/Debug-iphoneos\/EarlGreyExampleSwift.app\/PlugIns\/EarlGreyExampleSwiftTests.xctest\/EarlGreyExampleSwiftTests"

--- a/integration_tests/src/test/resources/compare/GameloopIT-android-compare
+++ b/integration_tests/src/test/resources/compare/GameloopIT-android-compare
@@ -63,7 +63,7 @@ AndroidArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
-      enable-output-report: false
+      output-report: none
 \s*
 RunTests
   Uploading \[test.obb\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/integration_tests/src/test/resources/compare/GameloopIT-android-compare
+++ b/integration_tests/src/test/resources/compare/GameloopIT-android-compare
@@ -63,6 +63,7 @@ AndroidArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
+      enable-output-report: false
 \s*
 RunTests
   Uploading \[test.obb\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/integration_tests/src/test/resources/compare/GameloopIT-ios-compare
+++ b/integration_tests/src/test/resources/compare/GameloopIT-ios-compare
@@ -53,6 +53,7 @@ IosArgs
       disable-usage-statistics: false
       only-test-configuration:\s
       skip-test-configuration:\s
+      enable-output-report: false
 
 RunTests
 \s*

--- a/integration_tests/src/test/resources/compare/GameloopIT-ios-compare
+++ b/integration_tests/src/test/resources/compare/GameloopIT-ios-compare
@@ -53,7 +53,7 @@ IosArgs
       disable-usage-statistics: false
       only-test-configuration:\s
       skip-test-configuration:\s
-      enable-output-report: false
+      output-report: none
 
 RunTests
 \s*

--- a/integration_tests/src/test/resources/compare/IgnoreFailedIT-compare
+++ b/integration_tests/src/test/resources/compare/IgnoreFailedIT-compare
@@ -1,1 +1,100 @@
-AndroidArgs    gcloud:      results-bucket: test-lab-[a-zA-Z0-9-]*      results-dir: [.a-zA-Z0-9_-]*      record-video: false      timeout: 15m      async: false      client-details:      network-profile: null      results-history-name: null      # Android gcloud      app: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-debug.apk      test: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-single-error-debug-androidTest.apk      additional-apks:      auto-google-login: false      use-orchestrator: true      directories-to-pull:      grant-permissions: all      type: null      other-files:      scenario-numbers:      scenario-labels:      obb-files:      obb-names:      performance-metrics: false      num-uniform-shards: null      test-runner-class: null      test-targets:      robo-directives:      robo-script: null      device:        - model: NexusLowRes          version: 28          locale: en          orientation: portrait      num-flaky-test-attempts: 0      test-targets-for-shard:      fail-fast: false    flank:      max-test-shards: 1      shard-time: -1      num-test-runs: 1      smart-flank-gcs-path:\s      smart-flank-disable-upload: false      default-test-time: 120.0      use-average-test-time-for-new-tests: false      files-to-download:      test-targets-always-run:      disable-sharding: false      project: flank-open-source      local-result-dir: results      full-junit-result: false      # Android Flank Yml      keep-file-path: false      additional-app-test-apks:      run-timeout: -1      legacy-junit-result: false      ignore-failed-tests: true      output-style: verbose      disable-results-upload: true      default-class-test-time: 240.0      disable-usage-statistics: falseRunTests Smart Flank cache hit: 0\% \(0 \/ 1\)  Shard times: 120s  Saved 1 shards to .*\/android_shards.json  Uploading \[app-debug.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  Uploading \[app-single-error-debug-androidTest.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  1 test \/ 1 shard  1 matrix ids created in \d{1,2}m \d{1,2}s  Raw results will be stored in your GCS bucket at \[https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\]Matrices webLink  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?[\s\S]*CostReport  Virtual devices    \$\d{1,2}.\d{1,2} for \d{1,2}mMatrixResultsReport  0 \/ 1 \(0.00\%\)  1 matrices failed[\s\S]*More details are available at:https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?FetchArtifacts    Updating matrix file\s*Matrices webLink  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+AndroidArgs
+    gcloud:
+      results-bucket: test-lab-[a-zA-Z0-9-]*
+      results-dir: [.a-zA-Z0-9_-]*
+      record-video: false
+      timeout: 15m
+      async: false
+      client-details:
+      network-profile: null
+      results-history-name: null
+      # Android gcloud
+      app: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-debug.apk
+      test: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-single-error-debug-androidTest.apk
+      additional-apks:
+      auto-google-login: false
+      use-orchestrator: true
+      directories-to-pull:
+      grant-permissions: all
+      type: null
+      other-files:
+      scenario-numbers:
+      scenario-labels:
+      obb-files:
+      obb-names:
+      performance-metrics: false
+      num-uniform-shards: null
+      test-runner-class: null
+      test-targets:
+      robo-directives:
+      robo-script: null
+      device:
+        - model: NexusLowRes
+          version: 28
+          locale: en
+          orientation: portrait
+      num-flaky-test-attempts: 0
+      test-targets-for-shard:
+      fail-fast: false
+
+    flank:
+      max-test-shards: 1
+      shard-time: -1
+      num-test-runs: 1
+      smart-flank-gcs-path:\s
+      smart-flank-disable-upload: false
+      default-test-time: 120.0
+      use-average-test-time-for-new-tests: false
+      files-to-download:
+      test-targets-always-run:
+      disable-sharding: false
+      project: flank-open-source
+      local-result-dir: results
+      full-junit-result: false
+      # Android Flank Yml
+      keep-file-path: false
+      additional-app-test-apks:
+      run-timeout: -1
+      legacy-junit-result: false
+      ignore-failed-tests: true
+      output-style: verbose
+      disable-results-upload: true
+      default-class-test-time: 240.0
+      disable-usage-statistics: false
+      output-report: none
+
+RunTests
+
+ Smart Flank cache hit: 0\% \(0 \/ 1\)
+  Shard times: 120s
+
+  Saved 1 shards to .*\/android_shards.json
+  Uploading \[app-debug.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[app-single-error-debug-androidTest.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+
+  1 test \/ 1 shard
+
+  1 matrix ids created in \d{1,2}m \d{1,2}s
+  Raw results will be stored in your GCS bucket at \[https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\]
+
+Matrices webLink
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+[\s\S]*
+CostReport
+  Virtual devices
+    \$\d{1,2}.\d{1,2} for \d{1,2}m
+
+
+MatrixResultsReport
+  0 \/ 1 \(0.00\%\)
+  1 matrices failed
+[\s\S]*
+More details are available at:
+https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+
+
+FetchArtifacts
+    Updating matrix file
+\s*
+Matrices webLink
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?

--- a/integration_tests/src/test/resources/compare/MultipleApksIT-compare
+++ b/integration_tests/src/test/resources/compare/MultipleApksIT-compare
@@ -1,1 +1,124 @@
-AndroidArgs    gcloud:      results-bucket: test-lab-[a-zA-Z0-9-]*      results-dir: [.a-zA-Z0-9_-]*      record-video: false      timeout: 15m      async: false      client-details:      network-profile: null      results-history-name: null      # Android gcloud      app: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-debug.apk      test: null      additional-apks:      auto-google-login: false      use-orchestrator: false      directories-to-pull:      grant-permissions: all      type: null      other-files:      scenario-numbers:      scenario-labels:      obb-files:      obb-names:      performance-metrics: false      num-uniform-shards: null      test-runner-class: null      test-targets:      robo-directives:      robo-script: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]MainActivity_robo_script.json      device:        - model: NexusLowRes          version: 28          locale: en          orientation: portrait      num-flaky-test-attempts: 0      test-targets-for-shard:      fail-fast: false\s*    flank:      max-test-shards: 50      shard-time: -1      num-test-runs: 1      smart-flank-gcs-path:\s      smart-flank-disable-upload: false      default-test-time: 120.0      use-average-test-time-for-new-tests: false      files-to-download:      test-targets-always-run:      disable-sharding: false      project: flank-open-source      local-result-dir: results      full-junit-result: false      # Android Flank Yml      keep-file-path: false      additional-app-test-apks:        - app: null          test: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-multiple-success-debug-androidTest.apk        - app: null          test: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-multiple-error-debug-androidTest.apk        - app: null          test: gs:\/\/flank-open-source.appspot.com\/integration\/app-single-success-debug-androidTest.apk      run-timeout: -1      legacy-junit-result: false      ignore-failed-tests: false      output-style: single      disable-results-upload: false      default-class-test-time: 240.0      disable-usage-statistics: false\s*RunTests\s* Smart Flank cache hit: 0\% \(0 \/ 9\)  Shard times: 120s, 120s, 120s, 120s, 120s, 240s, 240s, 240s, 240s\s* Smart Flank cache hit: 0\% \(0 \/ 9\)  Shard times: 120s, 120s, 120s, 120s, 120s, 240s, 240s, 240s, 240s\s* Smart Flank cache hit: 0\% \(0 \/ 1\)  Shard times: 120s\s*  Saved 3 shards to .*\/android_shards.json  Uploading \[android_shards.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  Uploading \[app-debug.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*[\s\S]*  11 tests \+ 8 parameterized classes \/ 19 shards\s*  Uploading \[session_id.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  4 matrix ids created in \d{1,2}m \d{1,2}s  Raw results will be stored in your GCS bucket at \[https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\]\s*Matrices webLink  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?[\s\S]*CostReport  Virtual devices    \$\d{1,2}.\d{1,2} for \d{1,2}m[\s\S]*  Uploading \[CostReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*MatrixResultsReport  3 \/ 4 \(75\.00\%\)  1 matrices failed[\s\S]*More details are available at:https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?\s*  Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  Uploading \[HtmlErrorReport.html\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*FetchArtifacts    Updating matrix file\s*Matrices webLink  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+AndroidArgs
+    gcloud:
+      results-bucket: test-lab-[a-zA-Z0-9-]*
+      results-dir: [.a-zA-Z0-9_-]*
+      record-video: false
+      timeout: 15m
+      async: false
+      client-details:
+      network-profile: null
+      results-history-name: null
+      # Android gcloud
+      app: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-debug.apk
+      test: null
+      additional-apks:
+      auto-google-login: false
+      use-orchestrator: false
+      directories-to-pull:
+      grant-permissions: all
+      type: null
+      other-files:
+      scenario-numbers:
+      scenario-labels:
+      obb-files:
+      obb-names:
+      performance-metrics: false
+      num-uniform-shards: null
+      test-runner-class: null
+      test-targets:
+      robo-directives:
+      robo-script: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]MainActivity_robo_script.json
+      device:
+        - model: NexusLowRes
+          version: 28
+          locale: en
+          orientation: portrait
+      num-flaky-test-attempts: 0
+      test-targets-for-shard:
+      fail-fast: false
+\s*
+    flank:
+      max-test-shards: 50
+      shard-time: -1
+      num-test-runs: 1
+      smart-flank-gcs-path:\s
+      smart-flank-disable-upload: false
+      default-test-time: 120.0
+      use-average-test-time-for-new-tests: false
+      files-to-download:
+      test-targets-always-run:
+      disable-sharding: false
+      project: flank-open-source
+      local-result-dir: results
+      full-junit-result: false
+      # Android Flank Yml
+      keep-file-path: false
+      additional-app-test-apks:
+        - app: null
+          test: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-multiple-success-debug-androidTest.apk
+        - app: null
+          test: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-multiple-error-debug-androidTest.apk
+        - app: null
+          test: gs:\/\/flank-open-source.appspot.com\/integration\/app-single-success-debug-androidTest.apk
+      run-timeout: -1
+      legacy-junit-result: false
+      ignore-failed-tests: false
+      output-style: single
+      disable-results-upload: false
+      default-class-test-time: 240.0
+      disable-usage-statistics: false
+      output-report: none
+\s*
+RunTests
+\s*
+ Smart Flank cache hit: 0\% \(0 \/ 9\)
+  Shard times: 120s, 120s, 120s, 120s, 120s, 240s, 240s, 240s, 240s
+\s*
+ Smart Flank cache hit: 0\% \(0 \/ 9\)
+  Shard times: 120s, 120s, 120s, 120s, 120s, 240s, 240s, 240s, 240s
+\s*
+ Smart Flank cache hit: 0\% \(0 \/ 1\)
+  Shard times: 120s
+\s*
+  Saved 3 shards to .*\/android_shards.json
+  Uploading \[android_shards.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[app-debug.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+[\s\S]*
+  11 tests \+ 8 parameterized classes \/ 19 shards
+\s*
+  Uploading \[session_id.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  4 matrix ids created in \d{1,2}m \d{1,2}s
+  Raw results will be stored in your GCS bucket at \[https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\]
+\s*
+Matrices webLink
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+[\s\S]*
+CostReport
+  Virtual devices
+    \$\d{1,2}.\d{1,2} for \d{1,2}m
+[\s\S]*
+  Uploading \[CostReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+
+MatrixResultsReport
+  3 \/ 4 \(75\.00\%\)
+  1 matrices failed
+[\s\S]*
+More details are available at:
+https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+\s*
+  Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[HtmlErrorReport.html\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+
+FetchArtifacts
+    Updating matrix file
+\s*
+Matrices webLink
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?

--- a/integration_tests/src/test/resources/compare/MultipleDevicesIT-android-compare
+++ b/integration_tests/src/test/resources/compare/MultipleDevicesIT-android-compare
@@ -1,1 +1,139 @@
-AndroidArgs    gcloud:      results-bucket: test-lab-[a-zA-Z0-9-]*      results-dir: [.a-zA-Z0-9_-]*      record-video: false      timeout: 15m      async: false      client-details:      network-profile: null      results-history-name: null      # Android gcloud      app: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-debug.apk      test: null      additional-apks:      auto-google-login: false      use-orchestrator: false      directories-to-pull:      grant-permissions: all      type: null      other-files:      scenario-numbers:      scenario-labels:      obb-files:      obb-names:      performance-metrics: false      num-uniform-shards: null      test-runner-class: null      test-targets:      robo-directives:      robo-script: null      device:        - model: NexusLowRes          version: 28          locale: en          orientation: portrait        - model: Pixel2          version: 28          locale: en          orientation: portrait        - model: HUR          version: 28          locale: en          orientation: portrait      num-flaky-test-attempts: 2      test-targets-for-shard:      fail-fast: false\s*    flank:      max-test-shards: 5      shard-time: -1      num-test-runs: 1      smart-flank-gcs-path:\s      smart-flank-disable-upload: false      default-test-time: 120.0      use-average-test-time-for-new-tests: false      files-to-download:      test-targets-always-run:      disable-sharding: false      project: flank-open-source      local-result-dir: results      full-junit-result: false      # Android Flank Yml      keep-file-path: false      additional-app-test-apks:        - app: null          test: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-multiple-success-debug-androidTest.apk        - app: null          test: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-multiple-error-debug-androidTest.apk        - app: null          test: gs:\/\/flank-open-source.appspot.com\/integration\/app-single-success-debug-androidTest.apk      run-timeout: -1      legacy-junit-result: false      ignore-failed-tests: false      output-style: single      disable-results-upload: false      default-class-test-time: 240.0      disable-usage-statistics: false\s*RunTests\s* Smart Flank cache hit: 0\% \(0 \/ 9\)  Shard times: 240s, 240s, 360s, 360s, 360s\s*\s* Smart Flank cache hit: 0\% \(0 \/ 9\)  Shard times: 240s, 240s, 360s, 360s, 360s\s*\s* Smart Flank cache hit: 0\% \(0 \/ 1\)  Shard times: 120s\s*  Saved 3 shards to .*\/android_shards.json  Uploading \[android_shards.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  Uploading \[app-debug.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*[\s\S]*  11 tests \+ 8 parameterized classes \/ 11 shards\s*  Uploading \[session_id.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  3 matrix ids created in \d{1,2}m \d{1,2}s  Raw results will be stored in your GCS bucket at \[https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9-]*\/[.a-zA-Z0-9_-]*\]\s*Matrices webLink  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?[\s\S]*CostReport  Physical devices    \$\d{1,2}.\d{1,2} for \d{1,2}m\s*  Virtual devices    \$\d{1,2}.\d{1,2} for \d{1,2}m\s*  Total    \$\d{1,2}.\d{1,2} for \d{1,2}m\s*  Uploading \[CostReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*MatrixResultsReport  2 \/ 3 \(66\.67\%\)  1 matrices failed[\s\S]*More details are available at:https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?\s*  Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  Uploading \[HtmlErrorReport.html\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*  (Uploading \[performanceMetrics.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/matrix_[0-9]\/\.*\s*){3}  Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*FetchArtifacts    Updating matrix file\s*Matrices webLink  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+AndroidArgs
+    gcloud:
+      results-bucket: test-lab-[a-zA-Z0-9-]*
+      results-dir: [.a-zA-Z0-9_-]*
+      record-video: false
+      timeout: 15m
+      async: false
+      client-details:
+      network-profile: null
+      results-history-name: null
+      # Android gcloud
+      app: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-debug.apk
+      test: null
+      additional-apks:
+      auto-google-login: false
+      use-orchestrator: false
+      directories-to-pull:
+      grant-permissions: all
+      type: null
+      other-files:
+      scenario-numbers:
+      scenario-labels:
+      obb-files:
+      obb-names:
+      performance-metrics: false
+      num-uniform-shards: null
+      test-runner-class: null
+      test-targets:
+      robo-directives:
+      robo-script: null
+      device:
+        - model: NexusLowRes
+          version: 28
+          locale: en
+          orientation: portrait
+        - model: Pixel2
+          version: 28
+          locale: en
+          orientation: portrait
+        - model: HUR
+          version: 28
+          locale: en
+          orientation: portrait
+      num-flaky-test-attempts: 2
+      test-targets-for-shard:
+      fail-fast: false
+\s*
+    flank:
+      max-test-shards: 5
+      shard-time: -1
+      num-test-runs: 1
+      smart-flank-gcs-path:\s
+      smart-flank-disable-upload: false
+      default-test-time: 120.0
+      use-average-test-time-for-new-tests: false
+      files-to-download:
+      test-targets-always-run:
+      disable-sharding: false
+      project: flank-open-source
+      local-result-dir: results
+      full-junit-result: false
+      # Android Flank Yml
+      keep-file-path: false
+      additional-app-test-apks:
+        - app: null
+          test: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-multiple-success-debug-androidTest.apk
+        - app: null
+          test: [0-9a-zA-Z\\\/_.:-]*[\\\/]test_runner[\\\/]src[\\\/]test[\\\/]kotlin[\\\/]ftl[\\\/]fixtures[\\\/]tmp[\\\/]apk[\\\/]app-multiple-error-debug-androidTest.apk
+        - app: null
+          test: gs:\/\/flank-open-source.appspot.com\/integration\/app-single-success-debug-androidTest.apk
+      run-timeout: -1
+      legacy-junit-result: false
+      ignore-failed-tests: false
+      output-style: single
+      disable-results-upload: false
+      default-class-test-time: 240.0
+      disable-usage-statistics: false
+      output-report: none
+\s*
+RunTests
+\s*
+ Smart Flank cache hit: 0\% \(0 \/ 9\)
+  Shard times: 240s, 240s, 360s, 360s, 360s
+\s*
+\s*
+ Smart Flank cache hit: 0\% \(0 \/ 9\)
+  Shard times: 240s, 240s, 360s, 360s, 360s
+\s*
+\s*
+ Smart Flank cache hit: 0\% \(0 \/ 1\)
+  Shard times: 120s
+\s*
+  Saved 3 shards to .*\/android_shards.json
+  Uploading \[android_shards.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[app-debug.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+[\s\S]*
+  11 tests \+ 8 parameterized classes \/ 11 shards
+\s*
+  Uploading \[session_id.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  3 matrix ids created in \d{1,2}m \d{1,2}s
+  Raw results will be stored in your GCS bucket at \[https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9-]*\/[.a-zA-Z0-9_-]*\]
+\s*
+Matrices webLink
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+[\s\S]*
+CostReport
+  Physical devices
+    \$\d{1,2}.\d{1,2} for \d{1,2}m
+\s*
+  Virtual devices
+    \$\d{1,2}.\d{1,2} for \d{1,2}m
+\s*
+  Total
+    \$\d{1,2}.\d{1,2} for \d{1,2}m
+\s*
+  Uploading \[CostReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+
+MatrixResultsReport
+  2 \/ 3 \(66\.67\%\)
+  1 matrices failed
+[\s\S]*
+More details are available at:
+https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+\s*
+  Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[HtmlErrorReport.html\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  (Uploading \[performanceMetrics.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/matrix_[0-9]\/\.*\s*){3}
+  Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+
+FetchArtifacts
+    Updating matrix file
+\s*
+Matrices webLink
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
+  matrix-[a-zA-Z0-9]* https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?

--- a/integration_tests/src/test/resources/compare/RunTimeoutIT-compare
+++ b/integration_tests/src/test/resources/compare/RunTimeoutIT-compare
@@ -61,6 +61,7 @@ AndroidArgs
       disable-results-upload: true
       default-class-test-time: 240.0
       disable-usage-statistics: false
+      enable-output-report: false
 
 RunTests
   Saved 1 shards to .*\/android_shards.json

--- a/integration_tests/src/test/resources/compare/RunTimeoutIT-compare
+++ b/integration_tests/src/test/resources/compare/RunTimeoutIT-compare
@@ -61,7 +61,7 @@ AndroidArgs
       disable-results-upload: true
       default-class-test-time: 240.0
       disable-usage-statistics: false
-      enable-output-report: false
+      output-report: none
 
 RunTests
   Saved 1 shards to .*\/android_shards.json

--- a/integration_tests/src/test/resources/compare/SanityRoboIT-compare
+++ b/integration_tests/src/test/resources/compare/SanityRoboIT-compare
@@ -61,7 +61,7 @@ AndroidArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
-      enable-output-report: false
+      output-report: none
 
 RunTests
   Uploading \[app-debug.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/integration_tests/src/test/resources/compare/SanityRoboIT-compare
+++ b/integration_tests/src/test/resources/compare/SanityRoboIT-compare
@@ -61,6 +61,7 @@ AndroidArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
+      enable-output-report: false
 
 RunTests
   Uploading \[app-debug.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/integration_tests/src/test/resources/compare/TestFilteringIT-compare
+++ b/integration_tests/src/test/resources/compare/TestFilteringIT-compare
@@ -64,6 +64,7 @@ AndroidArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
+      enable-output-report: false
 \s*
 RunTests
   No tests for app-single-success-debug-androidTest.apk

--- a/integration_tests/src/test/resources/compare/TestFilteringIT-compare
+++ b/integration_tests/src/test/resources/compare/TestFilteringIT-compare
@@ -64,7 +64,7 @@ AndroidArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
-      enable-output-report: false
+      output-report: none
 \s*
 RunTests
   No tests for app-single-success-debug-androidTest.apk

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -270,3 +270,8 @@ flank:
   ## Each test configuration name must match the name of a configuration specified in a test plan and is case-sensitive.
   ## Default: null (run all test configurations)
   # skip-test-configuration: en
+
+  ### Enable output report flag
+  ## Saves output results as parsable json file and optionally upload it to Gcloud..
+  ## Default: false
+  # enable-output-report: false

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -271,7 +271,7 @@ flank:
   ## Default: null (run all test configurations)
   # skip-test-configuration: en
 
-  ### Enable output report flag
-  ## Saves output results as parsable json file and optionally upload it to Gcloud..
-  ## Default: false
-  # enable-output-report: false
+  ### Enable output report with set type
+  ## Saves output results as parsable file and optionally upload it to Gcloud. Possible values are [none, json].
+  ## Default: none
+  # output-report: none

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -347,3 +347,8 @@ flank:
   ## Disable sending usage statistics (without sensitive data) to the analytic tool.
   ## Default: false
   # disable-usage-statistics: false
+
+  ### Enable output report flag
+  ## Saves output results as parsable json file and optionally upload it to Gcloud..
+  ## Default: false
+  # enable-output-report: false

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -348,7 +348,7 @@ flank:
   ## Default: false
   # disable-usage-statistics: false
 
-  ### Enable output report flag
-  ## Saves output results as parsable json file and optionally upload it to Gcloud..
-  ## Default: false
-  # enable-output-report: false
+  ### Enable output report with set type
+  ## Saves output results as parsable file and optionally upload it to Gcloud. Possible values are [none, json].
+  ## Default: none
+  # output-report: none

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -119,7 +119,7 @@ AndroidArgs
       disable-results-upload: $disableResultsUpload
       default-class-test-time: $defaultClassTestTime
       disable-usage-statistics: $disableUsageStatistics
-      enable-output-report: $enableOutputReport
+      output-report: $outputReportType
         """.trimIndent()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -119,6 +119,7 @@ AndroidArgs
       disable-results-upload: $disableResultsUpload
       default-class-test-time: $defaultClassTestTime
       disable-usage-statistics: $disableUsageStatistics
+      enable-output-report: $enableOutputReport
         """.trimIndent()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/CommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CommonArgs.kt
@@ -44,5 +44,6 @@ data class CommonArgs(
     override val defaultTestTime: Double,
     override val defaultClassTestTime: Double,
     override val useAverageTestTimeForNewTests: Boolean,
-    override val disableUsageStatistics: Boolean
+    override val disableUsageStatistics: Boolean,
+    override val enableOutputReport: Boolean
 ) : IArgs

--- a/test_runner/src/main/kotlin/ftl/args/CommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CommonArgs.kt
@@ -2,6 +2,7 @@ package ftl.args
 
 import ftl.args.yml.Type
 import ftl.config.Device
+import ftl.reports.output.OutputReportType
 import ftl.run.status.OutputStyle
 
 data class CommonArgs(
@@ -45,5 +46,5 @@ data class CommonArgs(
     override val defaultClassTestTime: Double,
     override val useAverageTestTimeForNewTests: Boolean,
     override val disableUsageStatistics: Boolean,
-    override val enableOutputReport: Boolean
+    override val outputReportType: OutputReportType
 ) : IArgs

--- a/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
@@ -2,6 +2,7 @@ package ftl.args
 
 import ftl.args.yml.toType
 import ftl.config.CommonConfig
+import ftl.reports.output.OutputReportType
 import ftl.run.status.OutputStyle
 import ftl.run.status.asOutputStyle
 import ftl.util.require
@@ -53,7 +54,7 @@ fun CommonConfig.createCommonArgs(
     defaultClassTestTime = flank::defaultClassTestTime.require(),
     useAverageTestTimeForNewTests = flank::useAverageTestTimeForNewTests.require(),
     disableUsageStatistics = flank.disableUsageStatistics ?: false,
-    enableOutputReport = flank.enableOutputReport ?: false
+    outputReportType = OutputReportType.fromName(flank.outputReport)
 ).apply {
     ArgsHelper.createJunitBucket(project, smartFlankGcsPath)
 }

--- a/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
@@ -52,7 +52,8 @@ fun CommonConfig.createCommonArgs(
     defaultTestTime = flank::defaultTestTime.require(),
     defaultClassTestTime = flank::defaultClassTestTime.require(),
     useAverageTestTimeForNewTests = flank::useAverageTestTimeForNewTests.require(),
-    disableUsageStatistics = flank.disableUsageStatistics ?: false
+    disableUsageStatistics = flank.disableUsageStatistics ?: false,
+    enableOutputReport = flank.enableOutputReport ?: false
 ).apply {
     ArgsHelper.createJunitBucket(project, smartFlankGcsPath)
 }

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -8,6 +8,7 @@ import ftl.analytics.IgnoreInStatistics
 import ftl.args.yml.Type
 import ftl.config.Device
 import ftl.config.common.CommonFlankConfig.Companion.defaultLocalResultsDir
+import ftl.reports.output.OutputReportType
 import ftl.run.status.OutputStyle
 import ftl.util.timeoutToMils
 import java.nio.file.Paths
@@ -95,7 +96,7 @@ interface IArgs {
 
     val disableUsageStatistics: Boolean
 
-    val enableOutputReport: Boolean
+    val outputReportType: OutputReportType
 
     fun useLocalResultDir() = localResultDir != defaultLocalResultsDir
 

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -95,6 +95,8 @@ interface IArgs {
 
     val disableUsageStatistics: Boolean
 
+    val enableOutputReport: Boolean
+
     fun useLocalResultDir() = localResultDir != defaultLocalResultsDir
 
     companion object {

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -98,7 +98,7 @@ IosArgs
       disable-usage-statistics: $disableUsageStatistics
       only-test-configuration: $onlyTestConfiguration
       skip-test-configuration: $skipTestConfiguration
-      enable-output-report: $enableOutputReport
+      output-report: $outputReportType
         """.trimIndent()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -98,6 +98,7 @@ IosArgs
       disable-usage-statistics: $disableUsageStatistics
       only-test-configuration: $onlyTestConfiguration
       skip-test-configuration: $skipTestConfiguration
+      enable-output-report: $enableOutputReport
         """.trimIndent()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -11,6 +11,10 @@ import ftl.config.android.AndroidFlankConfig
 import ftl.config.android.AndroidGcloudConfig
 import ftl.config.createConfiguration
 import ftl.mock.MockServer
+import ftl.reports.output.configure
+import ftl.reports.output.log
+import ftl.reports.output.outputReport
+import ftl.reports.output.toOutputReportConfiguration
 import ftl.run.ANDROID_SHARD_FILE
 import ftl.run.dumpShards
 import ftl.run.newTestRun
@@ -62,6 +66,8 @@ class AndroidRunCommand : CommonRunCommand(), Runnable {
         AndroidArgs.load(Paths.get(configPath), cli = this).apply {
             setupLogLevel()
             logLn(this)
+            outputReport.configure(toOutputReportConfiguration())
+            outputReport.log(this)
             setCrashReportTag(
                 DEVICE_SYSTEM to "android",
                 TEST_TYPE to type?.name.orEmpty()

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/ios/IosRunCommand.kt
@@ -11,6 +11,10 @@ import ftl.config.createConfiguration
 import ftl.config.ios.IosFlankConfig
 import ftl.config.ios.IosGcloudConfig
 import ftl.mock.MockServer
+import ftl.reports.output.configure
+import ftl.reports.output.log
+import ftl.reports.output.outputReport
+import ftl.reports.output.toOutputReportConfiguration
 import ftl.run.IOS_SHARD_FILE
 import ftl.run.dumpShards
 import ftl.run.newTestRun
@@ -62,6 +66,8 @@ class IosRunCommand : CommonRunCommand(), Runnable {
         IosArgs.load(Paths.get(configPath), cli = this).apply {
             setupLogLevel()
             logLn(this)
+            outputReport.configure(toOutputReportConfiguration())
+            outputReport.log(this)
             setCrashReportTag(
                 DEVICE_SYSTEM to "ios",
                 TEST_TYPE to type?.name.orEmpty()

--- a/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
@@ -180,6 +180,13 @@ data class CommonFlankConfig @JsonIgnore constructor(
     @set:JsonProperty("disable-usage-statistics")
     var disableUsageStatistics: Boolean? by data
 
+    @set:CommandLine.Option(
+        names = ["--enable-output-report"],
+        description = ["Saves output results as parsable json file and optionally upload it to Gcloud."]
+    )
+    @set:JsonProperty("enable-output-report")
+    var enableOutputReport: Boolean? by data
+
     constructor() : this(mutableMapOf<String, Any?>().withDefault { null })
 
     companion object : IYmlKeys {
@@ -213,6 +220,7 @@ data class CommonFlankConfig @JsonIgnore constructor(
             defaultClassTestTime = DEFAULT_CLASS_TEST_TIME_SEC
             useAverageTestTimeForNewTests = false
             disableUsageStatistics = false
+            enableOutputReport = false
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
@@ -8,6 +8,7 @@ import ftl.args.yml.IYmlKeys
 import ftl.args.yml.ymlKeys
 import ftl.config.Config
 import ftl.config.FtlConstants
+import ftl.reports.output.OutputReportType
 import ftl.shard.DEFAULT_CLASS_TEST_TIME_SEC
 import ftl.shard.DEFAULT_TEST_TIME_SEC
 import picocli.CommandLine
@@ -181,11 +182,11 @@ data class CommonFlankConfig @JsonIgnore constructor(
     var disableUsageStatistics: Boolean? by data
 
     @set:CommandLine.Option(
-        names = ["--enable-output-report"],
-        description = ["Saves output results as parsable json file and optionally upload it to Gcloud."]
+        names = ["--output-report"],
+        description = ["Saves output results as parsable file and optionally upload it to Gcloud."]
     )
-    @set:JsonProperty("enable-output-report")
-    var enableOutputReport: Boolean? by data
+    @set:JsonProperty("output-report")
+    var outputReport: String? by data
 
     constructor() : this(mutableMapOf<String, Any?>().withDefault { null })
 
@@ -220,7 +221,7 @@ data class CommonFlankConfig @JsonIgnore constructor(
             defaultClassTestTime = DEFAULT_CLASS_TEST_TIME_SEC
             useAverageTestTimeForNewTests = false
             disableUsageStatistics = false
-            enableOutputReport = false
+            outputReport = OutputReportType.NONE.name
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/reports/CostReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/CostReport.kt
@@ -29,7 +29,6 @@ object CostReport : IReport {
 
     private fun generate(matrices: MatrixMap): String {
         val cost = estimate(matrices)
-
         StringWriter().use { writer ->
             writer.println(reportName())
             cost.split("\n").forEach { writer.println(indent + it) }

--- a/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
@@ -10,6 +10,8 @@ import ftl.json.MatrixMap
 import ftl.json.SavedMatrix
 import ftl.json.asPrintableTable
 import ftl.json.isFailed
+import ftl.reports.output.log
+import ftl.reports.output.outputReport
 import ftl.reports.util.IReport
 import ftl.reports.xml.model.JUnitTestResult
 import java.io.StringWriter
@@ -53,6 +55,7 @@ object MatrixResultsReport : IReport {
 
             if (matrices.map.isNotEmpty()) {
                 val savedMatrices = matrices.map.values
+                outputReport.log(savedMatrices)
                 writer.println(savedMatrices.toList().asPrintableTable())
                 savedMatrices.printMatricesLinks(writer)
             }

--- a/test_runner/src/main/kotlin/ftl/reports/outcome/TestOutcome.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/outcome/TestOutcome.kt
@@ -4,12 +4,14 @@ import com.google.api.services.toolresults.model.Environment
 import com.google.api.services.toolresults.model.Outcome
 import com.google.api.services.toolresults.model.Step
 import ftl.json.getDetails
+import ftl.reports.api.data.TestSuiteOverviewData
 import ftl.util.StepOutcome
 
 data class TestOutcome(
     val device: String = "",
     val outcome: String = "",
     val details: String = "",
+    val testSuiteOverview: TestSuiteOverviewData = TestSuiteOverviewData()
 )
 
 fun TestOutcomeContext.createMatrixOutcomeSummaryUsingEnvironments(): List<TestOutcome> = environments
@@ -17,7 +19,8 @@ fun TestOutcomeContext.createMatrixOutcomeSummaryUsingEnvironments(): List<TestO
         TestOutcome(
             device = environment.axisValue(),
             outcome = environment.outcomeSummary,
-            details = environment.getOutcomeDetails(isRoboTest)
+            details = environment.getOutcomeDetails(isRoboTest),
+            testSuiteOverview = environment.createTestSuiteOverviewData()
         )
     }
 
@@ -32,7 +35,8 @@ fun TestOutcomeContext.createMatrixOutcomeSummaryUsingSteps() = steps
         TestOutcome(
             device = device,
             outcome = steps.getOutcomeSummary(),
-            details = steps.getOutcomeDetails(isRoboTest)
+            details = steps.getOutcomeDetails(isRoboTest),
+            testSuiteOverview = steps.createTestSuiteOverviewData()
         )
     }
 

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReport.kt
@@ -28,12 +28,21 @@ fun OutputReport.add(key: String, reportNode: Any) {
 fun OutputReport.generate() {
     val (resultsDirectory, outputFile) = configuration.local
     val (resultsBucket, resultsDir) = configuration.remote
-    outputData
-        .takeIf { configuration.enabled }
-        ?.toJson()
-        ?.storeToFile(resultsDirectory, outputFile)
+    storeOutputData(resultsDirectory, outputFile)
         ?.takeIf { configuration.remote.uploadReport }
         ?.uploadToGcloud(resultsBucket, resultsDir)
+}
+
+private fun OutputReport.storeOutputData(
+    resultsDirectory: String,
+    outputFile: String
+) = when (configuration.type) {
+    OutputReportType.JSON ->
+        outputData
+            .takeIf { configuration.enabled }
+            ?.toJson()
+            ?.storeToFile(resultsDirectory, outputFile)
+    OutputReportType.NONE -> null
 }
 
 private fun OutputData.toJson() = prettyPrint.toJson(this)

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReport.kt
@@ -1,0 +1,49 @@
+package ftl.reports.output
+
+import ftl.gc.GcStorage
+import ftl.run.common.prettyPrint
+import java.io.File
+import java.nio.file.Paths
+
+var outputReport = OutputReport()
+    private set
+
+data class OutputReport(
+    val outputData: OutputData = mapOf(),
+    val configuration: OutputReportConfiguration = OutputReportConfiguration()
+)
+
+private typealias OutputData = Map<String, Any>
+
+fun OutputReport.configure(reportConfiguration: OutputReportConfiguration) {
+    outputReport = copy(configuration = reportConfiguration)
+}
+
+fun OutputReport.add(key: String, reportNode: Any) {
+    if (configuration.enabled) {
+        outputReport = copy(outputData = outputData + (key to reportNode))
+    }
+}
+
+fun OutputReport.generate() {
+    val (resultsDirectory, outputFile) = configuration.local
+    val (resultsBucket, resultsDir) = configuration.remote
+    outputData
+        .takeIf { configuration.enabled }
+        ?.toJson()
+        ?.storeToFile(resultsDirectory, outputFile)
+        ?.takeIf { configuration.remote.uploadReport }
+        ?.uploadToGcloud(resultsBucket, resultsDir)
+}
+
+private fun OutputData.toJson() = prettyPrint.toJson(this)
+
+private fun String.storeToFile(
+    directoryPath: String,
+    fileName: String
+) = Paths.get(directoryPath, fileName).toFile()
+    .apply { writeText(this@storeToFile) }
+
+private fun File.uploadToGcloud(resultsBucket: String, resultsDir: String) {
+    GcStorage.upload(absolutePath, resultsBucket, resultsDir)
+}

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReportConfiguration.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReportConfiguration.kt
@@ -1,7 +1,7 @@
 package ftl.reports.output
 
 import ftl.args.IArgs
-import java.nio.file.Paths
+import ftl.args.localStorageDirectory
 
 data class OutputReportConfiguration(
     val enabled: Boolean = false,
@@ -29,6 +29,3 @@ fun IArgs.toOutputReportConfiguration() = OutputReportConfiguration(
         resultsDir = resultsDir
     )
 )
-
-private val IArgs.localStorageDirectory
-    get() = if (useLocalResultDir()) localResultDir else Paths.get(localResultDir, resultsDir).toString()

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReportConfiguration.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReportConfiguration.kt
@@ -5,6 +5,7 @@ import ftl.args.localStorageDirectory
 
 data class OutputReportConfiguration(
     val enabled: Boolean = false,
+    val type: OutputReportType = OutputReportType.NONE,
     val local: OutputReportLocalConfiguration = OutputReportLocalConfiguration(),
     val remote: OutputReportRemoteConfiguration = OutputReportRemoteConfiguration(),
 )
@@ -21,7 +22,8 @@ data class OutputReportRemoteConfiguration(
 )
 
 fun IArgs.toOutputReportConfiguration() = OutputReportConfiguration(
-    enabled = enableOutputReport,
+    enabled = outputReportType != OutputReportType.NONE,
+    type = outputReportType,
     local = OutputReportLocalConfiguration(localStorageDirectory),
     remote = OutputReportRemoteConfiguration(
         uploadReport = disableResultsUpload.not(),

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReportConfiguration.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReportConfiguration.kt
@@ -1,0 +1,34 @@
+package ftl.reports.output
+
+import ftl.args.IArgs
+import java.nio.file.Paths
+
+data class OutputReportConfiguration(
+    val enabled: Boolean = false,
+    val local: OutputReportLocalConfiguration = OutputReportLocalConfiguration(),
+    val remote: OutputReportRemoteConfiguration = OutputReportRemoteConfiguration(),
+)
+
+data class OutputReportLocalConfiguration(
+    val storageDirectory: String = "",
+    val outputFile: String = "outputReport.json"
+)
+
+data class OutputReportRemoteConfiguration(
+    val resultsBucket: String = "",
+    val resultsDir: String = "",
+    val uploadReport: Boolean = false
+)
+
+fun IArgs.toOutputReportConfiguration() = OutputReportConfiguration(
+    enabled = enableOutputReport,
+    local = OutputReportLocalConfiguration(localStorageDirectory),
+    remote = OutputReportRemoteConfiguration(
+        uploadReport = disableResultsUpload.not(),
+        resultsBucket = resultsBucket,
+        resultsDir = resultsDir
+    )
+)
+
+private val IArgs.localStorageDirectory
+    get() = if (useLocalResultDir()) localResultDir else Paths.get(localResultDir, resultsDir).toString()

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReportLoggers.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReportLoggers.kt
@@ -1,0 +1,37 @@
+package ftl.reports.output
+
+import ftl.args.IArgs
+import ftl.json.MatrixMap
+import ftl.json.SavedMatrix
+import java.math.BigDecimal
+
+internal fun OutputReport.log(args: IArgs) {
+    add("args", args)
+}
+
+internal fun OutputReport.log(matrixMap: MatrixMap) {
+    add("weblinks", matrixMap.map.values.map { it.webLink })
+}
+
+internal fun OutputReport.log(matrices: Collection<SavedMatrix>) {
+    add(
+        "testresults",
+        matrices.map {
+            it.matrixId to it.testAxises
+        }.toMap()
+    )
+}
+
+internal fun OutputReport.log(
+    physicalCost: BigDecimal,
+    virtualCost: BigDecimal,
+    totalCost: BigDecimal
+) {
+    add("cost", OutputReportCostNode(physicalCost, virtualCost, totalCost))
+}
+
+private data class OutputReportCostNode(
+    val physical: BigDecimal,
+    val virtual: BigDecimal,
+    val total: BigDecimal
+)

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReportLoggers.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReportLoggers.kt
@@ -15,7 +15,7 @@ internal fun OutputReport.log(matrixMap: MatrixMap) {
 
 internal fun OutputReport.log(matrices: Collection<SavedMatrix>) {
     add(
-        "testresults",
+        "test_results",
         matrices.map {
             it.matrixId to it.testAxises
         }.toMap()

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReportType.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReportType.kt
@@ -1,0 +1,12 @@
+package ftl.reports.output
+
+enum class OutputReportType {
+    NONE,
+    JSON;
+
+    override fun toString() = super.toString().toLowerCase()
+
+    companion object {
+        fun fromName(name: String?) = if (name.equals(JSON.name, ignoreCase = true)) JSON else NONE
+    }
+}

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -6,6 +6,8 @@ import ftl.args.IosArgs
 import ftl.json.SavedMatrix
 import ftl.json.updateMatrixMap
 import ftl.json.validate
+import ftl.reports.output.log
+import ftl.reports.output.outputReport
 import ftl.reports.util.ReportManager
 import ftl.run.common.fetchArtifacts
 import ftl.run.common.pollMatrices
@@ -34,7 +36,7 @@ suspend fun IArgs.newTestRun() = withTimeoutOrNull(parsedTimeout) {
         cancelTestsOnTimeout(args.project, matrixMap.map) { fetchArtifacts(matrixMap, args) }
 
         matrixMap.printMatricesWebLinks(project)
-
+        outputReport.log(matrixMap)
         matrixMap.validate(ignoreFailedTests)
     }
 }

--- a/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
+++ b/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
@@ -2,6 +2,9 @@ package ftl.run.exception
 
 import flank.common.logLn
 import ftl.json.SavedMatrix
+import ftl.reports.output.add
+import ftl.reports.output.generate
+import ftl.reports.output.outputReport
 import ftl.run.cancelMatrices
 import ftl.util.closeCrashReporter
 import ftl.util.report
@@ -11,6 +14,7 @@ import kotlin.system.exitProcess
 fun withGlobalExceptionHandling(block: () -> Int) {
     withGlobalExceptionHandling(block) {
         closeCrashReporter()
+        outputReport.generate()
         exitProcess(it)
     }
 }
@@ -86,7 +90,10 @@ internal fun withGlobalExceptionHandling(block: () -> Int, exitProcessFunction: 
 private val FlankException.messageOrUnavailable: String
     get() = if (message.isNullOrBlank()) "[Unavailable]" else message as String
 
-private fun printError(string: String?) = System.err.println(string)
+private fun printError(string: String?) {
+    System.err.println(string)
+    string?.let { outputReport.add("error", it) }
+}
 
 private fun SavedMatrix.logError() {
     logLn("Matrix is $state")

--- a/test_runner/src/main/kotlin/ftl/util/Billing.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Billing.kt
@@ -1,5 +1,7 @@
 package ftl.util
 
+import ftl.reports.output.log
+import ftl.reports.output.outputReport
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.util.concurrent.TimeUnit
@@ -30,6 +32,8 @@ private fun estimateCosts(billableVirtualMinutes: BigDecimal, billablePhysicalMi
     val virtualCost = billableVirtualMinutes.multiply(virtualCostPerMinute).setScale(2, RoundingMode.HALF_UP)
     val physicalCost = billablePhysicalMinutes.multiply(physicalCostPerMinute).setScale(2, RoundingMode.HALF_UP)
     val totalCost = (virtualCost + physicalCost).setScale(2, RoundingMode.HALF_UP)
+
+    outputReport.log(physicalCost, virtualCost, totalCost)
 
     val billableVirtualTime = prettyTime(billableVirtualMinutes)
     val billablePhysicalTime = prettyTime(billablePhysicalMinutes)

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -378,6 +378,7 @@ AndroidArgs
       disable-results-upload: true
       default-class-test-time: 30.0
       disable-usage-statistics: false
+      enable-output-report: false
             """.trimIndent()
         )
     }
@@ -450,6 +451,7 @@ AndroidArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
+      enable-output-report: false
             """.trimIndent(),
             args.toString()
         )

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -146,6 +146,7 @@ class AndroidArgsTest {
           output-style: single
           disable-results-upload: true
           default-class-test-time: 30.0
+          output-report: json
       """
 
     @After
@@ -378,7 +379,7 @@ AndroidArgs
       disable-results-upload: true
       default-class-test-time: 30.0
       disable-usage-statistics: false
-      enable-output-report: false
+      output-report: json
             """.trimIndent()
         )
     }
@@ -451,7 +452,7 @@ AndroidArgs
       disable-results-upload: false
       default-class-test-time: 240.0
       disable-usage-statistics: false
-      enable-output-report: false
+      output-report: none
             """.trimIndent(),
             args.toString()
         )

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -284,6 +284,7 @@ IosArgs
       disable-usage-statistics: false
       only-test-configuration: pl
       skip-test-configuration: 
+      enable-output-report: false
             """.trimIndent()
         )
     }
@@ -347,6 +348,7 @@ IosArgs
       disable-usage-statistics: false
       only-test-configuration: 
       skip-test-configuration: 
+      enable-output-report: false
             """.trimIndent(),
             args.toString()
         )

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -107,6 +107,7 @@ class IosArgsTest {
           disable-results-upload: true
           default-class-test-time: 30.0
           only-test-configuration: pl
+          output-report: json
         """
 
     @get:Rule
@@ -284,7 +285,7 @@ IosArgs
       disable-usage-statistics: false
       only-test-configuration: pl
       skip-test-configuration: 
-      enable-output-report: false
+      output-report: json
             """.trimIndent()
         )
     }
@@ -348,7 +349,7 @@ IosArgs
       disable-usage-statistics: false
       only-test-configuration: 
       skip-test-configuration: 
-      enable-output-report: false
+      output-report: none
             """.trimIndent(),
             args.toString()
         )

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
@@ -495,11 +495,11 @@ class AndroidRunCommandTest {
     }
 
     @Test
-    fun `--enable-output-report parse`() {
+    fun `--output-report parse`() {
         val cmd = AndroidRunCommand()
-        CommandLine(cmd).parseArgs("--enable-output-report")
+        CommandLine(cmd).parseArgs("--output-report=json")
 
-        assertThat(cmd.config.common.flank.enableOutputReport).isTrue()
+        assertThat(cmd.config.common.flank.outputReport).isEqualTo("json")
     }
 
     @Test(expected = FlankConfigurationError::class)

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
@@ -494,6 +494,14 @@ class AndroidRunCommandTest {
         assertThat(cmd.config.common.flank.useAverageTestTimeForNewTests).isTrue()
     }
 
+    @Test
+    fun `--enable-output-report parse`() {
+        val cmd = AndroidRunCommand()
+        CommandLine(cmd).parseArgs("--enable-output-report")
+
+        assertThat(cmd.config.common.flank.enableOutputReport).isTrue()
+    }
+
     @Test(expected = FlankConfigurationError::class)
     fun `should throw if --full-junit-result and JUnitResult xml used`() {
         val cmd = AndroidRunCommand()

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
@@ -348,11 +348,11 @@ class IosRunCommandTest {
     }
 
     @Test
-    fun `--enable-output-report parse`() {
+    fun `--output-report parse`() {
         val cmd = IosRunCommand()
-        CommandLine(cmd).parseArgs("--enable-output-report")
+        CommandLine(cmd).parseArgs("--output-report=json")
 
-        assertThat(cmd.config.common.flank.enableOutputReport).isTrue()
+        assertThat(cmd.config.common.flank.outputReport).isEqualTo("json")
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
@@ -348,6 +348,14 @@ class IosRunCommandTest {
     }
 
     @Test
+    fun `--enable-output-report parse`() {
+        val cmd = IosRunCommand()
+        CommandLine(cmd).parseArgs("--enable-output-report")
+
+        assertThat(cmd.config.common.flank.enableOutputReport).isTrue()
+    }
+
+    @Test
     fun `should dump shards on ios test run`() {
         assumeFalse(isWindows) // TODO remove in #1180
 

--- a/test_runner/src/test/kotlin/ftl/reports/output/OutputReportLoggersTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/output/OutputReportLoggersTest.kt
@@ -1,0 +1,72 @@
+package ftl.reports.output
+
+import com.google.common.truth.Truth.assertThat
+import ftl.args.AndroidArgs
+import ftl.json.SavedMatrix
+import ftl.reports.outcome.TestOutcome
+import org.junit.Before
+import org.junit.Test
+import java.math.BigDecimal
+
+class OutputReportLoggersTest {
+
+    @Before
+    fun setup() {
+        outputReport.configure(outputReport.configuration.copy(enabled = true))
+    }
+
+    @Test
+    fun `should log args`() {
+        // given
+        val args = AndroidArgs.default()
+
+        // when
+        outputReport.log(args)
+
+        // then
+        assertThat(outputReport.outputData).containsEntry("args", args)
+    }
+
+    @Test
+    fun `should log weblinks`() {
+        // given
+        val args = AndroidArgs.default()
+
+        // when
+        outputReport.log(args)
+
+        // then
+        assertThat(outputReport.outputData).containsEntry("args", args)
+    }
+
+    @Test
+    fun `should log test_results`() {
+        // given
+        val matrices = listOf(
+            SavedMatrix(matrixId = "1", testAxises = listOf(TestOutcome("device1")))
+        )
+        val testResults = matrices.map {
+            it.matrixId to it.testAxises
+        }.toMap()
+
+        // when
+        outputReport.log(matrices)
+
+        // then
+        assertThat(outputReport.outputData).containsEntry("test_results", testResults)
+    }
+
+    @Test
+    fun `should log costs`() {
+        // given
+        val physical: BigDecimal = BigDecimal.ONE
+        val virtual: BigDecimal = BigDecimal.TEN
+        val total: BigDecimal = BigDecimal.ZERO
+
+        // when
+        outputReport.log(physical, virtual, total)
+
+        // then
+        assertThat(outputReport.outputData).containsKey("cost")
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/reports/output/OutputReportTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/output/OutputReportTest.kt
@@ -1,0 +1,114 @@
+package ftl.reports.output
+
+import com.google.common.truth.Truth.assertThat
+import ftl.gc.GcStorage
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class OutputReportTest {
+
+    @Test
+    fun `should update configuration`() {
+        // given
+        val initialConfig = outputReport.configuration
+        val configuration = OutputReportConfiguration(
+            enabled = true,
+            local = OutputReportLocalConfiguration("x"),
+            remote = OutputReportRemoteConfiguration(uploadReport = false)
+        )
+
+        // when
+        outputReport.configure(configuration)
+
+        // then
+        assertThat(outputReport.configuration).isEqualTo(configuration)
+        assertThat(initialConfig).isNotEqualTo(configuration)
+    }
+
+    @Test
+    fun `should add node to report`() {
+        // given
+        outputReport.configure(outputReport.configuration.copy(enabled = true))
+
+        // when
+        outputReport.add("test", "node")
+
+        // then
+        assertThat(outputReport.outputData).containsEntry("test", "node")
+    }
+
+    @Test
+    fun `should not generate report if not disabled`() {
+        // given
+        val tempDirectory = Files.createTempDirectory("temp")
+        val configuration = OutputReportConfiguration(
+            enabled = false,
+            local = OutputReportLocalConfiguration(tempDirectory.toString()),
+            remote = OutputReportRemoteConfiguration(uploadReport = false)
+        )
+        val expectedPath = Paths.get(configuration.local.storageDirectory, configuration.local.outputFile)
+
+        // when
+        outputReport.configure(configuration)
+        outputReport.add("test", "node")
+        outputReport.generate()
+
+        // then
+        assertThat(expectedPath.toFile().exists()).isFalse()
+    }
+
+    @Test
+    fun `should generate report if enabled`() {
+        // given
+        val tempDirectory = Files.createTempDirectory("temp")
+        val configuration = OutputReportConfiguration(
+            enabled = true,
+            local = OutputReportLocalConfiguration(tempDirectory.toString()),
+            remote = OutputReportRemoteConfiguration(uploadReport = false)
+        )
+        val expectedPath = Paths.get(configuration.local.storageDirectory, configuration.local.outputFile)
+
+        // when
+        outputReport.configure(configuration)
+        outputReport.add("test", "node")
+        outputReport.generate()
+
+        // then
+        assertThat(expectedPath.toFile().exists()).isTrue()
+
+        // clean
+        expectedPath.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun `should generate report if enabled and not upload to gcloud if disabled`() {
+        // given
+        val tempDirectory = Files.createTempDirectory("temp")
+        val configuration = OutputReportConfiguration(
+            enabled = true,
+            local = OutputReportLocalConfiguration(tempDirectory.toString()),
+            remote = OutputReportRemoteConfiguration(uploadReport = false)
+        )
+        val expectedPath = Paths.get(configuration.local.storageDirectory, configuration.local.outputFile)
+
+        // when
+        outputReport.configure(configuration)
+        outputReport.add("test", "node")
+        mockkObject(GcStorage) {
+            outputReport.generate()
+
+            // then
+            assertThat(expectedPath.toFile().exists()).isTrue()
+            verify(exactly = 0) {
+                GcStorage.upload(
+                    expectedPath.toFile().absolutePath,
+                    configuration.remote.resultsBucket,
+                    configuration.remote.resultsDir
+                )
+            }
+        }
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/reports/output/OutputReportTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/output/OutputReportTest.kt
@@ -41,11 +41,32 @@ class OutputReportTest {
     }
 
     @Test
-    fun `should not generate report if not disabled`() {
+    fun `should not generate report if disabled`() {
         // given
         val tempDirectory = Files.createTempDirectory("temp")
         val configuration = OutputReportConfiguration(
             enabled = false,
+            local = OutputReportLocalConfiguration(tempDirectory.toString()),
+            remote = OutputReportRemoteConfiguration(uploadReport = false)
+        )
+        val expectedPath = Paths.get(configuration.local.storageDirectory, configuration.local.outputFile)
+
+        // when
+        outputReport.configure(configuration)
+        outputReport.add("test", "node")
+        outputReport.generate()
+
+        // then
+        assertThat(expectedPath.toFile().exists()).isFalse()
+    }
+
+    @Test
+    fun `should generate report if report type is NONE`() {
+        // given
+        val tempDirectory = Files.createTempDirectory("temp")
+        val configuration = OutputReportConfiguration(
+            enabled = true,
+            type = OutputReportType.NONE,
             local = OutputReportLocalConfiguration(tempDirectory.toString()),
             remote = OutputReportRemoteConfiguration(uploadReport = false)
         )
@@ -66,6 +87,7 @@ class OutputReportTest {
         val tempDirectory = Files.createTempDirectory("temp")
         val configuration = OutputReportConfiguration(
             enabled = true,
+            type = OutputReportType.JSON,
             local = OutputReportLocalConfiguration(tempDirectory.toString()),
             remote = OutputReportRemoteConfiguration(uploadReport = false)
         )
@@ -89,6 +111,7 @@ class OutputReportTest {
         val tempDirectory = Files.createTempDirectory("temp")
         val configuration = OutputReportConfiguration(
             enabled = true,
+            type = OutputReportType.JSON,
             local = OutputReportLocalConfiguration(tempDirectory.toString()),
             remote = OutputReportRemoteConfiguration(uploadReport = false)
         )


### PR DESCRIPTION
Fixes #1437 

## Test Plan
> How do we know the code works?

1. Enable output report using option ( cli: `--output-report=json`, yaml: `output-report: json` under `flank` root)
1. Run Flank and see that the output reported is stored ( file `outputReport.json`)
1. Compare file content with console output

## Checklist

- [x] [SDD](https://github.com/Flank/flank/issues/1437#issuecomment-769299621)
- [x] Documented
- [x] Unit tested
- [x] Integration tests updated
