### PR TITLE
refactor: Refactor data scratch-device model

### DIFF
--- a/test_runner/src/main/kotlin/ftl/adapter/GoogleDeviceModel.kt
+++ b/test_runner/src/main/kotlin/ftl/adapter/GoogleDeviceModel.kt
@@ -1,0 +1,19 @@
+package ftl.adapter
+
+import ftl.adapter.google.toAndroidApiModel
+import ftl.adapter.google.toIosApiModel
+import ftl.api.DeviceModel
+import ftl.client.google.AndroidCatalog
+import ftl.ios.IosCatalog
+
+object GoogleAndroidDeviceModel :
+    DeviceModel.Android.Fetch,
+    (String) -> List<DeviceModel.Android> by { projectId ->
+        AndroidCatalog.getModels(projectId).toAndroidApiModel()
+    }
+
+object GoogleIosDeviceModel :
+    DeviceModel.Ios.Fetch,
+    (String) -> List<DeviceModel.Ios> by { projectId ->
+        IosCatalog.getModels(projectId).toIosApiModel()
+    }

--- a/test_runner/src/main/kotlin/ftl/adapter/google/DeviceModelAdapter.kt
+++ b/test_runner/src/main/kotlin/ftl/adapter/google/DeviceModelAdapter.kt
@@ -1,0 +1,41 @@
+package ftl.adapter.google
+
+import com.google.testing.model.AndroidModel
+import com.google.testing.model.IosModel
+import ftl.api.DeviceModel
+import ftl.environment.orUnknown
+import ftl.environment.orUnspecified
+
+internal fun List<AndroidModel>.toAndroidApiModel(): List<DeviceModel.Android> = map { googleAndroidModel ->
+    DeviceModel.Android(
+        id = googleAndroidModel.id.orUnknown(),
+        name = googleAndroidModel.name.orUnknown(),
+        tags = googleAndroidModel.tags.orEmpty(),
+        screenX = googleAndroidModel.screenX.orUnspecified(),
+        screenY = googleAndroidModel.screenY.orUnspecified(),
+        formFactor = googleAndroidModel.formFactor.orUnknown(),
+        screenDensity = googleAndroidModel.screenDensity.orUnspecified(),
+        supportedVersionIds = googleAndroidModel.supportedVersionIds.orEmpty(),
+        form = googleAndroidModel.form.orUnknown(),
+        brand = googleAndroidModel.brand.orUnknown(),
+        codename = googleAndroidModel.codename.orUnknown(),
+        manufacturer = googleAndroidModel.manufacturer.orUnknown(),
+        thumbnailUrl = googleAndroidModel.thumbnailUrl.orUnknown(),
+        supportedAbis = googleAndroidModel.supportedAbis.orEmpty(),
+        lowFpsVideoRecording = googleAndroidModel.lowFpsVideoRecording ?: false
+    )
+}
+
+internal fun List<IosModel>.toIosApiModel(): List<DeviceModel.Ios> = map { googleiOSModel ->
+    DeviceModel.Ios(
+        googleiOSModel.id.orEmpty(),
+        googleiOSModel.name.orUnknown(),
+        googleiOSModel.tags.orEmpty(),
+        googleiOSModel.screenX.orUnspecified(),
+        googleiOSModel.screenY.orUnspecified(),
+        googleiOSModel.formFactor.orUnknown(),
+        googleiOSModel.screenDensity.orUnspecified(),
+        googleiOSModel.supportedVersionIds.orEmpty(),
+        googleiOSModel.deviceCapabilities.orEmpty()
+    )
+}

--- a/test_runner/src/main/kotlin/ftl/api/DeviceModels.kt
+++ b/test_runner/src/main/kotlin/ftl/api/DeviceModels.kt
@@ -1,0 +1,46 @@
+package ftl.api
+
+import ftl.adapter.GoogleAndroidDeviceModel
+import ftl.adapter.GoogleIosDeviceModel
+
+val fetchDeviceModelAndroid: DeviceModel.Android.Fetch get() = GoogleAndroidDeviceModel
+val fetchDeviceModelIos: DeviceModel.Ios.Fetch get() = GoogleIosDeviceModel
+
+object DeviceModel {
+
+    data class Android(
+        val id: String,
+        val name: String,
+        val tags: List<String>,
+        val screenX: Int,
+        val screenY: Int,
+        val formFactor: String,
+        val screenDensity: Int,
+        val supportedVersionIds: List<String>,
+        val form: String,
+        val brand: String,
+        val codename: String,
+        val manufacturer: String,
+        val thumbnailUrl: String,
+        val supportedAbis: List<String>,
+        val lowFpsVideoRecording: Boolean,
+    ) {
+
+        interface Fetch : (String) -> List<Android>
+    }
+
+    data class Ios(
+        val id: String,
+        val name: String,
+        val tags: List<String>,
+        val screenX: Int,
+        val screenY: Int,
+        val formFactor: String,
+        val screenDensity: Int,
+        val supportedVersionIds: List<String>,
+        val deviceCapabilities: List<String>,
+    ) {
+
+        interface Fetch : (String) -> List<Ios>
+    }
+}

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -1,6 +1,8 @@
 package ftl.args
 
+import com.google.common.annotations.VisibleForTesting
 import flank.common.logLn
+import ftl.api.fetchDeviceModelIos
 import ftl.args.yml.Type
 import ftl.ios.IosCatalog
 import ftl.ios.IosCatalog.getSupportedVersionId
