### PR TITLE
fix: Fix output report error with dump shards

### DIFF
--- a/common/src/main/kotlin/flank/common/Files.kt
+++ b/common/src/main/kotlin/flank/common/Files.kt
@@ -111,7 +111,7 @@ fun File.hasAllFiles(fileList: List<String>): Boolean {
 
 fun String.fileExists(): Boolean = Paths.get(this).exists()
 
-fun osPathSeperator() = (if (isWindows) "\\" else "/")
+fun osPathSeparator() = (if (isWindows) "\\" else "/")
 
 private fun Path.exists(): Boolean = Files.exists(this)
 

--- a/common/src/test/kotlin/flank/common/FilesTest.kt
+++ b/common/src/test/kotlin/flank/common/FilesTest.kt
@@ -48,7 +48,7 @@ class FilesTest {
         copyDirectory(folder1.absolutePath, folder2.absolutePath)
 
         // then
-        val strFile = folder2.absolutePath.toStr().plus(osPathSeperator()).plus(tempFolder2.root.name).plus(osPathSeperator())
+        val strFile = folder2.absolutePath.toStr().plus(osPathSeparator()).plus(tempFolder2.root.name).plus(osPathSeparator())
             .plus(fileInFolder1.name)
         assertTrue(strFile.fileExists())
         temporaryFolder.delete()

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReport.kt
@@ -1,5 +1,6 @@
 package ftl.reports.output
 
+import flank.common.fileExists
 import ftl.gc.GcStorage
 import ftl.run.common.prettyPrint
 import java.io.File
@@ -45,13 +46,14 @@ private fun OutputReport.storeOutputData(
     OutputReportType.NONE -> null
 }
 
-private fun OutputData.toJson() = prettyPrint.toJson(this)
+private fun OutputData.toJson(): String = prettyPrint.toJson(this)
 
 private fun String.storeToFile(
     directoryPath: String,
     fileName: String
-) = Paths.get(directoryPath, fileName).toFile()
-    .apply { writeText(this@storeToFile) }
+) = if (directoryPath.fileExists())
+    Paths.get(directoryPath, fileName).toFile().apply { writeText(this@storeToFile) }
+else null
 
 private fun File.uploadToGcloud(resultsBucket: String, resultsDir: String) {
     GcStorage.upload(absolutePath, resultsBucket, resultsDir)


### PR DESCRIPTION
When a user tries to dump shards AND the output report is enabled an error is thrown. This is due to the fact flank is trying to create `outputReport.json` file inside result directory which does not exist for dump shard run, to reproduce run on the current master:
1. add `output-report: json` to the config file
2. start flank with `--dump-shards`
3. see `FileNotFound` error

## Test Plan
> How do we know the code works?

1. add `output-report: json` to the config file
2. start flank with `--dump-shards`
3. no error is thrown and flank finishes run normally

## Checklist

- [x] Unit tested
