### PR TITLE
fix: Snapshot publish by disabling closing staging artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,7 @@ jobs:
 
     - name: Gradle close staging on MavenCentral
       uses: eskatos/gradle-command-action@v1
+      if: startsWith(github.ref, 'refs/tags/v')
       with:
         arguments: closeAndReleaseRepository -PMVN_CENTRAL_USER=${{ secrets.MVN_CENTRAL_USER }} -PMVN_CENTRAL_PASSWORD=${{ secrets.MVN_CENTRAL_PASSWORD }}
 


### PR DESCRIPTION

## Test Plan
> How do we know the code works?

Snapshots are published to maven central

