### PR TITLE
feat: Return directories path in Flank Github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,13 @@ inputs:
   flank_configuration_file:
     description: 'Flank configuration file'
     required: true
+outputs:
+  local_results_directory:
+    description: "Random number"
+    value: ${{ steps.output_paths.outputs.local_results_directory }}
+  gcloud_results_directory:
+    description: "Random number"
+    value: ${{ steps.output_paths.outputs.gcloud_results_directory }}
 runs:
   using: "composite"
   steps:
@@ -33,4 +40,10 @@ runs:
     - id: run_flank
       run: |
         java -jar flank.jar firebase test ${{ inputs.platform }} run -c=${{ inputs.flank_configuration_file }}
+      shell: bash
+    - id: output_paths
+      run: |
+      	file_path=$(find -name "flank-links.log")
+      	echo "::set-output name=local_results_directory::$(sed -n '1p' < $file_path)"
+      	echo "::set-output name=gcloud_results_directory::$(sed -n '2p' < $file_path)"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,10 @@ inputs:
     required: true
 outputs:
   local_results_directory:
-    description: "Random number"
+    description: "Path to local results directory"
     value: ${{ steps.output_paths.outputs.local_results_directory }}
   gcloud_results_directory:
-    description: "Random number"
+    description: "Path to Gcloud storage"
     value: ${{ steps.output_paths.outputs.gcloud_results_directory }}
 runs:
   using: "composite"

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -2,10 +2,12 @@ package ftl.run.platform
 
 import com.google.testing.Testing
 import com.google.testing.model.TestMatrix
+import flank.common.join
 import flank.common.logLn
 import ftl.args.AndroidArgs
 import ftl.args.isInstrumentationTest
 import ftl.args.shardsFilePath
+import ftl.config.FtlConstants
 import ftl.gc.GcAndroidDevice
 import ftl.gc.GcAndroidTestMatrix
 import ftl.gc.GcStorage
@@ -29,6 +31,7 @@ import ftl.run.platform.common.beforeRunTests
 import ftl.run.saveShardChunks
 import ftl.shard.Chunk
 import ftl.shard.testCases
+import ftl.util.saveToFlankLinks
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -85,6 +88,13 @@ private fun String.createGcsPath(contextIndex: Int, runIndex: Int) =
     else "$this/matrix_${contextIndex}_$runIndex/"
 
 private fun List<AndroidTestContext>.dumpShards(config: AndroidArgs) = takeIf { config.isInstrumentationTest }?.apply {
+    saveToFlankLinks(
+        config.shardsFilePath,
+        FtlConstants.GCS_STORAGE_LINK + join(
+            config.resultsBucket,
+            config.resultsDir
+        )
+    )
     if (config.testTargetsForShard.isEmpty())
         filterIsInstance<InstrumentationTestContext>()
             .asMatrixTestShards()

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunIosTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunIosTests.kt
@@ -1,9 +1,11 @@
 package ftl.run.platform
 
+import flank.common.join
 import flank.common.logLn
 import ftl.args.IosArgs
 import ftl.args.isXcTest
 import ftl.args.shardsFilePath
+import ftl.config.FtlConstants
 import ftl.gc.GcIosMatrix
 import ftl.gc.GcIosTestMatrix
 import ftl.gc.GcStorage
@@ -20,6 +22,7 @@ import ftl.run.platform.common.beforeRunTests
 import ftl.run.platform.ios.createIosTestContexts
 import ftl.shard.testCases
 import ftl.util.repeat
+import ftl.util.saveToFlankLinks
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -42,7 +45,10 @@ internal suspend fun IosArgs.runIosTests(): TestResult =
         val additionalIpasGcsFiles = uploadAdditionalIpas()
 
         dumpShardsIfXcTest()
-
+        saveToFlankLinks(
+            shardsFilePath,
+            FtlConstants.GCS_STORAGE_LINK + join(resultsBucket, resultsDir)
+        )
         val testShardChunks = xcTestRunData.flattenShardChunks()
         logLn(beforeRunMessage(testShardChunks))
 

--- a/test_runner/src/main/kotlin/ftl/util/Utils.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Utils.kt
@@ -5,6 +5,7 @@ package ftl.util
 import com.fasterxml.jackson.annotation.JsonProperty
 import flank.common.logLn
 import ftl.run.exception.FlankGeneralError
+import java.io.File
 import java.io.InputStream
 import java.time.Instant
 import java.time.ZoneOffset
@@ -114,3 +115,5 @@ fun <T> KMutableProperty<T?>.require() =
     )
 
 fun getGACPathOrEmpty(): String = System.getenv("GOOGLE_APPLICATION_CREDENTIALS").orEmpty()
+
+fun saveToFlankLinks(vararg links: String) = File("flank-links.log").writeText(links.joinToString(System.lineSeparator()))


### PR DESCRIPTION
Fixes #1599

## Test Plan
> How do we know the code works?

### Flank
Stores output path and gcloud path in file `flank-links.log`

### Github action
Returns local and gcloud path after running flank.

<TODO>

## Checklist

- [x] Test repository updated
- [x] Output variables returned
