### PR TITLE
feat: Add option to skip config validation

### DIFF
--- a/integration_tests/src/test/resources/compare/AllTestFilteredIT-android-compare
+++ b/integration_tests/src/test/resources/compare/AllTestFilteredIT-android-compare
@@ -63,6 +63,7 @@ AndroidArgs
       default-class-test-time: 240.0
       disable-usage-statistics: true
       output-report: none
+      skip-config-validation: false
 
 RunTests
   No tests for app-single-success-debug-androidTest.apk

--- a/integration_tests/src/test/resources/compare/AllTestFilteredIT-ios-compare
+++ b/integration_tests/src/test/resources/compare/AllTestFilteredIT-ios-compare
@@ -54,6 +54,7 @@ IosArgs
       only-test-configuration:\s
       skip-test-configuration:\s
       output-report: none
+      skip-config-validation: false
 Found xctest: [0-9a-zA-Z\/_.-]*\/test_runner\/src\/test\/kotlin\/ftl\/fixtures\/tmp\/ios\/EarlGreyExample\/Debug-iphoneos\/EarlGreyExampleSwift.app\/PlugIns\/EarlGreyExampleSwiftTests.xctest
 isMacOS = (true \(mac os x\)|false \(linux\))
 (PATH=~\/.flank\s)?nm -U "[0-9a-zA-Z\/_.-]*\/test_runner\/src\/test\/kotlin\/ftl\/fixtures\/tmp\/ios\/EarlGreyExample\/Debug-iphoneos\/EarlGreyExampleSwift.app\/PlugIns\/EarlGreyExampleSwiftTests.xctest\/EarlGreyExampleSwiftTests"

--- a/integration_tests/src/test/resources/compare/GameloopIT-android-compare
+++ b/integration_tests/src/test/resources/compare/GameloopIT-android-compare
@@ -64,6 +64,7 @@ AndroidArgs
       default-class-test-time: 240.0
       disable-usage-statistics: true
       output-report: none
