### PR TITLE
feat: Add app name to the test result

### DIFF
--- a/integration_tests/src/test/kotlin/integration/IntergrationTestsUtils.kt
+++ b/integration_tests/src/test/kotlin/integration/IntergrationTestsUtils.kt
@@ -86,8 +86,8 @@ enum class TestOutcome(val regex: Regex) {
 
 private val fromCommon =
     { outcome: String ->
-        if (isWindows) "\\?\\s$outcome\\s\\?\\smatrix-[a-zA-Z0-9]*\\s\\?\\s*[a-zA-Z0-9-]*\\s*\\?\\s[a-zA-Z0-9\\s,-]*\\s*\\?".toRegex()
-        else "│\\s$outcome\\s│\\s${"matrix"}-[a-zA-Z0-9]*\\s│\\s*[a-zA-Z0-9-]*\\s*│\\s[a-zA-Z0-9\\s,-]*\\s*│".toRegex()
+        if (isWindows) "\\?\\s$outcome\\s\\?\\smatrix-[a-zA-Z0-9]*\\s\\?\\s*[a-zA-Z0-9._-]*\\s*\\?\\s*[a-zA-Z0-9-]*\\s*\\?\\s[a-zA-Z0-9\\s,-]*\\s*\\?".toRegex()
+        else "│\\s$outcome\\s│\\s${"matrix"}-[a-zA-Z0-9]*\\s│\\s*[a-zA-Z0-9._-]*\\s*│\\s*[a-zA-Z0-9-]*\\s*│\\s[a-zA-Z0-9\\s,-]*\\s*│".toRegex()
     }
 
 fun String.removeUnicode() = replace("\u001B\\[\\d{1,2}m".toRegex(), "").trimIndent()

--- a/integration_tests/src/test/resources/compare/SanityRoboIT-compare
+++ b/integration_tests/src/test/resources/compare/SanityRoboIT-compare
@@ -83,11 +83,7 @@ CostReport
 
 MatrixResultsReport
   1 \/ 1 \(100\.00\%\)
-.*
-[│\?] OUTCOME [│\?]      MATRIX ID       [│\?]      TEST AXIS VALUE       [│\?] TEST DETAILS [│\?]
-.*
-[│\?] success [│\?] matrix-[a-zA-Z0-9\s]*[│\?] NexusLowRes-28-en-portrait [│\?] ---          [│\?]
-.*
+[\s\S]*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/test_runner/src/main/kotlin/ftl/json/SavedMatrixTableUtil.kt
+++ b/test_runner/src/main/kotlin/ftl/json/SavedMatrixTableUtil.kt
@@ -21,6 +21,10 @@ fun List<SavedMatrix>.asPrintableTable(): String = buildTable(
         data = flatMapTestAxis { matrix -> matrix.matrixId }
     ),
     TableColumn(
+        header = APP_NAME_COLUMN_HEADER,
+        data = flatMapTestAxis { matrix -> matrix.appFileName }
+    ),
+    TableColumn(
         header = TEST_AXIS_VALUE_HEADER,
         data = flatMapTestAxis { device }
     ),
@@ -43,5 +47,6 @@ private val TestOutcome.outcomeColor
 
 private const val OUTCOME_COLUMN_HEADER = "OUTCOME"
 private const val MATRIX_ID_COLUMN_HEADER = "MATRIX ID"
+private const val APP_NAME_COLUMN_HEADER = "APP NAME"
 private const val TEST_AXIS_VALUE_HEADER = "TEST AXIS VALUE"
 private const val OUTCOME_DETAILS_COLUMN_HEADER = "TEST DETAILS"

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReportLoggers.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReportLoggers.kt
@@ -17,7 +17,10 @@ internal fun OutputReport.log(matrices: Collection<SavedMatrix>) {
     add(
         "test_results",
         matrices.map {
-            it.matrixId to it.testAxises
+            it.matrixId to mapOf(
+                "app" to it.appFileName,
+                "test-axises" to it.testAxises
+            )
         }.toMap()
     )
 }

--- a/test_runner/src/test/kotlin/ftl/reports/output/OutputReportLoggersTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/output/OutputReportLoggersTest.kt
@@ -43,10 +43,13 @@ class OutputReportLoggersTest {
     fun `should log test_results`() {
         // given
         val matrices = listOf(
-            SavedMatrix(matrixId = "1", testAxises = listOf(TestOutcome("device1")))
+            SavedMatrix(matrixId = "1", testAxises = listOf(TestOutcome("device1")), appFileName = "any.apk")
         )
         val testResults = matrices.map {
-            it.matrixId to it.testAxises
+            it.matrixId to mapOf(
+                "app" to it.appFileName,
+                "test-axises" to it.testAxises
+            )
         }.toMap()
 
         // when


### PR DESCRIPTION
Fixes #1674

PR adds a new column (`APP NAME`) to the result table and updates the` outputReport.json` structure with an apk file name.

## Test Plan
> How do we know the code works?

1. Launch test run with flank with `output-report: json`
2. When the run is finished you should see the additional column in the result table with the header `APP NAME`
3. There should be apk's file name used in the test
4. Open `outputReport.json` 
5. Check if `test_results` structure is similar to
    ```
    "test_results": {
      "matrix-afvw8zv215owa": {
        "app": "app-debug.apk",
        "test-axises": [
    ```

## Checklist

- [x] Unit tested
