### PR TITLE
fix: Output path to local results github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,7 @@ runs:
     - id: output_paths
       run: |
         file_path=$(find -name "flank-links.log")
-        echo "::set-output name=local_results_directory::$(sed -n '1p' < $file_path)"
+        local_directory_file=$(sed -n '1p' < $file_path)
+        echo "::set-output name=local_results_directory::$(dirname $local_directory_file)"
         echo "::set-output name=gcloud_results_directory::$(sed -n '2p' < $file_path)"
       shell: bash


### PR DESCRIPTION
As you can see for [example in this run](https://github.com/Flank/flank-github-action-testing/runs/2087337805?check_suite_focus=true), output contains file name:
```
Local directory: /home/runner/work/flank-github-action-testing/flank-github-action-testing/results/2021-03-11_15-13-11.697000_GzOA/android_shards.json
Gcloud: https://console.developers.google.com/storage/browser/test-lab-v9cn46bb990nx-kz69ymd4nm9aq/2021-03-11_15-13-11.697000_GzOA
```

but it should be:
```
Local directory: /home/runner/work/flank-github-action-testing/flank-github-action-testing/results/2021-03-11_15-13-11.697000_GzOA
Gcloud: https://console.developers.google.com/storage/browser/test-lab-v9cn46bb990nx-kz69ymd4nm9aq/2021-03-11_15-13-11.697000_GzOA
```

This is a quick workaround to avoid making a new Flank release, when we will fix this on Flank side, it should be removed from Flank github action

## Test Plan
> How do we know the code works?

There should not be a file name at the end

Locally:
1. Create file `flank-links.log` with path to some file as a content
2. run command `file_path=$(find -name "flank-links.log")`
3. then `local_directory_file=$(sed -n '1p' < $file_path)`
4. at the end echo results `echo $(dirname $local_directory_file)`

Github action:
Should return local path without file name at the end
