### PR TITLE
refactor: Rename cli package

### DIFF
--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidLocalesCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidLocalesCommand.kt
@@ -1,7 +1,7 @@
 package ftl.cli.firebase.test.android
 
-import ftl.cli.firebase.test.android.configuration.AndroidLocalesDescribeCommand
-import ftl.cli.firebase.test.android.configuration.AndroidLocalesListCommand
+import ftl.cli.firebase.test.android.locales.AndroidLocalesDescribeCommand
+import ftl.cli.firebase.test.android.locales.AndroidLocalesListCommand
 import ftl.util.PrintHelp
 import picocli.CommandLine
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/locales/AndroidLocalesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/locales/AndroidLocalesDescribeCommand.kt
@@ -1,37 +1,41 @@
-package ftl.cli.firebase.test.android.configuration
+package ftl.cli.firebase.test.android.locales
 
 import ftl.config.FtlConstants
-import ftl.domain.ListAndroidLocales
+import ftl.domain.DescribeAndroidLocales
 import ftl.domain.invoke
 import picocli.CommandLine
 
 @CommandLine.Command(
-    name = "list",
+    name = "describe",
     headerHeading = "",
     synopsisHeading = "%n",
     descriptionHeading = "%n@|bold,underline Description:|@%n%n",
     parameterListHeading = "%n@|bold,underline Parameters:|@%n",
     optionListHeading = "%n@|bold,underline Options:|@%n",
-    header = ["Print current list of locales available to test against"],
-    description = ["Print current list of Android locales available to test against"],
+    header = ["Describe a locales "],
     usageHelpAutoWidth = true
 )
-class AndroidLocalesListCommand :
+class AndroidLocalesDescribeCommand :
     Runnable,
-    ListAndroidLocales {
+    DescribeAndroidLocales {
+
+    @CommandLine.Parameters(
+        index = "0",
+        arity = "1",
+        paramLabel = "LOCALE",
+        defaultValue = "",
+        description = [
+            "The locale to describe, found" +
+                " using \$ gcloud firebase test android locales list\n."
+        ]
+    )
+    override var locale: String = ""
 
     @CommandLine.Option(
         names = ["-c", "--config"],
         description = ["YAML config file path"]
     )
     override var configPath: String = FtlConstants.defaultAndroidConfig
-
-    @CommandLine.Option(
-        names = ["-h", "--help"],
-        usageHelp = true,
-        description = ["Prints this help message"]
-    )
-    var usageHelpRequested: Boolean = false
 
     override fun run() = invoke()
 }

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/locales/AndroidLocalesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/locales/AndroidLocalesListCommand.kt
@@ -1,41 +1,37 @@
-package ftl.cli.firebase.test.android.configuration
+package ftl.cli.firebase.test.android.locales
 
 import ftl.config.FtlConstants
-import ftl.domain.DescribeAndroidLocales
+import ftl.domain.ListAndroidLocales
 import ftl.domain.invoke
 import picocli.CommandLine
 
 @CommandLine.Command(
-    name = "describe",
+    name = "list",
     headerHeading = "",
     synopsisHeading = "%n",
     descriptionHeading = "%n@|bold,underline Description:|@%n%n",
     parameterListHeading = "%n@|bold,underline Parameters:|@%n",
     optionListHeading = "%n@|bold,underline Options:|@%n",
-    header = ["Describe a locales "],
+    header = ["Print current list of locales available to test against"],
+    description = ["Print current list of Android locales available to test against"],
     usageHelpAutoWidth = true
 )
-class AndroidLocalesDescribeCommand :
+class AndroidLocalesListCommand :
     Runnable,
-    DescribeAndroidLocales {
-
-    @CommandLine.Parameters(
-        index = "0",
-        arity = "1",
-        paramLabel = "LOCALE",
-        defaultValue = "",
-        description = [
-            "The locale to describe, found" +
-                " using \$ gcloud firebase test android locales list\n."
-        ]
-    )
-    override var locale: String = ""
+    ListAndroidLocales {
 
     @CommandLine.Option(
         names = ["-c", "--config"],
         description = ["YAML config file path"]
     )
     override var configPath: String = FtlConstants.defaultAndroidConfig
+
+    @CommandLine.Option(
+        names = ["-h", "--help"],
+        usageHelp = true,
+        description = ["Prints this help message"]
+    )
+    var usageHelpRequested: Boolean = false
 
     override fun run() = invoke()
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/locales/AndroidLocalesDescribeCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/locales/AndroidLocalesDescribeCommandTest.kt
@@ -1,4 +1,4 @@
-package ftl.cli.firebase.test.android.configuration
+package ftl.cli.firebase.test.android.locales
 
 import ftl.android.AndroidCatalog
 import ftl.run.exception.FlankConfigurationError

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/locales/AndroidLocalesListCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/locales/AndroidLocalesListCommandTest.kt
@@ -1,4 +1,4 @@
-package ftl.cli.firebase.test.android.configuration
+package ftl.cli.firebase.test.android.locales
 
 import com.google.common.truth.Truth.assertThat
 import ftl.android.AndroidCatalog


### PR DESCRIPTION
Fixes #1706 

Rename package `ftl.cli.firebase.test.android.configuration` to `ftl.cli.firebase.test.android.locales`

## Test Plan
> How do we know the code works?

Flank build and run as usual