@@ -81,9 +83,16 @@ private fun IosArgs.assertXcodeSupported() = when {
 }
 
 private fun IosArgs.assertDevicesSupported() = devices.forEach { device ->
-    if (!IosCatalog.supportedDevice(device.model, device.version, this.project))
+    if (!isDeviceSupported(device.model, device.version, this.project))
         throw IncompatibleTestDimensionError("iOS ${device.version} on ${device.model} is not a supported\nSupported version ids for '${device.model}': ${device.getSupportedVersionId(project).joinToString()}")
 }
+
+@VisibleForTesting
+internal fun isDeviceSupported(
+    modelId: String,
+    versionId: String,
+    projectId: String
+) = fetchDeviceModelIos(projectId).find { it.id == modelId }?.supportedVersionIds?.contains(versionId) ?: false
 
 private fun IosArgs.assertTestFiles() =
     if (isXcTest) {

--- a/test_runner/src/main/kotlin/ftl/client/google/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/AndroidCatalog.kt
@@ -2,9 +2,9 @@ package ftl.client.google
 
 import com.google.testing.model.AndroidDevice
 import com.google.testing.model.AndroidDeviceCatalog
+import com.google.testing.model.AndroidModel
 import com.google.testing.model.Orientation
 import flank.common.logLn
-import ftl.config.Device
 import ftl.environment.android.getDescription
 import ftl.environment.android.toCliTable
 import ftl.environment.asPrintableTable
@@ -30,14 +30,7 @@ object AndroidCatalog {
             .androidDeviceCatalog
     }
 
-    fun devicesCatalogAsTable(projectId: String) = getModels(projectId).toCliTable()
-
-    fun describeModel(projectId: String, modelId: String) = getModels(projectId).getDescription(modelId)
-
-    private fun getModels(projectId: String) = deviceCatalog(projectId).models
-
-    fun Device.getSupportedVersionId(projectId: String): List<String> = getModels(projectId).find { it.id == model }?.supportedVersionIds
-        ?: emptyList()
+    fun getModels(projectId: String): List<AndroidModel> = deviceCatalog(projectId).models.orEmpty()
 
     fun supportedVersionsAsTable(projectId: String) = getVersionsList(projectId).toCliTable()
 
@@ -58,17 +51,6 @@ object AndroidCatalog {
 
     fun androidVersionIds(projectId: String) =
         versionMap.getOrPut(projectId) { deviceCatalog(projectId).versions.map { it.id } }
-
-    fun supportedDeviceConfig(modelId: String, versionId: String, projectId: String): DeviceConfigCheck {
-        val foundModel = deviceCatalog(projectId).models.find { it.id == modelId } ?: return UnsupportedModelId
-        if (!androidVersionIds(projectId).contains(versionId)) return UnsupportedVersionId
-
-        foundModel.supportedVersionIds?.let {
-            if (!it.contains(versionId)) return IncompatibleModelVersion
-        } ?: return UnsupportedModelId
-
-        return SupportedDeviceConfig
-    }
 
     fun isVirtualDevice(device: AndroidDevice?, projectId: String): Boolean = device
         ?.androidModelId

--- a/test_runner/src/main/kotlin/ftl/domain/DescribeAndroidModels.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/DescribeAndroidModels.kt
@@ -1,8 +1,9 @@
 package ftl.domain
 
 import flank.common.logLn
+import ftl.api.fetchDeviceModelAndroid
 import ftl.args.AndroidArgs
-import ftl.client.google.AndroidCatalog
+import ftl.environment.android.getDescription
 import ftl.run.exception.FlankConfigurationError
 import java.nio.file.Paths
 
@@ -13,5 +14,6 @@ interface DescribeAndroidModels {
 
 operator fun DescribeAndroidModels.invoke() {
     if (modelId.isBlank()) throw FlankConfigurationError("Argument MODEL_ID must be specified.")
-    logLn(AndroidCatalog.describeModel(AndroidArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
+    // TODO move getDescription() and printing presentation layer during refactor of presentation after #1728
+    logLn(fetchDeviceModelAndroid(AndroidArgs.loadOrDefault(Paths.get(configPath)).project).getDescription(modelId))
 }

--- a/test_runner/src/main/kotlin/ftl/domain/DescribeAndroidTestEnvironment.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/DescribeAndroidTestEnvironment.kt
@@ -2,12 +2,14 @@ package ftl.domain
 
 import flank.common.logLn
 import ftl.api.Platform
+import ftl.api.fetchDeviceModelAndroid
 import ftl.api.fetchIpBlocks
 import ftl.api.fetchNetworkProfiles
 import ftl.api.fetchOrientation
 import ftl.api.fetchSoftwareCatalog
 import ftl.args.AndroidArgs
 import ftl.client.google.AndroidCatalog
+import ftl.environment.android.toCliTable
 import ftl.environment.common.toCliTable
 import ftl.environment.toCliTable
 import java.nio.file.Paths
@@ -18,12 +20,11 @@ interface DescribeAndroidTestEnvironment {
 
 fun DescribeAndroidTestEnvironment.invoke() {
     val projectId = AndroidArgs.loadOrDefault(Paths.get(configPath)).project
-    logLn(AndroidCatalog.devicesCatalogAsTable(projectId))
+    logLn(fetchDeviceModelAndroid(projectId).toCliTable()) // TODO move toCliTable() to presentation layer during refactor of presentation after #1728
     logLn(AndroidCatalog.supportedVersionsAsTable(projectId))
     logLn(AndroidCatalog.localesAsTable(projectId))
     logLn(fetchSoftwareCatalog().toCliTable())
     logLn(fetchNetworkProfiles().toCliTable())
-    // TODO move toCliTable() to presentation layer during refactor of presentation after #1728
-    logLn(fetchOrientation(projectId, Platform.ANDROID).toCliTable())
-    logLn(fetchIpBlocks().toCliTable())
+    logLn(fetchOrientation(projectId, Platform.ANDROID).toCliTable()) // TODO move toCliTable() to presentation layer during refactor of presentation after #1728
+    logLn(fetchIpBlocks().toCliTable()) // TODO move toCliTable() to presentation layer during refactor of presentation after #1728
 }

--- a/test_runner/src/main/kotlin/ftl/domain/DescribeIosModels.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/DescribeIosModels.kt
@@ -1,8 +1,10 @@
 package ftl.domain
 
 import flank.common.logLn
+import ftl.api.fetchDeviceModelIos
 import ftl.args.IosArgs
-import ftl.ios.IosCatalog
+import ftl.environment.android.getDescription
+import ftl.environment.ios.getDescription
 import ftl.run.exception.FlankConfigurationError
 import java.nio.file.Paths
 
@@ -13,5 +15,6 @@ interface DescribeIosModels {
 
 operator fun DescribeIosModels.invoke() {
     if (modelId.isBlank()) throw FlankConfigurationError("Argument MODEL_ID must be specified.")
-    logLn(IosCatalog.describeModel(IosArgs.loadOrDefault(Paths.get(configPath)).project, modelId))
+    // TODO move getDescription() and printing presentation layer during refactor of presentation after #1728
+    logLn(fetchDeviceModelIos(IosArgs.loadOrDefault(Paths.get(configPath)).project).getDescription(modelId))
 }

--- a/test_runner/src/main/kotlin/ftl/domain/DescribeIosTestEnvironment.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/DescribeIosTestEnvironment.kt
@@ -2,12 +2,14 @@ package ftl.domain
 
 import flank.common.logLn
 import ftl.api.Platform
+import ftl.api.fetchDeviceModelIos
 import ftl.api.fetchIpBlocks
 import ftl.api.fetchNetworkProfiles
 import ftl.api.fetchOrientation
 import ftl.api.fetchSoftwareCatalog
 import ftl.args.IosArgs
 import ftl.environment.common.toCliTable
+import ftl.environment.ios.toCliTable
 import ftl.environment.toCliTable
 import ftl.ios.IosCatalog
 import java.nio.file.Paths
@@ -18,12 +20,11 @@ interface DescribeIosTestEnvironment {
 
 operator fun DescribeIosTestEnvironment.invoke() {
     val projectId = IosArgs.loadOrDefault(Paths.get(configPath)).project
-    logLn(IosCatalog.devicesCatalogAsTable(projectId))
+    logLn(fetchDeviceModelIos(projectId).toCliTable()) // TODO move toCliTable() and printing presentation layer during refactor of presentation after #1728
     logLn(IosCatalog.softwareVersionsAsTable(projectId))
     logLn(IosCatalog.localesAsTable(projectId))
     logLn(fetchSoftwareCatalog().toCliTable())
     logLn(fetchNetworkProfiles().toCliTable())
-    // TODO move toCliTable() and printing presentation layer during refactor of presentation after #1728
-    logLn(fetchOrientation(projectId, Platform.IOS).toCliTable())
-    logLn(fetchIpBlocks().toCliTable())
+    logLn(fetchOrientation(projectId, Platform.IOS).toCliTable()) // TODO move toCliTable() and printing presentation layer during refactor of presentation after #1728
+    logLn(fetchIpBlocks().toCliTable()) // TODO move toCliTable() and printing presentation layer during refactor of presentation after #1728
 }

--- a/test_runner/src/main/kotlin/ftl/domain/ListAndroidModels.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/ListAndroidModels.kt
@@ -1,8 +1,9 @@
 package ftl.domain
 
 import flank.common.logLn
+import ftl.api.fetchDeviceModelAndroid
 import ftl.args.AndroidArgs
-import ftl.client.google.AndroidCatalog
+import ftl.environment.android.toCliTable
 import java.nio.file.Paths
 
 interface ListAndroidModels {
@@ -10,5 +11,6 @@ interface ListAndroidModels {
 }
 
 operator fun ListAndroidModels.invoke() {
-    logLn(AndroidCatalog.devicesCatalogAsTable(AndroidArgs.loadOrDefault(Paths.get(configPath)).project))
+    // TODO move toCliTable() and printing presentation layer during refactor of presentation after #1728
+    logLn(fetchDeviceModelAndroid(AndroidArgs.loadOrDefault(Paths.get(configPath)).project).toCliTable())
 }

--- a/test_runner/src/main/kotlin/ftl/domain/ListIosModels.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/ListIosModels.kt
@@ -1,8 +1,9 @@
 package ftl.domain
 
 import flank.common.logLn
+import ftl.api.fetchDeviceModelIos
 import ftl.args.IosArgs
-import ftl.ios.IosCatalog
+import ftl.environment.ios.toCliTable
 import java.nio.file.Paths
 
 interface ListIosModels {
@@ -10,5 +11,6 @@ interface ListIosModels {
 }
 
 operator fun ListIosModels.invoke() {
-    logLn(IosCatalog.devicesCatalogAsTable(IosArgs.loadOrDefault(Paths.get(configPath)).project))
+    // TODO move toCliTable() and printing presentation layer during refactor of presentation after #1728
+    logLn(fetchDeviceModelIos(IosArgs.loadOrDefault(Paths.get(configPath)).project).toCliTable())
 }

--- a/test_runner/src/main/kotlin/ftl/environment/TestEnvironmentInfo.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/TestEnvironmentInfo.kt
@@ -19,6 +19,10 @@ internal val tagToSystemOutColorMapper: (String) -> SystemOutColor = {
 }
 
 internal fun String?.orUnknown() = this ?: "UNKNOWN"
+internal fun Int?.orUnspecified() = this ?: UNSPECIFIED
+internal fun Int.isValid() = this != UNSPECIFIED
+
+private const val UNSPECIFIED = Integer.MIN_VALUE
 
 const val MODEL_ID = "MODEL_ID"
 const val MAKE = "MAKE"

--- a/test_runner/src/main/kotlin/ftl/environment/android/AndroidModelDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/android/AndroidModelDescription.kt
@@ -1,13 +1,13 @@
 package ftl.environment.android
 
-import com.google.testing.model.AndroidModel
+import ftl.api.DeviceModel
 import ftl.run.exception.FlankGeneralError
 
-fun List<AndroidModel>.getDescription(modelId: String) = findModel(modelId)?.prepareDescription().orErrorMessage(modelId)
+fun List<DeviceModel.Android>.getDescription(modelId: String) = findModel(modelId)?.prepareDescription().orErrorMessage(modelId)
 
-private fun List<AndroidModel>.findModel(modelId: String) = firstOrNull { it.id == modelId }
+private fun List<DeviceModel.Android>.findModel(modelId: String) = firstOrNull { it.id == modelId }
 
-private fun AndroidModel.prepareDescription() = """
+private fun DeviceModel.Android.prepareDescription() = """
     brand: $brand
     codename: $codename
     form: $form

--- a/test_runner/src/main/kotlin/ftl/environment/android/ListAndroidDevices.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/android/ListAndroidDevices.kt
@@ -1,6 +1,6 @@
 package ftl.environment.android
 
-import com.google.testing.model.AndroidModel
+import ftl.api.DeviceModel
 import ftl.environment.EMULATOR_DEVICE
 import ftl.environment.FORM
 import ftl.environment.MAKE
@@ -14,24 +14,24 @@ import ftl.environment.TestEnvironmentInfo
 import ftl.environment.VIRTUAL_DEVICE
 import ftl.environment.createTableColumnFor
 import ftl.environment.getOrCreateList
-import ftl.environment.orUnknown
+import ftl.environment.isValid
 import ftl.environment.tagToSystemOutColorMapper
 import ftl.util.SystemOutColor
 import ftl.util.applyColorsUsing
 import ftl.util.buildTable
 
-fun List<AndroidModel>.toCliTable() = createTestEnvironmentInfo().createAndroidDevicesTable()
+fun List<DeviceModel.Android>.toCliTable() = createTestEnvironmentInfo().createAndroidDevicesTable()
 
-private fun List<AndroidModel>.createTestEnvironmentInfo() =
+private fun List<DeviceModel.Android>.createTestEnvironmentInfo() =
     fold(mutableMapOf<String, MutableList<String>>()) { devicesInfo, androidDevice ->
         devicesInfo.apply {
-            getOrCreateList(MODEL_ID).add(androidDevice.codename.orUnknown())
-            getOrCreateList(MAKE).add(androidDevice.manufacturer.orUnknown())
-            getOrCreateList(MODEL_NAME).add(androidDevice.name.orUnknown())
-            getOrCreateList(FORM).add(androidDevice.form.orUnknown())
+            getOrCreateList(MODEL_ID).add(androidDevice.codename)
+            getOrCreateList(MAKE).add(androidDevice.manufacturer)
+            getOrCreateList(MODEL_NAME).add(androidDevice.name)
+            getOrCreateList(FORM).add(androidDevice.form)
             getOrCreateList(RESOLUTION).add(androidDevice.resolution)
-            getOrCreateList(OS_VERSION_IDS).add(androidDevice.supportedVersionIds?.joinToString().orEmpty())
-            getOrCreateList(TAGS).add(androidDevice.tags?.joinToString().orEmpty())
+            getOrCreateList(OS_VERSION_IDS).add(androidDevice.supportedVersionIds.joinToString())
+            getOrCreateList(TAGS).add(androidDevice.tags.joinToString())
         }
     }
 
@@ -45,8 +45,8 @@ private fun TestEnvironmentInfo.createAndroidDevicesTable() = buildTable(
     createTableColumnFor(TAGS).applyColorsUsing(tagToSystemOutColorMapper)
 )
 
-private val AndroidModel.resolution
-    get() = if (screenX == null || screenY == null) "UNKNOWN" else "$screenY x $screenX"
+private val DeviceModel.Android.resolution
+    get() = if (screenX.isValid() && screenY.isValid()) "$screenY x $screenX" else "UNKNOWN"
 
 private val formToSystemOutColorMapper: (String) -> SystemOutColor = {
     when (it) {

--- a/test_runner/src/main/kotlin/ftl/environment/ios/IosModelDescription.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ios/IosModelDescription.kt
@@ -1,13 +1,13 @@
 package ftl.environment.ios
 
-import com.google.testing.model.IosModel
+import ftl.api.DeviceModel
 import ftl.run.exception.FlankGeneralError
 
-fun List<IosModel>.getDescription(modelId: String) = findModel(modelId)?.prepareDescription().orErrorMessage(modelId)
+fun List<DeviceModel.Ios>.getDescription(modelId: String) = findModel(modelId)?.prepareDescription().orErrorMessage(modelId)
 
-private fun List<IosModel>.findModel(modelId: String) = firstOrNull { it.id == modelId }
+private fun List<DeviceModel.Ios>.findModel(modelId: String) = firstOrNull { it.id == modelId }
 
-private fun IosModel.prepareDescription() = "".appendList(DEVICE_CAPABILITIES_HEADER, deviceCapabilities)
+private fun DeviceModel.Ios.prepareDescription() = "".appendList(DEVICE_CAPABILITIES_HEADER, deviceCapabilities)
     .appendModelBasicData(this).appendList(SUPPORTED_VERSIONS_HEADER, supportedVersionIds).appendList(TAGS_HEADER, tags).trim()
 
 private fun String.appendList(header: String, items: List<String>?) =
@@ -18,7 +18,7 @@ private fun StringBuilder.appendItems(items: List<String>) = apply {
     items.forEach { appendLine("- $it") }
 }
 
-private fun String.appendModelBasicData(model: IosModel) = StringBuilder(this).appendLine(
+private fun String.appendModelBasicData(model: DeviceModel.Ios) = StringBuilder(this).appendLine(
     """
 formFactor: ${model.formFactor}
 id: ${model.id}

--- a/test_runner/src/main/kotlin/ftl/environment/ios/ListIOsDevices.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ios/ListIOsDevices.kt
@@ -1,6 +1,6 @@
 package ftl.environment.ios
 
-import com.google.testing.model.IosModel
+import ftl.api.DeviceModel
 import ftl.environment.MODEL_ID
 import ftl.environment.MODEL_NAME
 import ftl.environment.OS_VERSION_IDS
@@ -9,26 +9,26 @@ import ftl.environment.TAGS
 import ftl.environment.TestEnvironmentInfo
 import ftl.environment.createTableColumnFor
 import ftl.environment.getOrCreateList
-import ftl.environment.orUnknown
+import ftl.environment.isValid
 import ftl.environment.tagToSystemOutColorMapper
 import ftl.util.applyColorsUsing
 import ftl.util.buildTable
 
-fun List<IosModel>.asPrintableTable() = createTestEnvironmentInfo().createIoDevicesTable()
+fun List<DeviceModel.Ios>.toCliTable() = createTestEnvironmentInfo().createIoDevicesTable()
 
-fun List<IosModel>.createTestEnvironmentInfo() =
+fun List<DeviceModel.Ios>.createTestEnvironmentInfo() =
     fold(mutableMapOf<String, MutableList<String>>()) { deviceInfo, iOsDevice ->
         deviceInfo.apply {
-            getOrCreateList(MODEL_ID).add(iOsDevice.id.orUnknown())
-            getOrCreateList(MODEL_NAME).add(iOsDevice.name.orUnknown())
+            getOrCreateList(MODEL_ID).add(iOsDevice.id)
+            getOrCreateList(MODEL_NAME).add(iOsDevice.name)
             getOrCreateList(RESOLUTION).add(iOsDevice.resolution)
-            getOrCreateList(OS_VERSION_IDS).add(iOsDevice.supportedVersionIds?.joinToString().orEmpty())
-            getOrCreateList(TAGS).add(iOsDevice.tags?.joinToString().orEmpty())
+            getOrCreateList(OS_VERSION_IDS).add(iOsDevice.supportedVersionIds.joinToString())
+            getOrCreateList(TAGS).add(iOsDevice.tags.joinToString())
         }
     }
 
-private val IosModel.resolution
-    get() = if (screenX == null || screenY == null) "UNKNOWN" else "$screenY x $screenX"
+private val DeviceModel.Ios.resolution
+    get() = if (screenX.isValid() && screenY.isValid()) "$screenY x $screenX" else "UNKNOWN"
 
 private fun TestEnvironmentInfo.createIoDevicesTable() = buildTable(
     createTableColumnFor(MODEL_ID),

--- a/test_runner/src/main/kotlin/ftl/environment/ios/ListIOsSofwareVersions.kt
+++ b/test_runner/src/main/kotlin/ftl/environment/ios/ListIOsSofwareVersions.kt
@@ -11,7 +11,7 @@ import ftl.environment.tagToSystemOutColorMapper
 import ftl.util.applyColorsUsing
 import ftl.util.buildTable
 
-fun List<IosVersion>.asPrintableTable() = createTestEnvironmentInfo().createIOsSoftwareVersionsTable()
+fun List<IosVersion>.toCliTable() = createTestEnvironmentInfo().createIOsSoftwareVersionsTable()
 
 private fun List<IosVersion>.createTestEnvironmentInfo() =
     fold(mutableMapOf<String, MutableList<String>>()) { softwareInfo, softwareVersion ->

--- a/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -1,12 +1,13 @@
 package ftl.ios
 
 import com.google.testing.model.IosDeviceCatalog
+import com.google.testing.model.IosModel
 import com.google.testing.model.Orientation
 import ftl.config.Device
 import ftl.environment.asPrintableTable
 import ftl.environment.getLocaleDescription
-import ftl.environment.ios.asPrintableTable
 import ftl.environment.ios.getDescription
+import ftl.environment.ios.toCliTable
 import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
@@ -19,13 +20,9 @@ object IosCatalog {
     private val catalogMap: MutableMap<String, IosDeviceCatalog> = mutableMapOf()
     private val xcodeMap: MutableMap<String, List<String>> = mutableMapOf()
 
-    fun devicesCatalogAsTable(projectId: String) = getModels(projectId).asPrintableTable()
+    fun getModels(projectId: String): List<IosModel> = iosDeviceCatalog(projectId).models.orEmpty()
 
-    fun describeModel(projectId: String, modelId: String) = getModels(projectId).getDescription(modelId)
-
-    private fun getModels(projectId: String) = iosDeviceCatalog(projectId).models
-
-    fun softwareVersionsAsTable(projectId: String) = getVersionsList(projectId).asPrintableTable()
+    fun softwareVersionsAsTable(projectId: String) = getVersionsList(projectId).toCliTable()
 
     fun describeSoftwareVersion(projectId: String, versionId: String) =
         getVersionsList(projectId).getDescription(versionId)
@@ -45,12 +42,6 @@ object IosCatalog {
 
     private fun xcodeVersions(projectId: String) =
         xcodeMap.getOrPut(projectId) { iosDeviceCatalog(projectId).xcodeVersions.map { it.version } }
-
-    fun supportedDevice(
-        modelId: String,
-        versionId: String,
-        projectId: String
-    ) = iosDeviceCatalog(projectId).models.find { it.id == modelId }?.supportedVersionIds?.contains(versionId) ?: false
 
     fun Device.getSupportedVersionId(projectId: String): List<String> = iosDeviceCatalog(projectId).models.find { it.id == model }?.supportedVersionIds
         ?: emptyList()

--- a/test_runner/src/test/kotlin/ftl/android/AndroidCatalogTest.kt
+++ b/test_runner/src/test/kotlin/ftl/android/AndroidCatalogTest.kt
@@ -2,11 +2,9 @@ package ftl.android
 
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.model.AndroidDevice
+import ftl.api.fetchDeviceModelAndroid
 import ftl.client.google.AndroidCatalog
-import ftl.client.google.IncompatibleModelVersion
-import ftl.client.google.SupportedDeviceConfig
-import ftl.client.google.UnsupportedModelId
-import ftl.client.google.UnsupportedVersionId
+import ftl.environment.android.toCliTable
 import ftl.test.util.FlankTestRunner
 import io.mockk.every
 import io.mockk.mockk
@@ -28,20 +26,6 @@ class AndroidCatalogTest {
     @Test
     fun androidModelIds() {
         assertThat(AndroidCatalog.androidModelIds(projectId)).isNotEmpty()
-    }
-
-    @Test
-    fun supportedDeviceConfig() {
-        assertThat(AndroidCatalog.supportedDeviceConfig("ios", "23", projectId)).isEqualTo(UnsupportedModelId)
-        assertThat(AndroidCatalog.supportedDeviceConfig("NexusLowRes", "twenty-three", projectId)).isEqualTo(
-            UnsupportedVersionId
-        )
-        assertThat(AndroidCatalog.supportedDeviceConfig("NexusLowRes", "21", projectId)).isEqualTo(
-            IncompatibleModelVersion
-        )
-        assertThat(AndroidCatalog.supportedDeviceConfig("NexusLowRes", "23", projectId)).isEqualTo(SupportedDeviceConfig)
-        assertThat(AndroidCatalog.supportedDeviceConfig("brokenModel", "23", projectId)).isEqualTo(UnsupportedModelId)
-        assertThat(AndroidCatalog.supportedDeviceConfig("does not exist", "23", projectId)).isEqualTo(UnsupportedModelId)
     }
 
     @Test
@@ -85,7 +69,7 @@ class AndroidCatalogTest {
         val expectedSeparatorCount = expectedHeaders.size + 1
 
         // when
-        val devicesTable = AndroidCatalog.devicesCatalogAsTable(projectId)
+        val devicesTable = fetchDeviceModelAndroid(projectId).toCliTable()
         val headers = devicesTable.lines()[1]
 
         // then

--- a/test_runner/src/test/kotlin/ftl/args/SupportedDeviceConfigTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/SupportedDeviceConfigTest.kt
@@ -1,0 +1,29 @@
+package ftl.args
+
+import com.google.common.truth.Truth.assertThat
+import ftl.client.google.IncompatibleModelVersion
+import ftl.client.google.SupportedDeviceConfig
+import ftl.client.google.UnsupportedModelId
+import ftl.client.google.UnsupportedVersionId
+import org.junit.Test
+
+class SupportedDeviceConfigTest {
+
+    private val projectId = ""
+
+    @Test
+    fun supportedDeviceConfig() {
+        assertThat(supportedDeviceConfig("ios", "23", projectId))
+            .isEqualTo(UnsupportedModelId)
+        assertThat(supportedDeviceConfig("NexusLowRes", "twenty-three", projectId))
+            .isEqualTo(UnsupportedVersionId)
+        assertThat(supportedDeviceConfig("NexusLowRes", "21", projectId))
+            .isEqualTo(IncompatibleModelVersion)
+        assertThat(supportedDeviceConfig("NexusLowRes", "23", projectId))
+            .isEqualTo(SupportedDeviceConfig)
+        assertThat(supportedDeviceConfig("brokenModel", "23", projectId))
+            .isEqualTo(UnsupportedModelId)
+        assertThat(supportedDeviceConfig("does not exist", "23", projectId))
+            .isEqualTo(UnsupportedModelId)
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/args/ValidateIosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ValidateIosArgsTest.kt
@@ -1,0 +1,37 @@
+package ftl.args
+
+import com.google.common.truth.Truth.assertThat
+import ftl.api.fetchDeviceModelIos
+import ftl.environment.ios.toCliTable
+import org.junit.Test
+
+class ValidateIosArgsTest {
+
+    private val projectId = ""
+
+    @Test
+    fun supportedDevice() {
+        assertThat(isDeviceSupported("bogus", "11.2", projectId)).isFalse()
+        assertThat(isDeviceSupported("iphone8", "bogus", projectId)).isFalse()
+        assertThat(isDeviceSupported("iphone8", "11.2", projectId)).isTrue()
+    }
+
+    @Test
+    fun `should print available devices as table`() {
+        // given
+        val expectedHeaders = arrayOf("MODEL_ID", "MODEL_NAME", "RESOLUTION", "OS_VERSION_IDS", "TAGS")
+        val expectedSeparatorCount = expectedHeaders.size + 1
+
+        // when
+        val devicesTable = fetchDeviceModelIos(projectId).toCliTable()
+        val headers = devicesTable.lines()[1]
+
+        // then
+        // has all necessary headers
+        expectedHeaders.forEach {
+            assertThat(headers.contains(it)).isTrue()
+        }
+        // number of separators match
+        assertThat(headers.count { it == '│' }).isEqualTo(expectedSeparatorCount)
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/environment/android/AndroidModelDescriptionTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/android/AndroidModelDescriptionTest.kt
@@ -1,6 +1,6 @@
 package ftl.environment.android
 
-import com.google.testing.model.AndroidModel
+import ftl.api.DeviceModel
 import ftl.run.exception.FlankGeneralError
 import ftl.test.util.TestHelper.getThrowable
 import org.junit.Assert
@@ -10,23 +10,24 @@ class AndroidModelDescriptionTest {
     @Test
     fun `should return model with tag if any tag exists`() {
         val models = listOf(
-            AndroidModel().apply {
-                id = "walleye"
-                codename = "walleye"
-                brand = "Google"
-                form = "PHYSICAL"
-                formFactor = "PHONE"
-                manufacturer = "Google"
-                name = "Pixel 2"
-                screenDensity = 420
-                screenX = 1080
-                screenY = 1920
-                supportedAbis = listOf("arm64-v8a", "armeabi-v7a", "armeabi")
-                supportedVersionIds = listOf("26", "27", "28")
-                tags = listOf("default")
+            DeviceModel.Android(
+                id = "walleye",
+                codename = "walleye",
+                brand = "Google",
+                form = "PHYSICAL",
+                formFactor = "PHONE",
+                manufacturer = "Google",
+                name = "Pixel 2",
+                screenDensity = 420,
+                screenX = 1080,
+                screenY = 1920,
+                supportedAbis = listOf("arm64-v8a", "armeabi-v7a", "armeabi"),
+                supportedVersionIds = listOf("26", "27", "28"),
                 thumbnailUrl =
-                    "https://lh3.googleusercontent.com/j4urvb3lXTaFGZI6IzHmAjum2HQVID1OHPhDB7dOzRvXb2WscSX2RFwEEFFSYhajqRO5Yu0e6FYQ"
-            }
+                "https://lh3.googleusercontent.com/j4urvb3lXTaFGZI6IzHmAjum2HQVID1OHPhDB7dOzRvXb2WscSX2RFwEEFFSYhajqRO5Yu0e6FYQ",
+                tags = listOf("default"),
+                lowFpsVideoRecording = true
+            )
         )
 
         val modelDescription = models.getDescription("walleye")
@@ -59,22 +60,24 @@ class AndroidModelDescriptionTest {
     @Test
     fun `should return model without tag if no tags`() {
         val models = listOf(
-            AndroidModel().apply {
-                id = "walleye"
-                codename = "walleye"
-                brand = "Google"
-                form = "PHYSICAL"
-                formFactor = "PHONE"
-                manufacturer = "Google"
-                name = "Pixel 2"
-                screenDensity = 420
-                screenX = 1080
-                screenY = 1920
-                supportedAbis = listOf("arm64-v8a", "armeabi-v7a", "armeabi")
-                supportedVersionIds = listOf("26", "27", "28")
+            DeviceModel.Android(
+                id = "walleye",
+                codename = "walleye",
+                brand = "Google",
+                form = "PHYSICAL",
+                formFactor = "PHONE",
+                manufacturer = "Google",
+                name = "Pixel 2",
+                screenDensity = 420,
+                screenX = 1080,
+                screenY = 1920,
+                supportedAbis = listOf("arm64-v8a", "armeabi-v7a", "armeabi"),
+                supportedVersionIds = listOf("26", "27", "28"),
                 thumbnailUrl =
-                    "https://lh3.googleusercontent.com/j4urvb3lXTaFGZI6IzHmAjum2HQVID1OHPhDB7dOzRvXb2WscSX2RFwEEFFSYhajqRO5Yu0e6FYQ"
-            }
+                "https://lh3.googleusercontent.com/j4urvb3lXTaFGZI6IzHmAjum2HQVID1OHPhDB7dOzRvXb2WscSX2RFwEEFFSYhajqRO5Yu0e6FYQ",
+                tags = emptyList(),
+                lowFpsVideoRecording = true
+            )
         )
 
         val modelDescription = models.getDescription("walleye")
@@ -104,7 +107,7 @@ class AndroidModelDescriptionTest {
 
     @Test(expected = FlankGeneralError::class)
     fun `should return error message if model not found and throw FlankGeneralError`() {
-        val versions = listOf<AndroidModel>()
+        val versions = listOf<DeviceModel.Android>()
         val versionName = "test"
         val localesDescription = getThrowable { versions.getDescription(versionName) }
         val expected = "ERROR: '$versionName' is not a valid model"

--- a/test_runner/src/test/kotlin/ftl/environment/ios/IosModelDescriptionTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/ios/IosModelDescriptionTest.kt
@@ -1,6 +1,6 @@
 package ftl.environment.ios
 
-import com.google.testing.model.IosModel
+import ftl.api.DeviceModel
 import ftl.run.exception.FlankGeneralError
 import ftl.test.util.TestHelper.getThrowable
 import org.junit.Assert
@@ -10,17 +10,17 @@ class IosModelDescriptionTest {
     @Test
     fun `should return model with tag if any tag exists`() {
         val models = listOf(
-            IosModel().apply {
-                deviceCapabilities = listOf("accelerometer", "arm64")
-                formFactor = "PHONE"
-                id = "iphone6s"
-                name = "iPhone 6s"
-                screenDensity = 326
-                screenX = 750
-                screenY = 1334
-                supportedVersionIds = listOf("10.3", "11.2")
+            DeviceModel.Ios(
+                deviceCapabilities = listOf("accelerometer", "arm64"),
+                formFactor = "PHONE",
+                id = "iphone6s",
+                name = "iPhone 6s",
+                screenDensity = 326,
+                screenX = 750,
+                screenY = 1334,
+                supportedVersionIds = listOf("10.3", "11.2"),
                 tags = listOf("deprecated=10.3", "deprecated=11.2")
-            }
+            )
         )
 
         val modelDescription = models.getDescription("iphone6s")
@@ -47,16 +47,17 @@ class IosModelDescriptionTest {
     @Test
     fun `should return model without tag if no tags`() {
         val models = listOf(
-            IosModel().apply {
-                deviceCapabilities = listOf("accelerometer", "arm64")
-                formFactor = "PHONE"
-                id = "iphone6s"
-                name = "iPhone 6s"
-                screenDensity = 326
-                screenX = 750
-                screenY = 1334
-                supportedVersionIds = listOf("10.3", "11.2")
-            }
+            DeviceModel.Ios(
+                deviceCapabilities = listOf("accelerometer", "arm64"),
+                formFactor = "PHONE",
+                id = "iphone6s",
+                name = "iPhone 6s",
+                screenDensity = 326,
+                screenX = 750,
+                screenY = 1334,
+                supportedVersionIds = listOf("10.3", "11.2"),
+                tags = emptyList()
+            )
         )
 
         val modelDescription = models.getDescription("iphone6s")
@@ -79,7 +80,7 @@ class IosModelDescriptionTest {
 
     @Test(expected = FlankGeneralError::class)
     fun `should return error message if model not found and throw FlankGeneralError`() {
-        val versions = listOf<IosModel>()
+        val versions = listOf<DeviceModel.Ios>()
         val versionName = "test"
         val localesDescription = getThrowable { versions.getDescription(versionName) }
         val expected = "ERROR: '$versionName' is not a valid model"

--- a/test_runner/src/test/kotlin/ftl/ios/IosCatalogTest.kt
+++ b/test_runner/src/test/kotlin/ftl/ios/IosCatalogTest.kt
@@ -11,35 +11,9 @@ class IosCatalogTest {
     private val projectId = ""
 
     @Test
-    fun supportedDevice() {
-        assertThat(IosCatalog.supportedDevice("bogus", "11.2", projectId)).isFalse()
-        assertThat(IosCatalog.supportedDevice("iphone8", "bogus", projectId)).isFalse()
-        assertThat(IosCatalog.supportedDevice("iphone8", "11.2", projectId)).isTrue()
-    }
-
-    @Test
     fun supportedXcode() {
         assertThat(IosCatalog.supportedXcode("10.3", projectId)).isTrue()
         assertThat(IosCatalog.supportedXcode("0.1", projectId)).isFalse()
-    }
-
-    @Test
-    fun `should print available devices as table`() {
-        // given
-        val expectedHeaders = arrayOf("MODEL_ID", "MODEL_NAME", "RESOLUTION", "OS_VERSION_IDS", "TAGS")
-        val expectedSeparatorCount = expectedHeaders.size + 1
-
-        // when
-        val devicesTable = IosCatalog.devicesCatalogAsTable(projectId)
-        val headers = devicesTable.lines()[1]
-
-        // then
-        // has all necessary headers
-        expectedHeaders.forEach {
-            assertThat(headers.contains(it)).isTrue()
-        }
-        // number of separators match
-        assertThat(headers.count { it == '│' }).isEqualTo(expectedSeparatorCount)
     }
 
     @Test


### PR DESCRIPTION
Fixes #1745

## Test Plan
> How do we know the code works?

- Code is refactored according to the description in #1745
- commands working property
  - `android models describe`
  - `ios models describe`
  - `android models list`
  - `ios models describe`
- iOS and Android run validation works properly 

## Checklist

- [x] Unit tested
