### PR TITLE
docs: Add flank component diagram

### DIFF
--- a/docs/hld/flank-component-diagram.puml
+++ b/docs/hld/flank-component-diagram.puml
@@ -1,0 +1,52 @@
+@startuml
+'https://plantuml.com/component-diagram
+
+left to right direction
+
+legend left
+  |= Color |= Description |
+  |<#LightYellow>| Implemented |
+  |<#LightBlue>| Roadmap |
+end legend
+
+package ftl {
+
+package presentation {
+package cli {
+[Command line interface]
+}
+package desktop {
+[Desktop GUI] #LightBlue
+}
+package service {
+[Web socket API] #LightBlue
+}
+}
+
+package domain {
+[Internal domain logic] <- [Public domain functions]
+}
+
+package data {
+[Structures] - () Interfaces
+}
+
+package adapter {
+[Google OAuth2]
+[Google cloud bucket]
+[Firebase Test Lab]
+[Corellium] #LightBlue
+}
+
+[Command line interface] --> [Public domain functions]
+[Desktop GUI] --> [Public domain functions]
+[Web socket API] --> [Public domain functions]
+[Public domain functions] --> Interfaces
+Interfaces <---- [Google OAuth2]
+Interfaces <-- [Google cloud bucket]
+Interfaces <-- [Firebase Test Lab]
+Interfaces <- [Corellium]
+
+}
+
+@enduml


### PR DESCRIPTION
Fixes #1510 

![component diagram](http://www.plantuml.com/plantuml/proxy?cache=no&fmt=svg&src=https://raw.githubusercontent.com/Flank/flank/1510_Prepare_flank_architecture_diagram/docs/hld/flank-component-diagram.puml)

The architecture model above is based on well-known [PresentationDomainDataLayering](https://www.martinfowler.com/bliki/PresentationDomainDataLayering.html) proposed by Martin Fowler.

Basing on the model above will be easy to:
* scale the presentation layer by adding necessary implementations.
* replace external data providers.
* separate third-party library code from the domain, for keeping code clean.
* consider each layer as a separate module if needed.
* deliver output builds for different configurations.
* deliver domain layer even as a standalone library.