### PR TITLE
fix: Removed mandatory GitHub token on artifacts downloading

### DIFF
--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -26,7 +26,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.9.5"
+version = "1.9.6"
 group = "com.github.flank"
 
 application {

--- a/flank-scripts/src/main/kotlin/flank/scripts/data/github/GithubApi.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/data/github/GithubApi.kt
@@ -205,10 +205,10 @@ fun Request.appendGitHubHeaders(githubToken: String, contentType: String = "appl
 fun githubRepo(
     token: String,
     repoPath: String
-): Repo =
-    RtGithub(token)
-        .repos()
-        .get(Coordinates.Simple(repoPath))
+): Repo = when {
+    token.isEmpty() -> RtGithub()
+    else -> RtGithub(token)
+}.repos().get(Coordinates.Simple(repoPath))
 
 fun Repo.getRelease(tag: String): Release.Smart? =
     Releases.Smart(releases()).run {

--- a/flank-scripts/src/main/kotlin/flank/scripts/ops/testartifacts/Helpers.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/ops/testartifacts/Helpers.kt
@@ -4,7 +4,7 @@ import com.jcabi.github.Repo
 import flank.common.config.flankTestArtifactsRepository
 import flank.scripts.data.github.githubRepo
 import flank.scripts.utils.currentGitBranch
-import flank.scripts.utils.getEnv
+import flank.scripts.utils.getEnvOrDefault
 import java.io.File
 
 const val GITHUB_TOKEN_ENV_KEY = "GITHUB_TOKEN"
@@ -17,4 +17,5 @@ val File.testArtifacts: File get() = resolve(TEST_ARTIFACTS_PATH).apply { if (!e
 
 fun File.testArtifacts(branch: String = currentGitBranch()): File = testArtifacts.resolve(branch)
 
-internal fun testArtifactsRepo(): Repo = githubRepo(getEnv(GITHUB_TOKEN_ENV_KEY), flankTestArtifactsRepository)
+internal fun testArtifactsRepo(): Repo =
+    githubRepo(getEnvOrDefault(GITHUB_TOKEN_ENV_KEY, ""), flankTestArtifactsRepository)

--- a/flank-scripts/src/main/kotlin/flank/scripts/utils/Env.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/utils/Env.kt
@@ -3,4 +3,7 @@ package flank.scripts.utils
 fun getEnv(key: String): String =
     System.getenv(key) ?: throw RuntimeException("Environment variable '$key' not found!")
 
+fun getEnvOrDefault(key: String, default: String): String =
+    System.getenv(key) ?: default
+
 val isWindows: Boolean = System.getProperty("os.name").startsWith("Windows")


### PR DESCRIPTION
Fixes #1695 

## Test Plan
> How do we know the code works?

Flank should download test artifacts without any exceptions when GitHub token is not set in environment variables.