+      skip-config-validation: false
 \s*
 RunTests
   Uploading \[test.obb\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/integration_tests/src/test/resources/compare/GameloopIT-ios-compare
+++ b/integration_tests/src/test/resources/compare/GameloopIT-ios-compare
@@ -54,6 +54,7 @@ IosArgs
       only-test-configuration:\s
       skip-test-configuration:\s
       output-report: none
+      skip-config-validation: false
 
 RunTests
 \s*

--- a/integration_tests/src/test/resources/compare/IgnoreFailedIT-compare
+++ b/integration_tests/src/test/resources/compare/IgnoreFailedIT-compare
@@ -62,6 +62,7 @@ AndroidArgs
       default-class-test-time: 240.0
       disable-usage-statistics: true
       output-report: none
+      skip-config-validation: false
 
 RunTests
 

--- a/integration_tests/src/test/resources/compare/MultipleApksIT-compare
+++ b/integration_tests/src/test/resources/compare/MultipleApksIT-compare
@@ -68,6 +68,7 @@ AndroidArgs
       default-class-test-time: 240.0
       disable-usage-statistics: true
       output-report: none
+      skip-config-validation: false
 \s*
 RunTests
 \s*

--- a/integration_tests/src/test/resources/compare/MultipleDevicesIT-android-compare
+++ b/integration_tests/src/test/resources/compare/MultipleDevicesIT-android-compare
@@ -76,6 +76,7 @@ AndroidArgs
       default-class-test-time: 240.0
       disable-usage-statistics: true
       output-report: none
+      skip-config-validation: false
 \s*
 RunTests
 \s*

--- a/integration_tests/src/test/resources/compare/RunTimeoutIT-compare
+++ b/integration_tests/src/test/resources/compare/RunTimeoutIT-compare
@@ -62,6 +62,7 @@ AndroidArgs
       default-class-test-time: 240.0
       disable-usage-statistics: true
       output-report: none
+      skip-config-validation: false
 
 RunTests
   Saved 1 shards to .*[\\\/]android_shards.json

--- a/integration_tests/src/test/resources/compare/SanityRoboIT-compare
+++ b/integration_tests/src/test/resources/compare/SanityRoboIT-compare
@@ -62,6 +62,7 @@ AndroidArgs
       default-class-test-time: 240.0
       disable-usage-statistics: true
       output-report: none
+      skip-config-validation: false
 
 RunTests
   Uploading \[app-debug.apk\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/integration_tests/src/test/resources/compare/TestFilteringIT-compare
+++ b/integration_tests/src/test/resources/compare/TestFilteringIT-compare
@@ -65,6 +65,7 @@ AndroidArgs
       default-class-test-time: 240.0
       disable-usage-statistics: true
       output-report: none
+      skip-config-validation: false
 \s*
 RunTests
   No tests for app-single-success-debug-androidTest.apk

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -277,7 +277,7 @@ flank:
   # output-report: none
 
   ### Disable config validation (for both, yml and command line)
-  ## Flank won't validate options provided by the user if true. In general, it's not a good idea but,
+  ## If true, Flank won't validate options provided by the user. In general, it's not a good idea but,
   ## there are cases when this could be useful for a user
   ## (example: project can use devices that are not commonly available, the project has higher sharding limits, etc).
   ## Default: false

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -275,3 +275,10 @@ flank:
   ## Saves output results as parsable file and optionally upload it to Gcloud. Possible values are [none, json].
   ## Default: none
   # output-report: none
+
+  ### Disable config validation (for both, yml and command line)
+  ## Flank won't validate options provided by the user if true. In general, it's not a good idea but,
+  ## there are cases when this could be useful for a user
+  ## (example: project can use devices that are not commonly available, the project has higher sharding limits, etc).
+  ## Default: false
+  # skip-config-validation: false

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -354,7 +354,7 @@ flank:
   # output-report: none
 
   ### Disable config validation (for both, yml and command line)
-  ## Flank won't validate options provided by the user if true. In general, it's not a good idea but,
+  ## If true, Flank won't validate options provided by the user. In general, it's not a good idea but,
   ## there are cases when this could be useful for a user
   ## (example: project can use devices that are not commonly available, the project has higher sharding limits, etc).
   ## Default: false

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -352,3 +352,10 @@ flank:
   ## Saves output results as parsable file and optionally upload it to Gcloud. Possible values are [none, json].
   ## Default: none
   # output-report: none
+
+  ### Disable config validation (for both, yml and command line)
+  ## Flank won't validate options provided by the user if true. In general, it's not a good idea but,
+  ## there are cases when this could be useful for a user
+  ## (example: project can use devices that are not commonly available, the project has higher sharding limits, etc).
+  ## Default: false
+  # skip-config-validation: false

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -120,6 +120,7 @@ AndroidArgs
       default-class-test-time: $defaultClassTestTime
       disable-usage-statistics: $disableUsageStatistics
       output-report: $outputReportType
+      skip-config-validation: $skipConfigValidation
         """.trimIndent()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/CommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CommonArgs.kt
@@ -46,5 +46,6 @@ data class CommonArgs(
     override val defaultClassTestTime: Double,
     override val useAverageTestTimeForNewTests: Boolean,
     override val disableUsageStatistics: Boolean,
-    override val outputReportType: OutputReportType
+    override val outputReportType: OutputReportType,
+    override val skipConfigValidation: Boolean,
 ) : IArgs

--- a/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
@@ -54,7 +54,8 @@ fun CommonConfig.createCommonArgs(
     defaultClassTestTime = flank::defaultClassTestTime.require(),
     useAverageTestTimeForNewTests = flank::useAverageTestTimeForNewTests.require(),
     disableUsageStatistics = flank.disableUsageStatistics ?: false,
-    outputReportType = OutputReportType.fromName(flank.outputReport)
+    outputReportType = OutputReportType.fromName(flank.outputReport),
+    skipConfigValidation = flank::skipConfigValidation.require()
 ).apply {
     ArgsHelper.createJunitBucket(project, smartFlankGcsPath)
 }

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -97,6 +97,9 @@ interface IArgs {
     val disableUsageStatistics: Boolean
 
     val outputReportType: OutputReportType
+    val skipConfigValidation: Boolean
+    val shouldValidateConfig: Boolean
+        get() = !skipConfigValidation
 
     fun useLocalResultDir() = localResultDir != defaultLocalResultsDir
 

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -99,6 +99,7 @@ IosArgs
       only-test-configuration: $onlyTestConfiguration
       skip-test-configuration: $skipTestConfiguration
       output-report: $outputReportType
+      skip-config-validation: $skipConfigValidation
         """.trimIndent()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -15,7 +15,7 @@ import ftl.run.exception.FlankGeneralError
 import ftl.run.exception.IncompatibleTestDimensionError
 import java.io.File
 
-fun AndroidArgs.validate() = apply {
+fun AndroidArgs.validate() = if (shouldValidateConfig) apply {
     commonArgs.validate()
     assertDevicesSupported()
     assertShards()
@@ -33,7 +33,7 @@ fun AndroidArgs.validate() = apply {
     checkEnvironmentVariables()
     checkFilesToDownload()
     checkNumUniformShards()
-}
+} else this
 
 private fun AndroidArgs.assertTestTargetForShards() {
     if (testTargetsForShard.isNotEmpty()) {

--- a/test_runner/src/main/kotlin/ftl/args/ValidateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateCommonArgs.kt
@@ -11,12 +11,14 @@ import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
 
 fun CommonArgs.validate() {
-    assertProjectId()
-    assertShardTime()
-    assertRepeatTests()
-    assertSmartFlankGcsPath()
-    assertOrientationCorrectness()
-    checkDisableSharding()
+    if (shouldValidateConfig) {
+        assertProjectId()
+        assertShardTime()
+        assertRepeatTests()
+        assertSmartFlankGcsPath()
+        assertOrientationCorrectness()
+        checkDisableSharding()
+    }
 }
 
 private fun List<Device>.devicesWithMispeltOrientations(availableOrientations: List<String>) =

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -11,7 +11,7 @@ import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
 import ftl.run.exception.IncompatibleTestDimensionError
 
-fun IosArgs.validate() = apply {
+fun IosArgs.validate() = if (shouldValidateConfig) apply {
     commonArgs.validate()
     assertXcodeSupported()
     assertDevicesSupported()
@@ -24,7 +24,7 @@ fun IosArgs.validate() = apply {
     assertXcTestRunVersion()
     assertGameloop()
     assertXcTestRunData()
-}
+} else this
 
 private fun IosArgs.assertGameloop() {
     validateApp()

--- a/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
@@ -191,7 +191,7 @@ data class CommonFlankConfig @JsonIgnore constructor(
     @set:CommandLine.Option(
         names = ["--skip-config-validation"],
         description = [
-            "Flank won't validate options provided by the user if true. In general, it's not a good idea but, " +
+            "If true, Flank won't validate options provided by the user. In general, it's not a good idea but, " +
                 "there are cases when this could be useful for a user (example: project can use devices " +
                 "that are not commonly available, the project has higher sharding limits, etc."
         ]

--- a/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/common/CommonFlankConfig.kt
@@ -188,6 +188,17 @@ data class CommonFlankConfig @JsonIgnore constructor(
     @set:JsonProperty("output-report")
     var outputReport: String? by data
 
+    @set:CommandLine.Option(
+        names = ["--skip-config-validation"],
+        description = [
+            "Flank won't validate options provided by the user if true. In general, it's not a good idea but, " +
+                "there are cases when this could be useful for a user (example: project can use devices " +
+                "that are not commonly available, the project has higher sharding limits, etc."
+        ]
+    )
+    @set:JsonProperty("skip-config-validation")
+    var skipConfigValidation: Boolean? by data
+
     constructor() : this(mutableMapOf<String, Any?>().withDefault { null })
 
     companion object : IYmlKeys {
@@ -222,6 +233,7 @@ data class CommonFlankConfig @JsonIgnore constructor(
             useAverageTestTimeForNewTests = false
             disableUsageStatistics = false
             outputReport = OutputReportType.NONE.name
+            skipConfigValidation = false
         }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -380,6 +380,7 @@ AndroidArgs
       default-class-test-time: 30.0
       disable-usage-statistics: false
       output-report: json
+      skip-config-validation: false
             """.trimIndent()
         )
     }
@@ -453,6 +454,7 @@ AndroidArgs
       default-class-test-time: 240.0
       disable-usage-statistics: false
       output-report: none
+      skip-config-validation: false
             """.trimIndent(),
             args.toString()
         )
@@ -1584,6 +1586,36 @@ AndroidArgs
         flank:
           max-test-shards: ${AVAILABLE_VIRTUAL_SHARD_COUNT_RANGE.last + 1}
           disable-results-upload: true
+        """.trimIndent()
+        AndroidArgs.load(yaml).validate()
+    }
+
+    @Test
+    fun `should not throw an error if validation is disabled (yml) -- max test shards`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+        flank:
+          max-test-shards: ${Int.MAX_VALUE}
+          skip-config-validation: true
+        """.trimIndent()
+        AndroidArgs.load(yaml).validate()
+    }
+
+    @Test
+    fun `should not throw an error if validation is disabled (command line) -- device`() {
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          device:
+            - model: funnyDevice
+              version: 28
+              locale: en
+              orientation: portrait
+        flank:
+          skip-config-validation: true
         """.trimIndent()
         AndroidArgs.load(yaml).validate()
     }

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -286,6 +286,7 @@ IosArgs
       only-test-configuration: pl
       skip-test-configuration: 
       output-report: json
+      skip-config-validation: false
             """.trimIndent()
         )
     }
@@ -350,6 +351,7 @@ IosArgs
       only-test-configuration: 
       skip-test-configuration: 
       output-report: none
+      skip-config-validation: false
             """.trimIndent(),
             args.toString()
         )
@@ -585,6 +587,36 @@ IosArgs
       """
         assertThat(IosArgs.load(yaml).maxTestShards).isEqualTo(2)
         assertThat(IosArgs.load(yaml, cli).maxTestShards).isEqualTo(3)
+    }
+
+    @Test
+    fun `should not throw an error if validation is disabled (yml) -- max test shards`() {
+        val yaml = """
+        gcloud:
+          test: $testPath
+          xctestrun-file: $xctestrunFile
+        flank:
+          max-test-shards: ${Int.MAX_VALUE}
+          skip-config-validation: true
+        """.trimIndent()
+        IosArgs.load(yaml).validate()
+    }
+
+    @Test
+    fun `should not throw an error if validation is disabled (command line) -- device`() {
+        val yaml = """
+        gcloud:
+          test: $testPath
+          xctestrun-file: $xctestrunFile
+          device:
+            - model: funnyDevice
+              version: 28
+              locale: en
+              orientation: portrait
+        flank:
+          skip-config-validation: true
+        """.trimIndent()
+        IosArgs.load(yaml).validate()
     }
 
     @Test


### PR DESCRIPTION
Fixes #1710

## Test Plan
> How do we know the code works?

1. run `./gradlew flankFullRun`
2. launch test run with config:
    ```
    flank:
      max-test-shards: 5000000
    ```
3. you should see a validation error message `max-test-shards must be ...`
4. launch test run with config:
    ```
    flank:
      max-test-shards: 5000000
      skip-config-validation: true
    ```
5. test run proceeds normally

## Checklist

- [x] Documented
- [x] Unit tested
- [x] Integration tests updated
