### PR TITLE
fix: Fix NPE in GcToolResults

### DIFF
--- a/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcToolResults.kt
@@ -146,7 +146,7 @@ object GcToolResults {
 
     fun listAllTestCases(results: ToolResultsStep): List<TestCase> {
         var response = listTestCases(results)
-        val testCases = response.testCases.toMutableList()
+        val testCases = response.testCases.orEmpty().toMutableList()
         while (response.nextPageToken != null) {
             response = listTestCases(results, response.nextPageToken)
             testCases += response.testCases ?: emptyList()


### PR DESCRIPTION
Fixes #1649

PR adds NPE handling when fetching results

## Test Plan
> How do we know the code works?

1. build workflows finish with success
2. IT pass
