### PR TITLE
refactor: Structural output cancel last run

### DIFF
--- a/test_runner/src/main/kotlin/ftl/domain/CancelLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/CancelLastRun.kt
@@ -1,10 +1,11 @@
 package ftl.domain
 
 import ftl.args.AndroidArgs
+import ftl.presentation.Output
 import ftl.run.cancelLastRun
 
-interface CancelLastRun
+interface CancelLastRun : Output
 
 fun CancelLastRun.invoke() {
-    cancelLastRun(AndroidArgs.default())
+    cancelLastRun(AndroidArgs.default()).out()
 }

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/CancelCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/CancelCommand.kt
@@ -2,6 +2,9 @@ package ftl.presentation.cli.firebase
 
 import ftl.domain.CancelLastRun
 import ftl.domain.invoke
+import ftl.presentation.outputLogger
+import ftl.presentation.throwUnknownType
+import ftl.run.MatrixCancelStatus
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -32,4 +35,11 @@ class CancelCommand :
     var usageHelpRequested: Boolean = false
 
     override fun run() = invoke()
+
+    override val out = outputLogger {
+        when (this) {
+            is MatrixCancelStatus -> mapToMessage()
+            else -> throwUnknownType()
+        }
+    }
 }

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/MatrixCancelStatusMapper.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/MatrixCancelStatusMapper.kt
@@ -1,0 +1,10 @@
+package ftl.presentation.cli.firebase
+
+import flank.common.newLine
+import ftl.config.FtlConstants
+import ftl.run.MatrixCancelStatus
+
+internal fun MatrixCancelStatus.mapToMessage(): String = when (this) {
+    is MatrixCancelStatus.NoMatricesToCancel -> "${FtlConstants.indent}No matrices to cancel$newLine"
+    is MatrixCancelStatus.MatricesCanceled -> "${FtlConstants.indent}Cancelling ${count}x matrices$newLine"
+}

--- a/test_runner/src/main/kotlin/ftl/run/CancelLastRun.kt
+++ b/test_runner/src/main/kotlin/ftl/run/CancelLastRun.kt
@@ -3,7 +3,6 @@ package ftl.run
 import flank.common.logLn
 import ftl.args.IArgs
 import ftl.client.google.GcTestMatrix
-import ftl.config.FtlConstants
 import ftl.json.SavedMatrix
 import ftl.run.common.getLastArgs
 import ftl.run.common.getLastMatrices
@@ -13,34 +12,34 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 // used to cancel and update results from an async run
-fun cancelLastRun(args: IArgs) {
-    runBlocking {
-        val matrixMap = getLastMatrices(args)
-        val lastArgs = getLastArgs(args)
+fun cancelLastRun(args: IArgs): MatrixCancelStatus = runBlocking {
+    val matrixMap = getLastMatrices(args)
+    val lastArgs = getLastArgs(args)
 
-        cancelMatrices(matrixMap.map, lastArgs.project)
-    }
+    cancelMatrices(matrixMap.map, lastArgs.project)
 }
 
 /** Cancel all in progress matrices in parallel **/
-suspend fun cancelMatrices(matrixMap: Map<String, SavedMatrix>, project: String) = coroutineScope {
+suspend fun cancelMatrices(
+    matrixMap: Map<String, SavedMatrix>,
+    project: String
+): MatrixCancelStatus = coroutineScope {
     logLn("CancelMatrices")
 
-    var matrixCount = 0
+    return@coroutineScope matrixMap
+        .filter { matrix -> MatrixState.inProgress(matrix.value.state) }
+        .map { (matrixKey, _) -> matrixKey }
+        .onEach { matrixKey -> launch { GcTestMatrix.cancel(matrixKey, project) } }
+        .toMatrixCancelStatus()
+}
 
-    matrixMap.forEach { matrix ->
-        // Only cancel unfinished
-        if (MatrixState.inProgress(matrix.value.state)) {
-            matrixCount += 1
-            launch { GcTestMatrix.cancel(matrix.key, project) }
-        }
-    }
+private fun List<String>.toMatrixCancelStatus(): MatrixCancelStatus = if (size == 0) {
+    MatrixCancelStatus.NoMatricesToCancel
+} else {
+    MatrixCancelStatus.MatricesCanceled(size)
+}
 
-    if (matrixCount == 0) {
-        logLn(FtlConstants.indent + "No matrices to cancel")
-    } else {
-        logLn(FtlConstants.indent + "Cancelling ${matrixCount}x matrices")
-    }
-
-    logLn()
+sealed class MatrixCancelStatus {
+    object NoMatricesToCancel : MatrixCancelStatus()
+    data class MatricesCanceled(val count: Int) : MatrixCancelStatus()
 }

--- a/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
@@ -10,6 +10,7 @@ import ftl.json.SavedMatrixTest.Companion.testMatrix
 import ftl.json.createSavedMatrix
 import ftl.json.validate
 import ftl.reports.outcome.TestOutcome
+import ftl.run.MatrixCancelStatus
 import ftl.run.cancelMatrices
 import ftl.run.exception.CONFIGURATION_FAIL
 import ftl.run.exception.FTLError
@@ -28,10 +29,8 @@ import ftl.test.util.FlankTestRunner
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.runs
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
@@ -204,7 +203,7 @@ class UtilsTest {
     fun `should terminate process with exit code 1 and cancel running matrices if FlankTimeoutError is thrown`() {
         // given
         mockkStatic("ftl.run.CancelLastRunKt")
-        coEvery { cancelMatrices(any(), any()) } just runs
+        coEvery { cancelMatrices(any(), any()) } returns MatrixCancelStatus.MatricesCanceled(1)
         val exception = FlankTimeoutError(mapOf("anyMatrix" to mockk(relaxed = true)), "anyProject")
 
         // when-then


### PR DESCRIPTION
Fixes #1844

## Test Plan
> How do we know the code works?

- Code is refactored according to description in #1844
- `flank firebase cancel` command works like previously

## Checklist

- [x] Unit tested
