### PR TITLE
fix: Add storage dir support

### DIFF
--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -147,7 +147,7 @@ private fun AndroidArgs.assertTestTypes() {
 private fun AndroidArgs.assertDirectoriesToPull() {
     val correctNameRegex = "(/[a-zA-Z0-9_\\-.+]+)+/?".toRegex()
     directoriesToPull
-        .filter { !it.startsWith("/sdcard") && !it.startsWith("/data/local/tmp")  && !it.startsWith("/storage") || !correctNameRegex.matches(it) }
+        .filter { !it.startsWith("/sdcard") && !it.startsWith("/data/local/tmp") && !it.startsWith("/storage") || !correctNameRegex.matches(it) }
         .takeIf { it.isNotEmpty() }
         ?.also {
             throw FlankConfigurationError(

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -127,12 +127,12 @@ private fun AndroidArgs.assertTestTypes() {
 private fun AndroidArgs.assertDirectoriesToPull() {
     val correctNameRegex = "(/[a-zA-Z0-9_\\-.+]+)+/?".toRegex()
     directoriesToPull
-        .filter { !it.startsWith("/sdcard") && !it.startsWith("/data/local/tmp") || !correctNameRegex.matches(it) }
+        .filter { !it.startsWith("/sdcard") && !it.startsWith("/data/local/tmp")  && !it.startsWith("/storage") || !correctNameRegex.matches(it) }
         .takeIf { it.isNotEmpty() }
         ?.also {
             throw FlankConfigurationError(
                 "Invalid value for [directories-to-pull]: Invalid path $it.\n" +
-                    "Path must be absolute paths under /sdcard or /data/local/tmp (for example, --directories-to-pull /sdcard/tempDir1,/data/local/tmp/tempDir2).\n" +
+                    "Path must be absolute paths under /sdcard, /storage, or /data/local/tmp (for example, --directories-to-pull /sdcard/tempDir1,/data/local/tmp/tempDir2).\n" +
                     "Path names are restricted to the characters [a-zA-Z0-9_-./+]. "
             )
         }

--- a/test_runner/src/test/kotlin/ftl/args/ValidateDirectoriesToPullAndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ValidateDirectoriesToPullAndroidArgsTest.kt
@@ -18,6 +18,8 @@ class ValidateDirectoriesToPullAndroidArgsTest {
                 - /sdcard/data/sample
                 - /data/local/tmp/sample
                 - /sdcard/
+                - /storage
+                - /storage/emulated/0/Download
             flank:
               disable-sharding: true
         """.trimIndent()
@@ -50,7 +52,7 @@ class ValidateDirectoriesToPullAndroidArgsTest {
     @Test
     fun `should throw error with bad prefixed paths in directoriesToPull`() {
         // given
-        val expectedErrorMessage = getExpectedMessageForPaths(listOf("/sdcard/data/sample!", "/data/local/tmp/sample#"))
+        val expectedErrorMessage = getExpectedMessageForPaths(listOf("/sdcard/data/sample!", "/data/local/tmp/sample#", "/storage/sample@"))
         val testYaml = """
             gcloud:
               app: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk
@@ -58,6 +60,7 @@ class ValidateDirectoriesToPullAndroidArgsTest {
               directories-to-pull:
                 - /sdcard/data/sample!
                 - /data/local/tmp/sample#
+                - /storage/sample@
             flank:
               disable-sharding: true
         """.trimIndent()
@@ -81,6 +84,7 @@ class ValidateDirectoriesToPullAndroidArgsTest {
                 - /app/
                 - /data/sample
                 - /sdcard/test
+                - /storage/emulated
             flank:
               disable-sharding: true
         """.trimIndent()
@@ -94,6 +98,6 @@ class ValidateDirectoriesToPullAndroidArgsTest {
 
     private fun getExpectedMessageForPaths(badPaths: List<String>) =
         "Invalid value for [directories-to-pull]: Invalid path $badPaths.\n" +
-            "Path must be absolute paths under /sdcard or /data/local/tmp (for example, --directories-to-pull /sdcard/tempDir1,/data/local/tmp/tempDir2).\n" +
+            "Path must be absolute paths under /sdcard, /storage, or /data/local/tmp (for example, --directories-to-pull /sdcard/tempDir1,/data/local/tmp/tempDir2).\n" +
             "Path names are restricted to the characters [a-zA-Z0-9_-./+]. "
 }


### PR DESCRIPTION
Fixes #1873 

## Test Plan
Updated the tests in `ValidateDirectoriesToPullAndroidArgsTest` to include changes in this PR

## Checklist

- [x] Documented
- [x] Unit tested
