### PR TITLE
ci: Add missing subcommands

### DIFF
--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -26,7 +26,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.7.1"
+version = "1.7.2"
 group = "com.github.flank"
 
 application {

--- a/flank-scripts/src/main/kotlin/flank/scripts/cli/release/ReleaseCommand.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/cli/release/ReleaseCommand.kt
@@ -14,7 +14,9 @@ object ReleaseCommand : CliktCommand(
         subcommands(
             MakeReleaseCommand,
             DeleteReleaseCommand,
-            DeleteOldTagCommand
+            DeleteOldTagCommand,
+            NextTagCommand,
+            GenerateReleaseNotesCommand
         )
     }
 


### PR DESCRIPTION
Adds missing `NextTagCommand` and `GenerateReleaseNotesCommand` to the `release` command