### PR TITLE
docs: Create Github marketplace documentation for Flank action

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,4 @@ Flank is YAML compatible with [the gcloud CLI](https://cloud.google.com/sdk/gclo
 ### Documentation is at [flank.github.io/flank](https://flank.github.io/flank/)
 
 
-### Github action documentation
-
-[Github action documentation](https://github.com/Flank/flank/blob/%231600_marketplace_documentation/docs/flank-github-action/store_documentation.md)
+### Github action documentation is at [repository](https://github.com/Flank/flank/blob/master/docs/flank-github-action/store_documentation.md)

--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@ Flank is YAML compatible with [the gcloud CLI](https://cloud.google.com/sdk/gclo
 
 ### Documentation is at [flank.github.io/flank](https://flank.github.io/flank/)
 
+
+## Github action documentation
+
 [Github action documentation](https://github.com/Flank/flank/blob/%231600_marketplace_documentation/docs/flank-github-action/store_documentation.md)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Flank is YAML compatible with [the gcloud CLI](https://cloud.google.com/sdk/gclo
 ### Documentation is at [flank.github.io/flank](https://flank.github.io/flank/)
 
 
-## Github action documentation
+### Github action documentation
 
 [Github action documentation](https://github.com/Flank/flank/blob/%231600_marketplace_documentation/docs/flank-github-action/store_documentation.md)

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Flank is a [massively parallel Android and iOS test runner](https://docs.google.
 Flank is YAML compatible with [the gcloud CLI](https://cloud.google.com/sdk/gcloud/reference/alpha/firebase/test). Flank provides extra features to accelerate velocity and increase quality.
 
 ### Documentation is at [flank.github.io/flank](https://flank.github.io/flank/)
+
+[Github action documentation](https://github.com/Flank/flank/blob/%231600_marketplace_documentation/docs/flank-github-action/store_documentation.md)

--- a/docs/flank-github-action/store_documentation.md
+++ b/docs/flank-github-action/store_documentation.md
@@ -14,7 +14,7 @@ Documentation for Flank is at [flank.github.io/flank](https://flank.github.io/fl
 | `version`                  | Flank version to run. Minimal supported version is `v21.03.1`. Leaving it blank will fallback to latest version.                                                                                                                                          | `false`  | latest available |
 | `service_account`          | Service account to authenticate with. Could be path to file, link to file or file content itself. More information about creating a service account could be found at [documentation](https://flank.github.io/flank/#authenticate-with-a-service-account) | `true`   |                  |
 | `platform`                 | Platform to run. Could be `ios` or `android`                                                                                                                                                                                                              | `true`   |                  |
-| `flank_configuration_file` | Flank configuration file. More info how it should look like is in [documentation](https://flank.github.io/flank/#flank-configuration)                                                                                                                     | `true`   |                  |
+| `flank_configuration_file` | Flank configuration file. More information on how it should look like is in [documentation](https://flank.github.io/flank/#flank-configuration)                                                                                                                     | `true`   |                  |
 
 ### Outputs
 

--- a/docs/flank-github-action/store_documentation.md
+++ b/docs/flank-github-action/store_documentation.md
@@ -1,0 +1,117 @@
+## Action
+
+This Github action allow us to run Flank using your Github workflows.
+
+Flank is a [massively parallel Android and iOS test runner](https://docs.google.com/presentation/d/1goan9cXpimSJsS3L60WjljnFA_seUyaWb2e-bezm084/edit#slide=id.p1) for [Firebase Test Lab](https://firebase.google.com/docs/test-lab/). 
+
+Flank is YAML compatible with [the gcloud CLI](https://cloud.google.com/sdk/gcloud/reference/alpha/firebase/test). Flank provides extra features to accelerate velocity and increase quality.
+
+Documentation for flank is at [flank.github.io/flank](https://flank.github.io/flank/)
+
+
+## Usage
+
+### Inputs
+
+| Input name                 | Description                                                                                                                                                                                                                                               | Required | Default          |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|------------------|
+| `version`                  | Flank version to run. Minimal supported version is `v21.03.1`. Leaving it blank will fallback to latest version.                                                                                                                                          | `false`  | latest available |
+| `service_account`          | Service account to authenticate with. Could be path to file, link to file or file content itself. More information about creating a service account could be found at [documentation](https://flank.github.io/flank/#authenticate-with-a-service-account) | `true`   |                  |
+| `platform`                 | Platform to run. Could be `ios` or `android`                                                                                                                                                                                                              | `true`   |                  |
+| `flank_configuration_file` | Flank configuration file. More info how it should look like is in [documentation](https://flank.github.io/flank/#flank-configuration)                                                                                                                     | `true`   |                  |
+
+### Outputs
+
+| Output name                | Description                                                                                                              |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `gcloud_results_directory` | Link to Gcloud store where results are stored.                                                                           |
+| `local_results_directory`  | Path to local results directory. All output files from this run are stored inside. You could use it as output artifacts. |
+
+
+### Adding to workflows
+
+```yaml
+- name: <your name>
+  id: <id of action>
+  uses: Flank/flank@master
+  with:
+    version: <Flank version to run, minimum supported is v21.03.1, default latest>
+    service_account: <file content, file link or path to file with service account> 
+    platform: [android|ios]
+    flank_configuration_file: <Path to configuration file>
+```
+
+
+### Example workflows
+
+#### Service account file content from secrets
+```yaml
+- name: flank run
+  id: flank_run
+  uses: Flank/flank@master
+  with:
+    # Flank version to run
+    version: v21.03.1
+    # Service account file content from secrets
+    service_account: ${{ secrets.SERVICE_ACCOUNT }} 
+    # Run Android tests
+    platform: android
+    # Path to configuration file from local repo
+    flank_configuration_file: './testing/android/flank-simple-success.yml'
+
+- name: output
+  run: |
+    # Use local directory output
+    echo "Local directory: ${{ steps.flank_run.outputs.local_results_directory }}"
+    # Use Gcloud storage output 
+    echo "Gcloud: ${{ steps.flank_run.outputs.gcloud_results_directory }}"
+```
+
+#### Service account file from repository
+```yaml
+- name: flank run
+  id: flank_run
+  uses: Flank/flank@master
+  with:
+    # Service account file from repository
+    service_account: './service_account.json'
+    # Run Android tests
+    platform: android
+    # Path to configuration file from local repo
+    flank_configuration_file: './testing/android/flank-simple-success.yml'
+
+- name: output
+  run: |
+    # Use local directory output
+    echo "Local directory: ${{ steps.flank_run.outputs.local_results_directory }}"
+    # Use Gcloud storage output 
+    echo "Gcloud: ${{ steps.flank_run.outputs.gcloud_results_directory }}"
+```
+
+#### Create service account during workflow
+```yaml
+
+- name: Create service account
+  run: echo '${{ secrets.SERVICE_ACCOUNT }}' > service_account_created.json
+
+- name: flank run
+  id: flank_run
+  uses: Flank/flank@master
+  with:
+    # Service account created in previous step
+    service_account: './service_account_created.json'
+    # Run Android tests
+    platform: android
+    # Path to configuration file from local repo
+    flank_configuration_file: './testing/android/flank-simple-success.yml'
+
+- name: output
+  run: |
+    # Use local directory output
+    echo "Local directory: ${{ steps.flank_run.outputs.local_results_directory }}"
+    # Use Gcloud storage output 
+    echo "Gcloud: ${{ steps.flank_run.outputs.gcloud_results_directory }}"
+```
+
+## Runner OS support
+All 3 runner operating systems are supported.

--- a/docs/flank-github-action/store_documentation.md
+++ b/docs/flank-github-action/store_documentation.md
@@ -1,12 +1,12 @@
 ## Action
 
-This Github action allow us to run Flank using your Github workflows.
+This Github action allow running Flank using your Github workflows.
 
 Flank is a [massively parallel Android and iOS test runner](https://docs.google.com/presentation/d/1goan9cXpimSJsS3L60WjljnFA_seUyaWb2e-bezm084/edit#slide=id.p1) for [Firebase Test Lab](https://firebase.google.com/docs/test-lab/). 
 
 Flank is YAML compatible with [the gcloud CLI](https://cloud.google.com/sdk/gcloud/reference/alpha/firebase/test). Flank provides extra features to accelerate velocity and increase quality.
 
-Documentation for flank is at [flank.github.io/flank](https://flank.github.io/flank/)
+Documentation for Flank is at [flank.github.io/flank](https://flank.github.io/flank/)
 
 
 ## Usage

--- a/docs/flank-github-action/store_documentation.md
+++ b/docs/flank-github-action/store_documentation.md
@@ -1,6 +1,6 @@
 ## Action
 
-This Github action allow running Flank using your Github workflows.
+This Github action allows for running Flank as a Github workflow.
 
 Documentation for Flank is at [flank.github.io/flank](https://flank.github.io/flank/)
 

--- a/docs/flank-github-action/store_documentation.md
+++ b/docs/flank-github-action/store_documentation.md
@@ -2,10 +2,6 @@
 
 This Github action allow running Flank using your Github workflows.
 
-Flank is a [massively parallel Android and iOS test runner](https://docs.google.com/presentation/d/1goan9cXpimSJsS3L60WjljnFA_seUyaWb2e-bezm084/edit#slide=id.p1) for [Firebase Test Lab](https://firebase.google.com/docs/test-lab/). 
-
-Flank is YAML compatible with [the gcloud CLI](https://cloud.google.com/sdk/gcloud/reference/alpha/firebase/test). Flank provides extra features to accelerate velocity and increase quality.
-
 Documentation for Flank is at [flank.github.io/flank](https://flank.github.io/flank/)
 
 


### PR DESCRIPTION
Fixes #1600

This is the description of the Flank Github action which goes to the Github marketplace.
Unfortunately, we could not point to custom documentation, so I have added a link to the main documentation
