### PR TITLE
fix: Fix missing junit report in legacy mode

### DIFF
--- a/integration_tests/src/test/kotlin/integration/LegacyResultIT.kt
+++ b/integration_tests/src/test/kotlin/integration/LegacyResultIT.kt
@@ -1,0 +1,92 @@
+package integration
+
+import FlankCommand
+import com.google.common.truth.Truth
+import org.junit.Test
+import run
+import utils.CONFIGS_PATH
+import utils.FLANK_JAR_PATH
+import utils.androidRunCommands
+import utils.asOutputReport
+import utils.assertCostMatches
+import utils.assertExitCode
+import utils.assertTestCountMatches
+import utils.findTestDirectoryFromOutput
+import utils.firstTestSuiteOverview
+import utils.iosRunCommands
+import utils.json
+import utils.removeUnicode
+import utils.toJUnitXmlFile
+import utils.toOutputReportFile
+
+class LegacyResultIT {
+    private val name = this::class.java.simpleName
+
+    @Test
+    fun androidLegacyJUnitResultTest() {
+        val result = FlankCommand(
+            flankPath = FLANK_JAR_PATH,
+            ymlPath = "$CONFIGS_PATH/flank_android_single_legacy.yml",
+            params = androidRunCommands
+        ).run(
+            workingDirectory = "./",
+            testSuite = name
+        )
+
+        assertExitCode(result, 0)
+
+        val resOutput = result.output.removeUnicode()
+        val resultDirectory = resOutput.findTestDirectoryFromOutput()
+        Truth.assertThat(resultDirectory.toJUnitXmlFile().exists()).isTrue()
+
+        val outputReport = resultDirectory.toOutputReportFile().json().asOutputReport()
+
+        Truth.assertThat(outputReport.error).isEmpty()
+        Truth.assertThat(outputReport.cost).isNotNull()
+
+        outputReport.assertCostMatches()
+
+        Truth.assertThat(outputReport.testResults.count()).isEqualTo(1)
+        Truth.assertThat(outputReport.weblinks.count()).isEqualTo(1)
+
+        val testSuiteOverview = outputReport.firstTestSuiteOverview
+
+        testSuiteOverview.assertTestCountMatches(
+            total = 2,
+            skipped = 1
+        )
+    }
+
+    @Test
+    fun iosLegacyJUnitResultTest() {
+        val result = FlankCommand(
+            flankPath = FLANK_JAR_PATH,
+            ymlPath = "$CONFIGS_PATH/flank_ios_single_legacy.yml",
+            params = iosRunCommands
+        ).run(
+            workingDirectory = "./",
+            testSuite = name
+        )
+
+        assertExitCode(result, 0)
+
+        val resOutput = result.output.removeUnicode()
+        val resultDirectory = resOutput.findTestDirectoryFromOutput()
+        Truth.assertThat(resultDirectory.toJUnitXmlFile().exists()).isTrue()
+
+        val outputReport = resultDirectory.toOutputReportFile().json().asOutputReport()
+
+        Truth.assertThat(outputReport.error).isEmpty()
+        Truth.assertThat(outputReport.cost).isNotNull()
+
+        Truth.assertThat(outputReport.testResults.count()).isEqualTo(1)
+        Truth.assertThat(outputReport.weblinks.count()).isEqualTo(1)
+
+        val testSuiteOverview = outputReport.firstTestSuiteOverview
+
+        testSuiteOverview.assertTestCountMatches(
+            total = 17,
+            skipped = 0
+        )
+    }
+}

--- a/integration_tests/src/test/kotlin/integration/LegacyResultIT.kt
+++ b/integration_tests/src/test/kotlin/integration/LegacyResultIT.kt
@@ -1,7 +1,9 @@
 package integration
 
 import FlankCommand
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import flank.common.isWindows
+import org.junit.Assume.assumeFalse
 import org.junit.Test
 import run
 import utils.CONFIGS_PATH
