### PR TITLE
fix: Saving service account by flank script

### DIFF
--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -26,7 +26,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.9.0"
+version = "1.9.1"
 group = "com.github.flank"
 
 application {

--- a/flank-scripts/src/main/kotlin/flank/scripts/ops/firebase/SaveServiceAccount.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/ops/firebase/SaveServiceAccount.kt
@@ -8,10 +8,13 @@ import java.nio.file.Path
 fun saveServiceAccount(
     serviceAccount: String,
     serviceAccountPath: Path = defaultCredentialPath.toAbsolutePath()
-) = when {
-    serviceAccount.startsWith("http", true) -> downloadFile(serviceAccount, serviceAccountPath)
-    serviceAccount.endsWith(".json", true) -> saveFromFile(serviceAccount, serviceAccountPath)
-    else -> saveFromStr(serviceAccount, serviceAccountPath)
+) {
+    serviceAccountPath.parent.toFile().mkdirs()
+    when {
+        serviceAccount.startsWith("http", true) -> downloadFile(serviceAccount, serviceAccountPath)
+        serviceAccount.endsWith(".json", true) -> saveFromFile(serviceAccount, serviceAccountPath)
+        else -> saveFromStr(serviceAccount, serviceAccountPath)
+    }
 }
 
 private fun saveFromFile(


### PR DESCRIPTION
Fixes #

## Test Plan
> How do we know the code works?

When ```./config/gcloud``` path does not exist flank scripts should create directories.
