### PR TITLE
fix: Added workaround for uppercase project name

### DIFF
--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -181,9 +181,10 @@ object ArgsHelper {
         return bucket
     }
 
-    fun getDefaultProjectIdOrNull(): String? = if (useMock) "mockProjectId"
+    fun getDefaultProjectIdOrNull() = (if (useMock) "mock-project-id" else getUserProjectId())?.toLowerCase()
+
     // Allow users control over project by checking using Google's logic first before falling back to JSON.
-    else fromUserProvidedCredentials()
+    private fun getUserProjectId(): String? = fromUserProvidedCredentials()
         ?: ServiceOptions.getDefaultProjectId()?.let { if (it.isBlank()) null else it }
         ?: fromDefaultCredentials()
 

--- a/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateCommonArgs.kt
@@ -16,7 +16,7 @@ fun CommonConfig.createCommonArgs(
     // gcloud
     devices = gcloud::devices.require(),
     resultsBucket = ArgsHelper.createGcsBucket(
-        projectId = flank::project.require(),
+        projectId = flank::project.require().toLowerCase(),
         bucket = gcloud::resultsBucket.require()
     ),
     resultsDir = gcloud.resultsDir ?: uniqueObjectName(),
@@ -42,7 +42,7 @@ fun CommonConfig.createCommonArgs(
     testTargetsAlwaysRun = flank::testTargetsAlwaysRun.require(),
     runTimeout = flank::runTimeout.require(),
     fullJUnitResult = flank::fullJUnitResult.require(),
-    project = flank::project.require(),
+    project = flank::project.require().toLowerCase(),
     outputStyle = outputStyle,
     keepFilePath = flank::keepFilePath.require(),
     ignoreFailedTests = flank::ignoreFailedTests.require(),

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -85,7 +85,7 @@ class AndroidArgsTest {
             key1: value1
             key2: value2
           network-profile: LTE
-          project: projectFoo
+          project: project-foo
           results-history-name: android-history
 
           app: $appApk
@@ -233,7 +233,7 @@ class AndroidArgsTest {
                 )
             )
             assert(networkProfile, "LTE")
-            assert(project, "projectFoo")
+            assert(project, "project-foo")
             assert(resultsHistoryName ?: "", "android-history")
 
             // AndroidGcloudYml
@@ -364,7 +364,7 @@ AndroidArgs
         - class example.Test#grantPermission
         - class example.Test#grantPermission2
       disable-sharding: true
-      project: projectFoo
+      project: project-foo
       local-result-dir: results
       full-junit-result: true
       # Android Flank Yml
@@ -441,7 +441,7 @@ AndroidArgs
       files-to-download:
       test-targets-always-run:
       disable-sharding: false
-      project: mockProjectId
+      project: mock-project-id
       local-result-dir: results
       full-junit-result: false
       # Android Flank Yml
@@ -478,7 +478,7 @@ AndroidArgs
             assert(recordVideo, false)
             assert(testTimeout, "15m")
             assert(async, false)
-            assert(project, "mockProjectId")
+            assert(project, "mock-project-id")
             assert(clientDetails, null)
             assert(networkProfile, null)
 
@@ -968,6 +968,21 @@ AndroidArgs
       """
         assertThat(AndroidArgs.load(yaml).project).isEqualTo("a")
         assertThat(AndroidArgs.load(yaml, cli).project).isEqualTo("b")
+    }
+
+    @Test
+    fun `should parse cli project as lower case string`() {
+        val cli = AndroidRunCommand()
+        CommandLine(cli).parseArgs("--project=Upper-B")
+
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+          project: uPPer-a
+      """
+        assertThat(AndroidArgs.load(yaml).project).isEqualTo("upper-a")
+        assertThat(AndroidArgs.load(yaml, cli).project).isEqualTo("upper-b")
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
@@ -144,7 +144,7 @@ class ArgsHelperTest {
     @Test
     fun `getDefaultProjectId succeeds`() {
         assertThat(ArgsHelper.getDefaultProjectIdOrNull())
-            .isEqualTo("mockProjectId")
+            .isEqualTo("mock-project-id")
     }
 
     private fun makeTmpFile(filePath: String): String {

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -60,7 +60,7 @@ class IosArgsTest {
             key1: value1
             key2: value2
           network-profile: LTE
-          project: projectFoo
+          project: project-foo
           results-history-name: ios-history
           other-files:
             com.my.app:/Documents/file.txt: local/file.txt
@@ -182,7 +182,7 @@ flank:
                 )
             )
             assert(networkProfile, "LTE")
-            assert(project, "projectFoo")
+            assert(project, "project-foo")
             assert(resultsHistoryName ?: "", "ios-history")
 
             // IosGcloudYml
@@ -275,7 +275,7 @@ IosArgs
         - b/testBasicSelection
         - b/testBasicSelection2
       disable-sharding: true
-      project: projectFoo
+      project: project-foo
       local-result-dir: results
       run-timeout: 15m
       ignore-failed-tests: true
@@ -341,7 +341,7 @@ IosArgs
       # iOS flank
       test-targets:
       disable-sharding: false
-      project: mockProjectId
+      project: mock-project-id
       local-result-dir: results
       run-timeout: -1
       ignore-failed-tests: false
@@ -375,7 +375,7 @@ IosArgs
             assert(recordVideo, false)
             assert(testTimeout, "15m")
             assert(async, false)
-            assert(project, "mockProjectId")
+            assert(project, "mock-project-id")
             assert(clientDetails, null)
             assert(networkProfile, null)
 
@@ -557,6 +557,21 @@ IosArgs
       """
         assertThat(IosArgs.load(yaml).project).isEqualTo("a")
         assertThat(IosArgs.load(yaml, cli).project).isEqualTo("b")
+    }
+
+    @Test
+    fun `should parse cli project as lower case string`() {
+        val cli = IosRunCommand()
+        CommandLine(cli).parseArgs("--project=Upper-B")
+
+        val yaml = """
+        gcloud:
+          test: $testPath
+          xctestrun-file: $xctestrunFile
+          project: uPPer-a
+      """
+        assertThat(IosArgs.load(yaml).project).isEqualTo("upper-a")
+        assertThat(IosArgs.load(yaml, cli).project).isEqualTo("upper-b")
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/RefreshCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/RefreshCommandTest.kt
@@ -42,7 +42,7 @@ class RefreshCommandTest {
                 "matrixId": "matrix-1",
                 "state": "FINISHED",
                 "gcsPath": "1",
-                "webLink": "https://console.firebase.google.com/project/mockProjectId/testlab/histories/1/matrices/1/executions/1",
+                "webLink": "https://console.firebase.google.com/project/mock-project-id/testlab/histories/1/matrices/1/executions/1",
                 "downloaded": false,
                 "billableVirtualMinutes": 1,
                 "billablePhysicalMinutes": 0,


### PR DESCRIPTION
Fixes #1789 

FTL API does not work properly with upper case letters in the project name, it does not report any issues, but results are empty. The project name could be just lower case, so this PR makes all projects names lower case, to make them work properly with FTL API

## Test Plan
> How do we know the code works?

1. Run tests with the real project name, but make some letters upper case (ex. `Flank-Open-Source`)
2. All tests should run normally without any problems

## Checklist

- [x] Unit tested
