### PR TITLE
fix: Fix release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is workaround to prevent failing release when using `ubuntu` machines
