### PR TITLE
feat: Domain layer implementation for android test run Corellium MVP

### DIFF
--- a/corellium/domain/README.md
+++ b/corellium/domain/README.md
@@ -1,0 +1,34 @@
+# Flank-Corellium Domain Layer
+
+This module is specifying public API and internal implementation of flank-corellium use-cases.
+
+## Public API
+
+Functions and structures which are specified directly inside [flank.corellium.domain](./src/main/kotlin/flank/corellium/domain) package.
+
+## Internal implementation
+
+Everything inside nested packages of [flank.corellium.domain](./src/main/kotlin/flank/corellium/domain).
+
+## Design
+
+### Stateful execution
+
+Following specification is suitable for complicated long-running use-cases,
+when becomes convenient to split execution into smaller atomic chunks of work.
+
+#### Definition:
+
+* `Execution` is process which is creating initial `State`, and is running the set of `steps` on it in specific `Context`.
+* `Execution` can pass `Context` to `Step` if needed.
+* `Step` is a suspendable operation that is receiving `State` as the only argument.
+* `Step` must return received or new `State`.
+* `Step` can generate side effects.
+* `State` is a structure used for sharing data between preceding and following `steps`.
+* `Context` is providing arguments and functions for `step`.
+
+#### Utility:
+
+`Transform.kt`
+* [local link](src/main/kotlin/flank/corellium/domain/util/Transform.kt)
+* [github link](https://github.com/Flank/flank/blob/master/corellium/domain/src/main/kotlin/flank/corellium/domain/util/Transform.kt)

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestCorelliumAndroid.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestCorelliumAndroid.kt
@@ -4,6 +4,18 @@ import flank.corellium.api.Authorization
 import flank.corellium.api.CorelliumApi
 import flank.corellium.domain.RunTestCorelliumAndroid.Context
 import flank.corellium.domain.RunTestCorelliumAndroid.State
+import flank.corellium.domain.run.test.android.step.authorize
+import flank.corellium.domain.run.test.android.step.cleanUpInstances
+import flank.corellium.domain.run.test.android.step.createOutputDir
+import flank.corellium.domain.run.test.android.step.dumpShards
+import flank.corellium.domain.run.test.android.step.executeTests
+import flank.corellium.domain.run.test.android.step.finish
+import flank.corellium.domain.run.test.android.step.generateReport
+import flank.corellium.domain.run.test.android.step.installApks
+import flank.corellium.domain.run.test.android.step.invokeDevices
+import flank.corellium.domain.run.test.android.step.parseApksInfo
+import flank.corellium.domain.run.test.android.step.parseTestCasesFromApks
+import flank.corellium.domain.run.test.android.step.prepareShards
 import flank.corellium.domain.util.CreateTransformation
 import flank.corellium.domain.util.execute
 import flank.corellium.log.Instrument
@@ -85,10 +97,18 @@ object RunTestCorelliumAndroid {
 }
 
 operator fun Context.invoke(): Unit = runBlocking {
-    State() execute flowOf {
-        println("Not integrated yet, check following PR:")
-        println("https://github.com/Flank/flank/pull/1897")
-        println("will integrate business logic.")
-        this
-    }
+    State() execute flowOf(
+        authorize(),
+        parseTestCasesFromApks(),
+        prepareShards(),
+        createOutputDir(),
+        dumpShards(),
+        invokeDevices(),
+        installApks(),
+        parseApksInfo(),
+        executeTests(),
+        cleanUpInstances(),
+        generateReport(),
+        finish(),
+    )
 }

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/Authorize.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/Authorize.kt
@@ -1,0 +1,12 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.domain.RunTestCorelliumAndroid
+
+/**
+ * The Initial step required to perform further remote calls to Corellium API.
+ */
+internal fun RunTestCorelliumAndroid.Context.authorize() = RunTestCorelliumAndroid.step {
+    println("* Authorizing")
+    api.authorize(args.credentials).join()
+    this
+}

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/CleanUpInstances.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/CleanUpInstances.kt
@@ -1,0 +1,12 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.domain.RunTestCorelliumAndroid
+
+/**
+ * The step is cleaning instances from changes applied during test execution.
+ */
+internal fun RunTestCorelliumAndroid.Context.cleanUpInstances() = RunTestCorelliumAndroid.step {
+    println("* Cleaning instances")
+    println("TODO") // TODO
+    this
+}

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/CreateOutputDir.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/CreateOutputDir.kt
@@ -1,0 +1,26 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.domain.RunTestCorelliumAndroid
+import java.io.File
+
+/**
+ * The step is creating the output directory for execution results.
+ */
+internal fun RunTestCorelliumAndroid.Context.createOutputDir() = RunTestCorelliumAndroid.step {
+    println("* Preparing output directory")
+    require(args.outputDir.isNotEmpty())
+    val dir = File(args.outputDir)
+    when {
+        !dir.exists() -> {
+            dir.mkdirs()
+            println("Created ${dir.absolutePath}")
+        }
+        !dir.isDirectory -> {
+            throw IllegalStateException("Cannot create output directory, file ${dir.absolutePath} already exist")
+        }
+        else -> {
+            println(println("Already exist ${dir.absolutePath}"))
+        }
+    }
+    this
+}

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/DumpShards.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/DumpShards.kt
@@ -1,0 +1,27 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.domain.RunTestCorelliumAndroid
+import flank.corellium.shard.dumpTo
+import flank.corellium.shard.obfuscate
+import java.io.File
+
+/**
+ * The step is saving calculated shards on drive to output directory.
+ *
+ * require:
+ * * [RunTestCorelliumAndroid.Context.prepareShards]
+ * * [RunTestCorelliumAndroid.Context.createOutputDir]
+ */
+
+internal fun RunTestCorelliumAndroid.Context.dumpShards() = RunTestCorelliumAndroid.step {
+    println("* Dumping shards")
+    val file = File(args.outputDir, ANDROID_SHARD_FILENAME)
+    when (args.obfuscateDumpShards) {
+        true -> obfuscate(shards)
+        else -> shards
+    } dumpTo file.writer()
+    println("Created ${file.absolutePath}")
+    this
+}
+
+private const val ANDROID_SHARD_FILENAME = "android-shards.json"

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ExecuteTests.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ExecuteTests.kt
@@ -1,0 +1,71 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.api.AndroidTestPlan
+import flank.corellium.domain.RunTestCorelliumAndroid
+import flank.corellium.log.Instrument
+import flank.corellium.log.parseAdbInstrumentLog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
+
+/**
+ * The step is executing tests on previously invoked devices.
+ *
+ * require:
+ * * [RunTestCorelliumAndroid.Context.authorize]
+ * * [RunTestCorelliumAndroid.Context.prepareShards]
+ * * [RunTestCorelliumAndroid.Context.invokeDevices]
+ * * [RunTestCorelliumAndroid.Context.installApks]
+ * * [RunTestCorelliumAndroid.Context.parseApksInfo]
+ *
+ * updates:
+ * * [RunTestCorelliumAndroid.State.shards]
+ */
+internal fun RunTestCorelliumAndroid.Context.executeTests() = RunTestCorelliumAndroid.step {
+    println("* Executing tests")
+    val testPlan: AndroidTestPlan.Config = prepareTestPlan()
+    val list = coroutineScope {
+        api.executeTest(testPlan).mapIndexed { index, flow ->
+            async {
+                flow
+                    .flowOn(Dispatchers.IO)
+                    .dropWhile { !it.startsWith("INSTRUMENTATION_STATUS") }
+                    .parseAdbInstrumentLog()
+                    .onEach { status ->
+                        if (status is Instrument.Status) {
+                            val line = "$index: " + status.details.run { "$className#$testName" } + " - " + status.code
+                            println(line)
+                        }
+                    }
+                    .toList()
+            }
+        }.awaitAll()
+    }
+    copy(testResult = list)
+}
+
+/**
+ * Prepare [AndroidTestPlan.Config] for test execution.
+ * It's a simple data mapping, no API calls or logical operations.
+ */
+private fun RunTestCorelliumAndroid.State.prepareTestPlan(): AndroidTestPlan.Config =
+    AndroidTestPlan.Config(
+        shards.mapIndexed { index, shards ->
+            ids[index] to shards.flatMap { shard ->
+                shard.tests.map { test ->
+                    AndroidTestPlan.Shard(
+                        packageName = packageNames.getValue(test.name),
+                        testRunner = testRunners.getValue(test.name),
+                        testCases = test.cases.map { case ->
+                            "class " + case.name
+                        }
+                    )
+                }
+            }
+        }.toMap()
+    )

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/Finish.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/Finish.kt
@@ -1,0 +1,11 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.domain.RunTestCorelliumAndroid
+
+/**
+ * The final step, notifies that execution completes without exceptions.
+ */
+internal fun finish() = RunTestCorelliumAndroid.step {
+    println("* Finish")
+    this
+}

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/GenerateReport.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/GenerateReport.kt
@@ -1,0 +1,58 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.domain.RunTestCorelliumAndroid
+import flank.corellium.log.Instrument
+import flank.junit.JUnit
+import flank.junit.generateJUnitReport
+import flank.junit.writeAsXml
+import java.io.File
+
+/**
+ * The step is generating the summary report basing on the collected state.
+ * Generated JUnit report is saved as formatted xml file
+ *
+ * require:
+ * * [RunTestCorelliumAndroid.Context.executeTests]
+ * * [RunTestCorelliumAndroid.Context.createOutputDir]
+ *
+ */
+internal fun RunTestCorelliumAndroid.Context.generateReport() = RunTestCorelliumAndroid.step {
+    println("* Generating report")
+    val file = File(args.outputDir, JUNIT_REPORT_FILENAME)
+    testResult
+        .prepareInputForJUnit()
+        .generateJUnitReport()
+        .writeAsXml(file.bufferedWriter())
+    println("Created ${file.absolutePath}")
+    this
+}
+
+private const val JUNIT_REPORT_FILENAME = "JUnitReport.xml"
+
+/**
+ * Simple mapper, no logical operations or API calls,
+ * just converting one structure to another.
+ *
+ * @receiver Instrument results of each instance execution
+ * @return prepared input for generating JUnitReport
+ */
+private fun List<List<Instrument>>.prepareInputForJUnit(): List<JUnit.TestResult> =
+    flatMapIndexed { index: Int, list: List<Instrument> ->
+        list.filterIsInstance<Instrument.Status>().map { status ->
+            JUnit.TestResult(
+                suiteName = "shard_$index",
+                testName = status.details.testName,
+                className = status.details.className,
+                startAt = status.startTime,
+                endsAt = status.endTime,
+                stack = listOfNotNull(status.details.stack),
+                status = when (status.code) {
+                    Instrument.Code.PASSED -> JUnit.TestResult.Status.Passed
+                    Instrument.Code.FAILED -> JUnit.TestResult.Status.Failed
+                    Instrument.Code.EXCEPTION -> JUnit.TestResult.Status.Error
+                    Instrument.Code.SKIPPED -> JUnit.TestResult.Status.Skipped
+                    else -> throw IllegalArgumentException("Unsupported status code ${status.code}")
+                }
+            )
+        }
+    }

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/InstallApks.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/InstallApks.kt
@@ -1,0 +1,33 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.api.AndroidApps
+import flank.corellium.domain.RunTestCorelliumAndroid
+import flank.corellium.shard.Shard
+import kotlinx.coroutines.delay
+
+/**
+ * The step is installing required software on android instances.
+ *
+ * require:
+ * * [RunTestCorelliumAndroid.Context.authorize]
+ * * [RunTestCorelliumAndroid.Context.prepareShards]
+ * * [RunTestCorelliumAndroid.Context.invokeDevices]
+ */
+internal fun RunTestCorelliumAndroid.Context.installApks() = RunTestCorelliumAndroid.step {
+    println("* Installing apks")
+    require(shards.size <= ids.size) { "Not enough instances, required ${shards.size} but was $ids.size" }
+    val apks = prepareApkToInstall()
+    api.installAndroidApps(apks).join()
+    // If tests will be executed too fast just after the
+    // app installed, the instrumentation will fail
+    delay(8_000)
+    this
+}
+
+private fun RunTestCorelliumAndroid.State.prepareApkToInstall(): List<AndroidApps> =
+    shards.mapIndexed { index, list: List<Shard.App> ->
+        AndroidApps(
+            instanceId = ids[index],
+            paths = list.flatMap { app -> app.tests.map { test -> test.name } + app.name }
+        )
+    }

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/InvokeDevices.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/InvokeDevices.kt
@@ -1,0 +1,20 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.api.AndroidInstance
+import flank.corellium.domain.RunTestCorelliumAndroid
+import kotlinx.coroutines.flow.toList
+
+/**
+ * The step is invoking amount of instances equal to the previously calculated shards count.
+ * After the successful finish, the instances should be ready tu use.
+ *
+ * require:
+ * * [RunTestCorelliumAndroid.Context.prepareShards]
+ *
+ * updates:
+ * * [RunTestCorelliumAndroid.State.ids]
+ */
+internal fun RunTestCorelliumAndroid.Context.invokeDevices() = RunTestCorelliumAndroid.step {
+    println("* Invoking devices")
+    copy(ids = api.invokeAndroidDevices(AndroidInstance.Config(shards.size)).toList())
+}

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseApkInfo.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseApkInfo.kt
@@ -1,0 +1,29 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.domain.RunTestCorelliumAndroid
+
+/**
+ * The step is parsing information from app and test apk files.
+ *
+ * updates:
+ * * [RunTestCorelliumAndroid.State.packageNames]
+ * * [RunTestCorelliumAndroid.State.testRunners]
+ */
+internal fun RunTestCorelliumAndroid.Context.parseApksInfo() = RunTestCorelliumAndroid.step {
+    println("* Parsing apk info")
+    val packageNames = mutableMapOf<String, String>()
+    val testRunners = mutableMapOf<String, String>()
+    args.apks.map { app ->
+        packageNames[app.path] = api.parsePackageName(app.path)
+
+        app.tests.map { test ->
+            val info = api.parseTestApkInfo(test.path)
+            packageNames[test.path] = info.packageName
+            testRunners[test.path] = info.testRunner
+        }
+    }
+    copy(
+        packageNames = packageNames,
+        testRunners = testRunners
+    )
+}

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseTestCases.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseTestCases.kt
@@ -1,0 +1,20 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.domain.RunTestCorelliumAndroid
+
+/**
+ * The step is parsing the test methods from each test apk.
+ *
+ * updates:
+ * * [RunTestCorelliumAndroid.State.testCases]
+ */
+internal fun RunTestCorelliumAndroid.Context.parseTestCasesFromApks() = RunTestCorelliumAndroid.step {
+    println("* Parsing test cases")
+    copy(
+        testCases = args.apks
+            // Get the list of paths to test apks
+            .flatMap { app -> app.tests.map { test -> test.path } }
+            // Associate parsed test methods to each apk path
+            .associateWith(api.parseTestCases)
+    )
+}

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/PrepareShards.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/PrepareShards.kt
@@ -1,0 +1,49 @@
+package flank.corellium.domain.run.test.android.step
+
+import flank.corellium.domain.RunTestCorelliumAndroid
+import flank.corellium.shard.Shard
+import flank.corellium.shard.calculateShards
+
+/**
+ * The step is calculating shards data.
+ *
+ * require:
+ * * [RunTestCorelliumAndroid.Context.parseTestCasesFromApks]
+ *
+ * updates:
+ * * [RunTestCorelliumAndroid.State.shards]
+ */
+internal fun RunTestCorelliumAndroid.Context.prepareShards() = RunTestCorelliumAndroid.step {
+    println("* Calculating shards")
+    copy(
+        shards = calculateShards(
+            apps = prepareDataForSharding(
+                apks = args.apks,
+                testCases = testCases,
+            ),
+            maxCount = args.maxShardsCount
+        )
+    )
+}
+
+/**
+ * Prepare input data for sharding calculation.
+ * It's a simple data mapping, no API calls or logical operations.
+ */
+private fun prepareDataForSharding(
+    apks: List<RunTestCorelliumAndroid.Args.Apk.App>,
+    testCases: Map<String, List<String>>
+): List<Shard.App> =
+    apks.map { app ->
+        Shard.App(
+            name = app.path,
+            tests = app.tests.map { test ->
+                Shard.Test(
+                    name = test.path,
+                    cases = testCases
+                        .getValue(test.path)
+                        .map(Shard.Test::Case)
+                )
+            }
+        )
+    }

--- a/docs/corellium/steps-dependencies-class.puml
+++ b/docs/corellium/steps-dependencies-class.puml
@@ -1,0 +1,45 @@
+@startuml
+'https://plantuml.com/activity-diagram-beta
+
+'left to right direction
+
+legend left
+  |= Color |= Depends on |
+  |<#LightGreen>| API |
+  |<#LightBlue>| tool |
+end legend
+
+object authorize #LightGreen
+object parseTestCasesFromApks #LightBlue
+object createOutputDir
+object prepareShards #LightBlue
+object dumpShards #LightBlue
+object invokeDevices #LightGreen
+object installApks #LightGreen
+object parseApksInfo #LightBlue
+object executeTests #LightGreen
+object cleanUpInstances #LightGreen
+object generateReport #LightBlue
+object finish
+
+prepareShards --> invokeDevices
+
+prepareShards --> dumpShards
+parseTestCasesFromApks --> prepareShards
+authorize --> invokeDevices
+authorize --> installApks
+authorize --> executeTests
+authorize --> cleanUpInstances
+invokeDevices --> installApks
+invokeDevices --> executeTests
+createOutputDir --> dumpShards
+createOutputDir --> generateReport
+prepareShards --> executeTests
+parseApksInfo --> executeTests
+installApks --> executeTests
+executeTests --> generateReport
+executeTests ..> cleanUpInstances
+cleanUpInstances --> finish
+generateReport --> finish
+
+@enduml


### PR DESCRIPTION
Fixes #1802 

This PR adds a domain logic for `RunTestCorelliumAndroid`.

List of features:
* Parsing test cases & other info from apk.
* Creating and/or invoking android instances on demand.
* Advanced sharding.
  * Many apps and tests in one shard.
  * Tests from one app in many shards.
* Dumping shards to file.
* Executing tests
* Generating JUnitReport.xml

What is currently not supported:
* Smart sharding (using test case durations from previous runs).
* Flaky tests.
* Cleaning up devices after tests.
* Some other not listed stuff.

Module [README.md](https://github.com/Flank/flank/blob/corellium-domain/corellium/domain/README.md)

## Test Plan
> How do we know the code works?

Unit tests pass.
`$ flank corellium test android run -c="flank-corellium-android.yml"` is invoking a fully integrated feature.


## Checklist

- [x] Documented
- [x] Unit tested
