### PR TITLE
fix: Increase heap size

### DIFF
--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -378,4 +378,8 @@ val resolveArtifacts by tasks.registering {
     }
 }
 
-tasks.test { dependsOn(resolveArtifacts) }
+tasks.test {
+    maxHeapSize = "3072m"
+    minHeapSize = "512m"
+    dependsOn(resolveArtifacts)
+}


### PR DESCRIPTION
Fixes #1577 

Increase heap size for `test` task in `test_runner` module. This should mitigate `OutOfMemory` error during tests

## Test Plan
> How do we know the code works?

1. Run `./gradlew clean flankFullRun` -- should finish without any error
2. We can rerun `ubuntu-workflow` a couple of times and each should end with success
