### PR TITLE
ci: Publish Flank-scripts to Github

### DIFF
--- a/.github/workflows/release_flank_scripts.yml
+++ b/.github/workflows/release_flank_scripts.yml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: gradle/wrapper-validation-action@v1
 
-    - name: Gradle Upload to bintray
+    - name: Gradle Upload to Github packages and Github release
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: "flank-scripts:bintrayUpload -PJFROG_API_KEY=${{ secrets.JFROG_API_KEY }} -PJFROG_USER=${{ secrets.JFROG_USER }}"
+        arguments: "flank-scripts:releaseFlankScripts"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,6 @@ plugins {
     kotlin(Plugins.Kotlin.PLUGIN_JVM) version Versions.KOTLIN
     id(Plugins.KTLINT_GRADLE_PLUGIN) version Versions.KTLINT_GRADLE
     id(Plugins.BEN_MANES_PLUGIN) version Versions.BEN_MANES
-    id(Plugins.JFROG_BINTRAY) version Versions.BINTRAY
     id(Plugins.NEXUS_STAGING) version Versions.NEXUS_STAGING
 }
 

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -2,7 +2,6 @@ object Plugins {
 
     const val PLUGIN_SHADOW_JAR = "com.github.johnrengelman.shadow"
     const val KTLINT_GRADLE_PLUGIN = "org.jmailen.kotlinter"
-    const val JFROG_BINTRAY = "com.jfrog.bintray"
     const val MAVEN_PUBLISH = "maven-publish"
     const val NEXUS_STAGING = "io.codearte.nexus-staging"
     const val BEN_MANES_PLUGIN = "com.github.ben-manes.versions"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -13,9 +13,6 @@ object Versions {
 
     const val KTLINT = "0.40.0"
 
-    // https://github.com/bintray/gradle-bintray-plugin/releases
-    const val BINTRAY = "1.8.5"
-
     // https://github.com/Codearte/gradle-nexus-staging-plugin
     const val NEXUS_STAGING = "0.22.0"
 

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -152,7 +152,7 @@ val checkIfVersionUpdated by tasks.registering(Exec::class) {
 }
 
 val releaseFlankScripts by tasks.registering(Exec::class) {
-    //dependsOn(":flank-scripts:publish")
+    dependsOn(":flank-scripts:publish")
     commandLine(
         "gh", "release", "create",
         "flank-scripts-$version", "$buildDir/libs/$artifactID.jar",

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -1,8 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import com.jfrog.bintray.gradle.BintrayExtension
 import java.io.ByteArrayOutputStream
+import java.nio.file.Files
 import java.nio.file.Paths
-import java.util.Date
 
 plugins {
     application
@@ -10,7 +9,6 @@ plugins {
     kotlin(Plugins.Kotlin.PLUGIN_SERIALIZATION) version Versions.KOTLIN
     id(Plugins.PLUGIN_SHADOW_JAR) version Versions.SHADOW
     id(Plugins.MAVEN_PUBLISH)
-    id(Plugins.JFROG_BINTRAY)
 }
 
 val artifactID = "flank-scripts"
@@ -28,7 +26,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.6.3"
+version = "1.6.4"
 group = "com.github.flank"
 
 application {
@@ -39,30 +37,17 @@ application {
     )
 }
 
-bintray {
-    user = System.getenv("JFROG_USER") ?: properties["JFROG_USER"].toString()
-    key = System.getenv("JFROG_API_KEY") ?: properties["JFROG_API_KEY"].toString()
-    publish = true
-    override = true
-    setPublications("mavenJava")
-    pkg(
-        closureOf<BintrayExtension.PackageConfig> {
-            repo = "maven"
-            name = artifactID
-            userOrg = "flank"
-            setLicenses("Apache-2.0")
-            vcsUrl = "https://github.com/Flank/flank.git"
-            version(
-                closureOf<BintrayExtension.VersionConfig> {
-                    name = version.name
-                    released = Date().toString()
-                }
-            )
-        }
-    )
-}
-
 publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/Flank/flank")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR") ?: properties["GITHUB_ACTOR"].toString()
+                password = System.getenv("GITHUB_TOKEN") ?: properties["GITHUB_TOKEN"].toString()
+            }
+        }
+    }
     publications {
         create<MavenPublication>("mavenJava") {
             groupId = group.toString()
@@ -132,10 +117,16 @@ val prepareJar by tasks.registering(Copy::class) {
     into("$projectDir/bash")
 }
 
-tasks.register("download") {
-    val sourceUrl = "https://dl.bintray.com/flank/maven/com/github/flank/$artifactID/$version/$artifactID-$version.jar"
-    val destinationFile = Paths.get("bash", "flank-scripts.jar").toFile()
-    ant.invokeMethod("get", mapOf("src" to sourceUrl, "dest" to destinationFile))
+val download by tasks.registering(Exec::class) {
+    commandLine(
+        "gh", "release", "download", "flank-scripts-$version", "-D", System.getenv("GITHUB_WORKSPACE") ?: ".."
+    )
+    doLast {
+        Files.copy(
+            Paths.get( "$artifactID.jar"),
+            Paths.get("flank-scripts","bash", "$artifactID.jar")
+        )
+    }
 }
 
 val checkIfVersionUpdated by tasks.registering(Exec::class) {
@@ -159,6 +150,17 @@ val checkIfVersionUpdated by tasks.registering(Exec::class) {
         }
     }
 }
+
+val releaseFlankScripts by tasks.registering(Exec::class) {
+    //dependsOn(":flank-scripts:publish")
+    commandLine(
+        "gh", "release", "create",
+        "flank-scripts-$version", "$buildDir/libs/$artifactID.jar",
+        "-t", "'Flank Scripts $version'",
+        "-p"
+    )
+}
+
 
 fun isVersionChangedInBuildGradle(): Boolean {
 


### PR DESCRIPTION
Fixes #1565

## Test Plan
> How do we know the code works?

- [Flank scripts is released to Github Packages](https://github.com/Flank/flank/packages/628838)
- [Flank scripts is released to Github Releases](https://github.com/Flank/flank/releases/tag/flank-scripts-1.6.3)
- Above functions could be run using (`./gradlew flank-scripts:releaseFlankScripts`) ([Github CLI tool required](https://github.com/cli/cli))
- Download function works properly (`./gradlew :flank-scripts:download`) ([Github CLI tool required](https://github.com/cli/cli))
## Checklist

- [x] Publish to Github Packages
- [x] Publish to Github release
- [x] Update download function
- [x] JFrog deleted
