### PR TITLE
fix: Fix entrypoint file name

### DIFF
--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -155,7 +155,7 @@ tasks.withType<KotlinCompile>().configureEach {
 
 application {
     // unfortunately shadowJar task seems not to be working correctly with new property based approach
-    mainClassName = "ftl.MainKt"
+    mainClassName = "ftl.Main"
 }
 
 repositories {

--- a/test_runner/src/main/kotlin/ftl/Main.kt
+++ b/test_runner/src/main/kotlin/ftl/Main.kt
@@ -1,3 +1,4 @@
+@file:JvmName("Main")
 package ftl
 
 import ftl.presentation.cli.MainCommand

--- a/test_runner/src/test/kotlin/ftl/MainTest.kt
+++ b/test_runner/src/test/kotlin/ftl/MainTest.kt
@@ -10,6 +10,7 @@ import org.junit.Test
 import org.junit.contrib.java.lang.system.ExpectedSystemExit
 import org.junit.contrib.java.lang.system.SystemErrRule
 import org.junit.contrib.java.lang.system.SystemOutRule
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import picocli.CommandLine
 
@@ -24,6 +25,9 @@ class MainTest {
 
     @get:Rule
     val systemExit: ExpectedSystemExit = ExpectedSystemExit.none()
+
+    @get:Rule
+    val root = TemporaryFolder()
 
     private fun assertMainHelpStrings(output: String) {
         assertThat(output.normalizeLineEnding()).contains(
@@ -104,16 +108,20 @@ class MainTest {
 
     @Test
     fun `flank entrypoint should be ftl_Main`() {
+        // For reference: https://github.com/Flank/flank/issues/1780
+
+        val logFile = root.newFile()
         val result = ProcessBuilder(
             "java",
             "-cp",
             System.getProperty("java.class.path"),
             "ftl.Main"
         )
-            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .redirectOutput(logFile)
             .redirectError(ProcessBuilder.Redirect.INHERIT)
             .start().waitFor()
 
         assertEquals("Process did not finish with exit code 0, check entry point", 0, result)
+        assertMainHelpStrings(logFile.readText())
     }
 }

--- a/test_runner/src/test/kotlin/ftl/MainTest.kt
+++ b/test_runner/src/test/kotlin/ftl/MainTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import flank.common.normalizeLineEnding
 import ftl.presentation.cli.MainCommand
 import ftl.test.util.FlankTestRunner
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.ExpectedSystemExit
@@ -99,5 +100,20 @@ class MainTest {
                 "-c=./src/test/kotlin/ftl/fixtures/invalid.yml"
             )
         )
+    }
+
+    @Test
+    fun `flank entrypoint should be ftl_Main`() {
+        val result = ProcessBuilder(
+            "java",
+            "-cp",
+            System.getProperty("java.class.path"),
+            "ftl.Main"
+        )
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .start().waitFor()
+
+        assertEquals("Process did not finish with exit code 0, check entry point", 0, result)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/MainTest.kt
+++ b/test_runner/src/test/kotlin/ftl/MainTest.kt
@@ -121,7 +121,7 @@ class MainTest {
             .redirectError(ProcessBuilder.Redirect.INHERIT)
             .start().waitFor()
 
-        assertEquals("Process did not finish with exit code 0, check entry point", 0, result)
+        assertEquals("Process did not finish with exit code 0, check entrypoint", 0, result)
         assertMainHelpStrings(logFile.readText())
     }
 }


### PR DESCRIPTION
Fixes #1780 

## Test Plan
> How do we know the code works?

1. Run `./gradlew flankFullRun`
2. Unit tests pass
3. Follow 'steps to reproduce' in https://github.com/Flank/flank/issues/1780
    1. Update flank in fladle to 21.04.0 with flankVersion = '21.04.0'
    2. `./gradlew runFlank`
    3. task proceeds without error

## Checklist

- [x] Unit tested
