### PR TITLE
test: Optimize quota usage in IT

### DIFF
--- a/integration_tests/build.gradle.kts
+++ b/integration_tests/build.gradle.kts
@@ -52,7 +52,7 @@ tasks.register<Test>("integrationTestsAndroid") {
         events("skipped", "failed")
         exceptionFormat = TestExceptionFormat.FULL
     }
-    maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+    maxParallelForks = Runtime.getRuntime().availableProcessors()
 }
 
 tasks.register<Test>("integrationTestsIos") {

--- a/integration_tests/build.gradle.kts
+++ b/integration_tests/build.gradle.kts
@@ -38,17 +38,43 @@ tasks.test {
     }
 }
 
-tasks.register<Test>("integrationTests") {
+tasks.register<Test>("integrationTestsAndroid") {
     group = "Verification"
-    description = "Runs flank integration tests"
+    description = "Runs flank integration tests -- Android"
     filter {
         includeTestsMatching("*IT")
+    }
+    useJUnit {
+        includeCategories = setOf("integration.config.AndroidTest")
+        excludeCategories = setOf("integration.config.IosTest")
     }
     testLogging {
         events("skipped", "failed")
         exceptionFormat = TestExceptionFormat.FULL
     }
     maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+}
+
+tasks.register<Test>("integrationTestsIos") {
+    group = "Verification"
+    description = "Runs flank integration tests -- iOS"
+    filter {
+        includeTestsMatching("*IT")
+    }
+    useJUnit {
+        includeCategories = setOf("integration.config.IosTest")
+        excludeCategories = setOf("integration.config.AndroidTest")
+    }
+    testLogging {
+        events("skipped", "failed")
+        exceptionFormat = TestExceptionFormat.FULL
+    }
+    failFast = true
+}
+
+tasks.register("integrationTests") {
+    dependsOn("integrationTestsAndroid", "integrationTestsIos")
+    tasks["integrationTestsIos"].mustRunAfter("integrationTestsAndroid")
 }
 
 val compileTestKotlin: KotlinCompile by tasks

--- a/integration_tests/src/test/kotlin/integration/AllTestFilteredIT.kt
+++ b/integration_tests/src/test/kotlin/integration/AllTestFilteredIT.kt
@@ -2,7 +2,10 @@ package integration
 
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
+import integration.config.AndroidTest
+import integration.config.IosTest
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -19,6 +22,7 @@ import utils.toOutputReportFile
 class AllTestFilteredIT {
     private val name = this::class.java.simpleName
 
+    @Category(AndroidTest::class)
     @Test
     fun `filter all tests - android`() {
         val name = "$name-android"
@@ -45,6 +49,7 @@ class AllTestFilteredIT {
         assertThat(outputReport.weblinks).isEmpty()
     }
 
+    @Category(IosTest::class)
     @Test
     fun `filter all tests - ios`() {
         val name = "$name-ios"

--- a/integration_tests/src/test/kotlin/integration/CustomShardingIT.kt
+++ b/integration_tests/src/test/kotlin/integration/CustomShardingIT.kt
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.google.common.truth.Truth.assertThat
 import flank.common.isWindows
+import integration.config.AndroidTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.rules.TemporaryFolder
 import run
 import utils.AndroidTestShards
@@ -38,6 +40,7 @@ class CustomShardingIT {
     @get:Rule
     val root = TemporaryFolder()
 
+    @Category(AndroidTest::class)
     @Test
     fun `flank custom sharding -- android`() {
 

--- a/integration_tests/src/test/kotlin/integration/DumpShardsIT.kt
+++ b/integration_tests/src/test/kotlin/integration/DumpShardsIT.kt
@@ -3,8 +3,11 @@ package integration
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
 import flank.common.isWindows
+import integration.config.AndroidTest
+import integration.config.IosTest
 import org.junit.Assume.assumeFalse
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -22,6 +25,7 @@ import java.io.File
 class DumpShardsIT {
     private val name = this::class.java.simpleName
 
+    @Category(AndroidTest::class)
     @Test
     fun `dump shards - android`() {
         val name = "$name-android"
@@ -63,6 +67,7 @@ class DumpShardsIT {
             )
     }
 
+    @Category(IosTest::class)
     @Test
     fun `dump shards - ios`() {
         assumeFalse(isWindows)

--- a/integration_tests/src/test/kotlin/integration/GameloopIT.kt
+++ b/integration_tests/src/test/kotlin/integration/GameloopIT.kt
@@ -5,8 +5,11 @@ import com.google.common.truth.Truth.assertThat
 import flank.common.isLinux
 import flank.common.isMacOS
 import flank.common.isWindows
+import integration.config.AndroidTest
+import integration.config.IosTest
 import org.junit.Assume.assumeFalse
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -24,6 +27,7 @@ class GameloopIT {
 
     private val name = this::class.java.simpleName
 
+    @Category(AndroidTest::class)
     @Test
     fun androidGameloop() {
         val name = "$name-android"
@@ -54,6 +58,7 @@ class GameloopIT {
         assertThat(testAxis.outcome).isEqualTo("success")
     }
 
+    @Category(IosTest::class)
     @Test
     fun iosGameloop() {
         assumeFalse(isWindows)

--- a/integration_tests/src/test/kotlin/integration/IgnoreFailedIT.kt
+++ b/integration_tests/src/test/kotlin/integration/IgnoreFailedIT.kt
@@ -2,7 +2,9 @@ package integration
 
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
+import integration.config.AndroidTest
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -20,6 +22,7 @@ import utils.toOutputReportFile
 class IgnoreFailedIT {
     private val name = this::class.java.simpleName
 
+    @Category(AndroidTest::class)
     @Test
     fun `return with exit code 0 for failed tests`() {
         val result = FlankCommand(

--- a/integration_tests/src/test/kotlin/integration/LegacyResultIT.kt
+++ b/integration_tests/src/test/kotlin/integration/LegacyResultIT.kt
@@ -3,8 +3,11 @@ package integration
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
 import flank.common.isWindows
+import integration.config.AndroidTest
+import integration.config.IosTest
 import org.junit.Assume.assumeFalse
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -24,6 +27,7 @@ import utils.toOutputReportFile
 class LegacyResultIT {
     private val name = this::class.java.simpleName
 
+    @Category(AndroidTest::class)
     @Test
     fun androidLegacyJUnitResultTest() {
         val result = FlankCommand(
@@ -59,6 +63,7 @@ class LegacyResultIT {
         )
     }
 
+    @Category(IosTest::class)
     @Test
     fun iosLegacyJUnitResultTest() {
         assumeFalse(isWindows)

--- a/integration_tests/src/test/kotlin/integration/ManyTestsOnSingleShardIT.kt
+++ b/integration_tests/src/test/kotlin/integration/ManyTestsOnSingleShardIT.kt
@@ -2,7 +2,9 @@ package integration
 
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
+import integration.config.AndroidTest
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -25,6 +27,7 @@ class ManyTestsOnSingleShardIT {
 
     private val name = this::class.java.simpleName
 
+    @Category(AndroidTest::class)
     @Test
     fun `return with exit code 0 and has correct output`() {
         val result = FlankCommand(

--- a/integration_tests/src/test/kotlin/integration/MultipleApksIT.kt
+++ b/integration_tests/src/test/kotlin/integration/MultipleApksIT.kt
@@ -2,7 +2,9 @@ package integration
 
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
+import integration.config.AndroidTest
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -26,6 +28,7 @@ import utils.toOutputReportFile
 class MultipleApksIT {
     private val name = this::class.java.simpleName
 
+    @Category(AndroidTest::class)
     @Test
     fun `flank full option run`() {
         val result = FlankCommand(

--- a/integration_tests/src/test/kotlin/integration/MultipleDevicesIT.kt
+++ b/integration_tests/src/test/kotlin/integration/MultipleDevicesIT.kt
@@ -2,7 +2,9 @@ package integration
 
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
+import integration.config.AndroidTest
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -18,6 +20,7 @@ import utils.toOutputReportFile
 class MultipleDevicesIT {
     private val name = this::class.java.simpleName
 
+    @Category(AndroidTest::class)
     @Test
     fun `run tests on multiple devices - android`() {
         val name = "$name-android"

--- a/integration_tests/src/test/kotlin/integration/RunTimeoutIT.kt
+++ b/integration_tests/src/test/kotlin/integration/RunTimeoutIT.kt
@@ -2,7 +2,9 @@ package integration
 
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
+import integration.config.AndroidTest
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -16,6 +18,8 @@ import utils.toOutputReportFile
 
 class RunTimeoutIT {
     private val name = this::class.java.simpleName
+
+    @Category(AndroidTest::class)
     @Test
     fun `cancel test run on timeout`() {
         val result = FlankCommand(

--- a/integration_tests/src/test/kotlin/integration/SanityRoboIT.kt
+++ b/integration_tests/src/test/kotlin/integration/SanityRoboIT.kt
@@ -2,7 +2,9 @@ package integration
 
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
+import integration.config.AndroidTest
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -16,8 +18,8 @@ import utils.removeUnicode
 import utils.toOutputReportFile
 
 class SanityRoboIT {
-    private val name = this::class.java.simpleName
 
+    @Category(AndroidTest::class)
     @Test
     fun `sanity robo`() {
         val result = FlankCommand(

--- a/integration_tests/src/test/kotlin/integration/TestFilteringIT.kt
+++ b/integration_tests/src/test/kotlin/integration/TestFilteringIT.kt
@@ -2,7 +2,9 @@ package integration
 
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
+import integration.config.AndroidTest
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import run
 import utils.CONFIGS_PATH
 import utils.FLANK_JAR_PATH
@@ -20,6 +22,7 @@ import utils.toOutputReportFile
 class TestFilteringIT {
     private val name = this::class.java.simpleName
 
+    @Category(AndroidTest::class)
     @Test
     fun `run test from only one apk`() {
         val result = FlankCommand(

--- a/integration_tests/src/test/kotlin/integration/config/Categories.kt
+++ b/integration_tests/src/test/kotlin/integration/config/Categories.kt
@@ -1,0 +1,4 @@
+package integration.config
+
+interface AndroidTest
+interface IosTest


### PR DESCRIPTION
PR introduces a category approach in IT. Tests are divided into `AndroidTest` and `IosTest` category. It can be achieved with annotating tests with either `@Category(AndroidTest::class)` or `@Category(IosTest::class)` 

#### Changes:
There are slightly different rules applied to each category.
`AndroidTest` category:
* runs in parallel
* no fail-fast
* runs first

`IosTest` category:
* runs tests sequentially
* with fail-fast
* depends on `AndroidTest` category

For each category 2 new gradle tasks were created `instrumentationTestsAnroid` and `instrumentationTestsIos` -- each runs corresponding category.

`instrumentationTests` task was refactored and now it depends on android and ios tasks, forcing android category tests to run before iOS

#### Great, but what does it give us actually?
Flank project keeps facing exceeded quota problem, mainly due to iOS tests that use physical devices. 

With proposed changes, flank first runs android tests. If 'common' logic (meaning, shared by both android and ios) tests will fail, only virtual devices will be used. Since flank has like 2-3x more android tests we keep parallel settings to make it faster.

Once android category is done, ios starts. A combination of sequential run and `fail-fast: true` will terminate the test run with a minimal number of devices used to detect a problem.

To sum up:
:heavy_plus_sign: test coverage is the same
:heavy_plus_sign: we burn less quota if a problem is found
:heavy_minus_sign: full IT run takes more time, locally, on my machine its `16m 40s` old vs `19m 12s` new --  so it's about +15% longer time run