@@ -37,17 +39,17 @@ class LegacyResultIT {
 
         val resOutput = result.output.removeUnicode()
         val resultDirectory = resOutput.findTestDirectoryFromOutput()
-        Truth.assertThat(resultDirectory.toJUnitXmlFile().exists()).isTrue()
+        assertThat(resultDirectory.toJUnitXmlFile().exists()).isTrue()
 
         val outputReport = resultDirectory.toOutputReportFile().json().asOutputReport()
 
-        Truth.assertThat(outputReport.error).isEmpty()
-        Truth.assertThat(outputReport.cost).isNotNull()
+        assertThat(outputReport.error).isEmpty()
+        assertThat(outputReport.cost).isNotNull()
 
         outputReport.assertCostMatches()
 
-        Truth.assertThat(outputReport.testResults.count()).isEqualTo(1)
-        Truth.assertThat(outputReport.weblinks.count()).isEqualTo(1)
+        assertThat(outputReport.testResults.count()).isEqualTo(1)
+        assertThat(outputReport.weblinks.count()).isEqualTo(1)
 
         val testSuiteOverview = outputReport.firstTestSuiteOverview
 
@@ -59,6 +61,7 @@ class LegacyResultIT {
 
     @Test
     fun iosLegacyJUnitResultTest() {
+        assumeFalse(isWindows)
         val result = FlankCommand(
             flankPath = FLANK_JAR_PATH,
             ymlPath = "$CONFIGS_PATH/flank_ios_single_legacy.yml",
@@ -72,15 +75,15 @@ class LegacyResultIT {
 
         val resOutput = result.output.removeUnicode()
         val resultDirectory = resOutput.findTestDirectoryFromOutput()
-        Truth.assertThat(resultDirectory.toJUnitXmlFile().exists()).isTrue()
+        assertThat(resultDirectory.toJUnitXmlFile().exists()).isTrue()
 
         val outputReport = resultDirectory.toOutputReportFile().json().asOutputReport()
 
-        Truth.assertThat(outputReport.error).isEmpty()
-        Truth.assertThat(outputReport.cost).isNotNull()
+        assertThat(outputReport.error).isEmpty()
+        assertThat(outputReport.cost).isNotNull()
 
-        Truth.assertThat(outputReport.testResults.count()).isEqualTo(1)
-        Truth.assertThat(outputReport.weblinks.count()).isEqualTo(1)
+        assertThat(outputReport.testResults.count()).isEqualTo(1)
+        assertThat(outputReport.weblinks.count()).isEqualTo(1)
 
         val testSuiteOverview = outputReport.firstTestSuiteOverview
 

--- a/integration_tests/src/test/resources/cases/flank_android_single_legacy.yml
+++ b/integration_tests/src/test/resources/cases/flank_android_single_legacy.yml
@@ -1,0 +1,8 @@
+gcloud:
+  app: ../test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
+  test: ../test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk
+
+flank:
+  disable-sharding: true
+  output-report: json
+  legacy-junit-result: true

--- a/integration_tests/src/test/resources/cases/flank_ios_single_legacy.yml
+++ b/integration_tests/src/test/resources/cases/flank_ios_single_legacy.yml
@@ -1,0 +1,7 @@
+gcloud:
+  test: "../test_runner/src/test/kotlin/ftl/fixtures/tmp/ios/EarlGreyExample/EarlGreyExample.zip"
+  xctestrun-file: "../test_runner/src/test/kotlin/ftl/fixtures/tmp/ios/EarlGreyExample/EarlGreyExampleSwiftTests.xctestrun"
+
+flank:
+  output-report: json
+  legacy-junit-result: true

--- a/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/NewTestRun.kt
@@ -36,8 +36,8 @@ suspend fun IArgs.newTestRun() = withTimeoutOrNull(parsedTimeout) {
         }
 
         val duration = measureTime {
-            ReportManager.generate(matrixMap, args, testShardChunks, ignoredTests)
             cancelTestsOnTimeout(args.project, matrixMap.map) { fetchArtifacts(matrixMap, args) }
+            ReportManager.generate(matrixMap, args, testShardChunks, ignoredTests)
 
             matrixMap.printMatricesWebLinks(project)
             outputReport.log(matrixMap)


### PR DESCRIPTION
Fixes #1778 

## Test Plan
> How do we know the code works?

All tests should pass, when using android tests with legacy mode Flank should generate JUnitReport in the results directory, performance metrics file should be created.

This pr is a revert of @piotradamczyk5 change related to ```performanceMetrics.json``` creation. I was checking this feature and still works fine. 

To test if ```performanceMetrics.json```  are created:

1. Run any test case with a physical device for e.g.
```  
device:
    - model: starqlteue
      version: 26
```

1.  Check if the Flank output contains a line about uploading ```performanceMetrics.json``` to gcs

```
 Uploading [performanceMetrics.json] to https://console.developers.google.com/storage/browser/test-lab-v9cn46bb990nx-kz69ymd4nm9aq/2021-04-19_07-59-02.195180_AbIK/matrix_0/...
```

1. Check if local matrix directories contain ```performanceMetrics.json``` 

1. Run the same Flank configuration on the current master and compare ```performanceMetrics.json```.

## Test results

```yml

gcloud:
  app: ./test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
  test: ./test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk
  device:
    - model: starqlteue
      version: 26

flank:
  disable-sharding: true
  output-report: json

```

1.  ```performanceMetrics.json``` from this branch [link](https://console.cloud.google.com/storage/browser/_details/test-lab-v9cn46bb990nx-kz69ymd4nm9aq/2021-04-19_08-38-03.546503_fWjv/matrix_0/performanceMetrics.json)

1. ```performanceMetrics.json``` from current master [link](https://console.cloud.google.com/storage/browser/_details/test-lab-v9cn46bb990nx-kz69ymd4nm9aq/2021-04-19_08-57-35.859011_MpIb/matrix_0/performanceMetrics.json?authuser=1)

## Checklist

- [X] Integration tests updated
