### PR TITLE
feat: Add junit module

### DIFF
--- a/corellium/junit/build.gradle.kts
+++ b/corellium/junit/build.gradle.kts
@@ -1,0 +1,23 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin(Plugins.Kotlin.PLUGIN_JVM)
+    kotlin(Plugins.Kotlin.PLUGIN_SERIALIZATION) version Versions.KOTLIN
+}
+
+repositories {
+    mavenCentral()
+    maven(url = "https://kotlin.bintray.com/kotlinx")
+}
+
+tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
+
+dependencies {
+    implementation(Dependencies.KOTLIN_COROUTINES_CORE)
+
+    implementation(Dependencies.JACKSON_KOTLIN)
+    implementation(Dependencies.JACKSON_YAML)
+    implementation(Dependencies.JACKSON_XML)
+
+    testImplementation(Dependencies.JUNIT)
+}

--- a/corellium/junit/src/main/kotlin/flank/junit/JUnit.kt
+++ b/corellium/junit/src/main/kotlin/flank/junit/JUnit.kt
@@ -13,13 +13,26 @@ import flank.junit.mapper.xmlPrettyWriter
 import java.io.File
 import java.text.SimpleDateFormat
 
+// ========================= Functions =========================
+
 /**
- * Generate [JUnit.Report] from the list of [JUnit.TestResult].
+ * The default way for generating the structural representation of XML JUnit report, from the list of raw test results.
  *
+ * * This early implementation doesn't support flaky tests.
+ * * The list of test case results should be sorted in same order as received from console output
+ *
+ * @receiver list of raw test cases results.
+ * @return structural representation of XML JUnit report
  */
 fun List<JUnit.TestResult>.generateJUnitReport(): JUnit.Report =
     JUnit.Report(mapToTestSuites())
 
+/**
+ * Parse [JUnit.Report] from file path.
+ *
+ * @receiver path to XML JUnit report
+ * @return parsed structural representation of XML JUnit report
+ */
 fun String.parseJUnitReportFromFile(): JUnit.Report =
     File(this).let { file ->
         objectMapper.readValue(file)
@@ -27,8 +40,16 @@ fun String.parseJUnitReportFromFile(): JUnit.Report =
             ?: throw IllegalArgumentException("cannot parse JUnitReport from: $this")
     }
 
+/**
+ * Write JUnite report as formatted XML string.
+ *
+ * @receiver structural representation of XML JUnit report
+ * @return formatted XML string
+ */
 fun JUnit.Report.formatXmlString(): String =
     xmlPrettyWriter.writeValueAsString(this)
+
+// ========================= Structures =========================
 
 /**
  * The scope for JUnit structures

--- a/corellium/junit/src/main/kotlin/flank/junit/JUnit.kt
+++ b/corellium/junit/src/main/kotlin/flank/junit/JUnit.kt
@@ -1,0 +1,180 @@
+package flank.junit
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
+import com.fasterxml.jackson.module.kotlin.readValue
+import flank.junit.mapper.TimeSerializer
+import flank.junit.mapper.mapToTestSuites
+import flank.junit.mapper.objectMapper
+import flank.junit.mapper.readEmptyTestSuites
+import flank.junit.mapper.xmlPrettyWriter
+import java.io.File
+import java.text.SimpleDateFormat
+
+/**
+ * Generate [JUnit.Report] from the list of [JUnit.TestResult].
+ *
+ */
+fun List<JUnit.TestResult>.generateJUnitReport(): JUnit.Report =
+    JUnit.Report(mapToTestSuites())
+
+fun String.parseJUnitReportFromFile(): JUnit.Report =
+    File(this).let { file ->
+        objectMapper.readValue(file)
+            ?: file.readEmptyTestSuites()
+            ?: throw IllegalArgumentException("cannot parse JUnitReport from: $this")
+    }
+
+fun JUnit.Report.formatXmlString(): String =
+    xmlPrettyWriter.writeValueAsString(this)
+
+/**
+ * The scope for JUnit structures
+ *
+ * references:
+ * * [format description](https://help.catchsoftware.com/display/ET/JUnit+Format)
+ * * [xsd schema](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd)
+ */
+object JUnit {
+
+    /**
+     * Compact representation of test case execution result.
+     * Contains all data required to generate JUnitReport.
+     */
+    data class TestResult(
+        val suiteName: String,
+        val testName: String,
+        val className: String,
+        val startAt: Long,
+        val endsAt: Long,
+        val stack: List<String>,
+        val status: Status,
+    ) {
+        enum class Status { Passed, Failed, Error, Skipped }
+    }
+
+    /**
+     * The complete representation of JUnitReport XML file.
+     *
+     * @property testsuites Contains an aggregation of testsuite results
+     */
+    @JacksonXmlRootElement(localName = "testsuites")
+    data class Report(
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @JacksonXmlProperty(localName = "testsuite")
+        val testsuites: List<Suite> = emptyList()
+    )
+
+    /**
+     * Contains the results of the testsuite execution.
+     *
+     * @property name Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents.
+     * @property time Time taken (in seconds) to execute the tests in the suite.
+     * @property timestamp when the test was executed. Timezone may not be specified. ISO8601 datetime pattern.
+     * @property tests The total number of tests in the suite.
+     * @property hostname Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.
+     * @property properties Properties (e.g., environment settings) set during test execution
+     * @property failures The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals.
+     * @property flakes The number of tests classified as flaky.
+     * @property errors The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.
+     * @property skipped The total number of ignored or skipped tests in the suite.
+     * @property systemOut Data that was written to standard out while the test was executed.
+     * @property systemErr Data that was written to standard error while the test was executed.
+     */
+    data class Suite(
+        @JacksonXmlProperty(isAttribute = true)
+        val name: String,
+
+        @JacksonXmlProperty(isAttribute = true)
+        val tests: Int,
+
+        @JacksonXmlProperty(isAttribute = true)
+        val failures: Int,
+
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        @JacksonXmlProperty(isAttribute = true)
+        val flakes: Int = 0,
+
+        @JacksonXmlProperty(isAttribute = true)
+        val errors: Int,
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @JacksonXmlProperty(isAttribute = true)
+        val skipped: Int = 0,
+
+        @JacksonXmlProperty(isAttribute = true)
+        @JsonSerialize(using = TimeSerializer::class)
+        val time: Double,
+
+        @JacksonXmlProperty(isAttribute = true)
+        val timestamp: String,
+
+        @JacksonXmlProperty(isAttribute = true)
+        val hostname: String = "localhost",
+
+        @JacksonXmlProperty(localName = "testcase")
+        val testcases: Collection<Case>,
+
+        // not used
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        val properties: Any? = null,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JacksonXmlProperty(localName = "system-out")
+        val systemOut: Any? = null,
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JacksonXmlProperty(localName = "system-err")
+        val systemErr: Any? = null,
+    )
+
+    /**
+     * Properties: name, classname, and time; are always present except for empty test cases <testcase/>
+     *
+     * @property name Name of the test method.
+     * @property classname Full class name for the class the test method is in.
+     * @property time Time taken (in seconds) to execute the test.
+     * @property failure Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace
+     * @property error Indicates that the test errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace
+     * @property skipped The default value `absent` is used by FilterNotNull to filter out absent `skipped` values.
+     * @property flaky Indicates that the test if flaky. Use null instead of false values.
+     */
+    data class Case(
+        @JacksonXmlProperty(isAttribute = true)
+        val name: String,
+
+        @JacksonXmlProperty(isAttribute = true)
+        val classname: String,
+
+        @JacksonXmlProperty(isAttribute = true)
+        @JsonSerialize(using = TimeSerializer::class)
+        val time: Double,
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        val error: List<String> = emptyList(),
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        val failure: List<String> = emptyList(),
+
+        @JsonInclude(JsonInclude.Include.CUSTOM, valueFilter = FilterNotNull::class)
+        val skipped: Unit? = Unit,
+
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        @JacksonXmlProperty(isAttribute = true)
+        val flaky: Boolean = false,
+    )
+
+    @Suppress("UnusedPrivateClass")
+    private class FilterNotNull {
+        // other != null -> absent (default value)
+        // other == null -> present
+        override fun equals(other: Any?) = other != null
+        override fun hashCode() = javaClass.hashCode()
+    }
+
+    private const val ISO8601_DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ssXXX"
+
+    internal val dateFormat = SimpleDateFormat(ISO8601_DATETIME_PATTERN)
+}

--- a/corellium/junit/src/main/kotlin/flank/junit/mapper/Structural.kt
+++ b/corellium/junit/src/main/kotlin/flank/junit/mapper/Structural.kt
@@ -1,0 +1,29 @@
+package flank.junit.mapper
+
+import flank.junit.JUnit
+
+internal fun List<JUnit.TestResult>.mapToTestSuites() = this
+    .groupBy { case -> case.suiteName }
+    .map { (suiteName, cases: List<JUnit.TestResult>) ->
+        JUnit.Suite(
+            name = suiteName,
+            tests = cases.size,
+            failures = cases.count { it.status == JUnit.TestResult.Status.Failed },
+            errors = cases.count { it.status == JUnit.TestResult.Status.Error },
+            skipped = cases.count { it.status == JUnit.TestResult.Status.Skipped },
+            timestamp = JUnit.dateFormat.format(cases.map { it.startAt }.minOrNull() ?: 0),
+            time = cases.filterNot { it.status == JUnit.TestResult.Status.Skipped }.run {
+                if (isEmpty()) 0.0
+                else (last().endsAt - first().startAt).toDouble() / 1000
+            },
+            testcases = cases.map { case ->
+                JUnit.Case(
+                    name = case.testName,
+                    classname = case.className,
+                    time = (case.endsAt - case.startAt).toDouble() / 1000,
+                    error = if (case.status == JUnit.TestResult.Status.Error) case.stack else emptyList(),
+                    failure = if (case.status == JUnit.TestResult.Status.Failed) case.stack else emptyList(),
+                )
+            }
+        )
+    }

--- a/corellium/junit/src/main/kotlin/flank/junit/mapper/Xml.kt
+++ b/corellium/junit/src/main/kotlin/flank/junit/mapper/Xml.kt
@@ -1,0 +1,46 @@
+package flank.junit.mapper
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import flank.junit.JUnit
+import java.io.File
+import java.util.Locale
+
+internal val xmlModule = JacksonXmlModule().apply { setDefaultUseWrapper(false) }
+
+internal val objectMapper = XmlMapper(xmlModule)
+    .apply {
+        configure(FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL, true)
+        configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
+    }
+    .registerModules(KotlinModule())
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+internal val xmlPrettyWriter = objectMapper.writerWithDefaultPrettyPrinter()
+
+internal class TimeSerializer : JsonSerializer<Double>() {
+    override fun serialize(value: Double, gen: JsonGenerator, serializers: SerializerProvider) {
+        gen.writeString(
+            if (value == 0.0) "0.0"
+            else String.format(Locale.US, "%.3f", value)
+        )
+    }
+}
+
+/**
+ * For <testsuites/> objectMapper is returning null.
+ * This is helper method for fixing this behaviour.
+ */
+internal fun File.readEmptyTestSuites(): JUnit.Report? =
+    JUnit.Report().takeIf {
+        readLines()
+            .filter { it.isNotBlank() }
+            .run { size < 3 && last() == "<testsuites/>" }
+    }

--- a/corellium/junit/src/test/kotlin/flank/junit/FailOnInvalidJUnitReport.kt
+++ b/corellium/junit/src/test/kotlin/flank/junit/FailOnInvalidJUnitReport.kt
@@ -1,0 +1,20 @@
+package flank.junit
+
+import org.junit.Assert
+import org.junit.Test
+import java.lang.IllegalArgumentException
+
+class FailOnInvalidJUnitReport {
+
+    @Test(expected = IllegalArgumentException::class)
+    fun test() {
+        val path = RESOURCES + "JUnitReport_invalid.xml"
+        val parsed = path.parseJUnitReportFromFile()
+
+        println(parsed)
+        Assert.assertEquals(
+            JUnit.Report(),
+            parsed
+        )
+    }
+}

--- a/corellium/junit/src/test/kotlin/flank/junit/GenerateJUnitReport.kt
+++ b/corellium/junit/src/test/kotlin/flank/junit/GenerateJUnitReport.kt
@@ -1,0 +1,106 @@
+package flank.junit
+
+import org.junit.Assert
+import org.junit.Test
+
+class GenerateJUnitReport {
+
+    @Test
+    fun test() {
+        val expected = JUnit.Report(
+            testsuites = listOf(
+                JUnit.Suite(
+                    name = "suite1",
+                    tests = 3,
+                    failures = 1,
+                    errors = 1,
+                    skipped = 0,
+                    time = 8.0,
+                    timestamp = "1970-01-01T01:00:01+01:00",
+                    testcases = listOf(
+                        JUnit.Case(
+                            name = "test1",
+                            classname = "test1.Test1",
+                            time = 4.0,
+                            error = listOf("some error")
+                        ),
+                        JUnit.Case(
+                            name = "test2",
+                            classname = "test1.Test1",
+                            time = 2.0,
+                            failure = listOf("some assertion failed"),
+                        ),
+                        JUnit.Case(
+                            name = "test1",
+                            classname = "test1.Test2",
+                            time = 3.0,
+                        )
+                    )
+                ),
+                JUnit.Suite(
+                    name = "suite2",
+                    tests = 1,
+                    failures = 0,
+                    errors = 0,
+                    skipped = 1,
+                    time = 0.0,
+                    timestamp = "1970-01-01T01:00:00+01:00",
+                    testcases = listOf(
+                        JUnit.Case(
+                            name = "test1",
+                            classname = "test1.Test1",
+                            time = 0.0,
+                        ),
+                    )
+                ),
+            )
+        )
+
+        val testCases = listOf(
+            JUnit.TestResult(
+                testName = "test1",
+                className = "test1.Test1",
+                suiteName = "suite1",
+                startAt = 1_000,
+                endsAt = 5_000,
+                status = JUnit.TestResult.Status.Error,
+                stack = listOf("some error")
+            ),
+            JUnit.TestResult(
+                testName = "test2",
+                className = "test1.Test1",
+                suiteName = "suite1",
+                startAt = 6_000,
+                endsAt = 8_000,
+                status = JUnit.TestResult.Status.Failed,
+                stack = listOf("some assertion failed")
+            ),
+            JUnit.TestResult(
+                testName = "test1",
+                className = "test1.Test2",
+                suiteName = "suite1",
+                startAt = 6_000,
+                endsAt = 9_000,
+                status = JUnit.TestResult.Status.Passed,
+                stack = emptyList()
+            ),
+            JUnit.TestResult(
+                testName = "test1",
+                className = "test1.Test1",
+                suiteName = "suite2",
+                startAt = 0,
+                endsAt = 0,
+                status = JUnit.TestResult.Status.Skipped,
+                stack = emptyList()
+            ),
+        )
+
+        val actual = testCases.generateJUnitReport()
+
+        println(actual.formatXmlString())
+
+        Assert.assertEquals(expected, actual)
+
+    }
+
+}

--- a/corellium/junit/src/test/kotlin/flank/junit/GenerateJUnitReport.kt
+++ b/corellium/junit/src/test/kotlin/flank/junit/GenerateJUnitReport.kt
@@ -16,7 +16,7 @@ class GenerateJUnitReport {
                     errors = 1,
                     skipped = 0,
                     time = 8.0,
-                    timestamp = "1970-01-01T01:00:01+01:00",
+                    timestamp = JUnit.dateFormat.format(1_000),
                     testcases = listOf(
                         JUnit.Case(
                             name = "test1",
@@ -44,7 +44,7 @@ class GenerateJUnitReport {
                     errors = 0,
                     skipped = 1,
                     time = 0.0,
-                    timestamp = "1970-01-01T01:00:00+01:00",
+                    timestamp = JUnit.dateFormat.format(0),
                     testcases = listOf(
                         JUnit.Case(
                             name = "test1",

--- a/corellium/junit/src/test/kotlin/flank/junit/GenerateJUnitReport.kt
+++ b/corellium/junit/src/test/kotlin/flank/junit/GenerateJUnitReport.kt
@@ -100,7 +100,5 @@ class GenerateJUnitReport {
         println(actual.formatXmlString())
 
         Assert.assertEquals(expected, actual)
-
     }
-
 }

--- a/corellium/junit/src/test/kotlin/flank/junit/ParseAndFormatJUnitReport.kt
+++ b/corellium/junit/src/test/kotlin/flank/junit/ParseAndFormatJUnitReport.kt
@@ -9,12 +9,11 @@ class ParseAndFormatJUnitReport {
     @Test
     fun test() {
         val path = RESOURCES + "JUnitReport.xml"
-        val expected = File(path).readText()
+        val expected = File(path).readLines().toTypedArray()
 
         val parsed = path.parseJUnitReportFromFile()
-        val formatted = parsed.formatXmlString()
+        val formatted = parsed.formatXmlString().trim().lines().toTypedArray()
 
-        println(formatted)
-        Assert.assertEquals(expected, formatted)
+        Assert.assertArrayEquals(expected, formatted)
     }
 }

--- a/corellium/junit/src/test/kotlin/flank/junit/ParseAndFormatJUnitReport.kt
+++ b/corellium/junit/src/test/kotlin/flank/junit/ParseAndFormatJUnitReport.kt
@@ -1,0 +1,20 @@
+package flank.junit
+
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+
+class ParseAndFormatJUnitReport {
+
+    @Test
+    fun test() {
+        val path = RESOURCES + "JUnitReport.xml"
+        val expected = File(path).readText()
+
+        val parsed = path.parseJUnitReportFromFile()
+        val formatted = parsed.formatXmlString()
+
+        println(formatted)
+        Assert.assertEquals(expected, formatted)
+    }
+}

--- a/corellium/junit/src/test/kotlin/flank/junit/ParseEmptyJUnitReport.kt
+++ b/corellium/junit/src/test/kotlin/flank/junit/ParseEmptyJUnitReport.kt
@@ -1,0 +1,38 @@
+package flank.junit
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+/**
+ * Various tests for parsing empty test reports in different shapes.
+ */
+@RunWith(Parameterized::class)
+class ParseEmptyJUnitReport(
+    private val name: String
+) {
+
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data() = listOf(
+            "JUnitReport_empty_1.xml",
+            "JUnitReport_empty_2.xml",
+            "JUnitReport_empty_3.xml",
+        )
+    }
+
+    @Test
+    fun test() {
+        val path = RESOURCES + name
+        val parsed = path.parseJUnitReportFromFile()
+
+        println(parsed)
+        Assert.assertEquals(
+            JUnit.Report(),
+            parsed
+        )
+    }
+}

--- a/corellium/junit/src/test/kotlin/flank/junit/Util.kt
+++ b/corellium/junit/src/test/kotlin/flank/junit/Util.kt
@@ -1,0 +1,4 @@
+package flank.junit
+
+const val RESOURCES = "./src/test/resources/"
+const val JUNIT_REPORT = ""

--- a/corellium/junit/src/test/resources/JUnit.xsd
+++ b/corellium/junit/src/test/resources/JUnit.xsd
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--https://raw.githubusercontent.com/windyroad/JUnit-Schema/master/JUnit.xsd-->
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+            Copyright © 2011, Windy Road Technology Pty. Limited
+            The Apache Ant JUnit XML Schema is distributed under the terms of the Apache License Version 2.0 http://www.apache.org/licenses/
+            Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+    </xs:annotation>
+    <xs:element name="testsuite" type="testsuite"/>
+    <xs:simpleType name="ISO8601_DATETIME_PATTERN">
+        <xs:restriction base="xs:dateTime">
+            <xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="testsuites">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:complexContent>
+                            <xs:extension base="testsuite">
+                                <xs:attribute name="package" type="xs:token" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="id" type="xs:int" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:extension>
+                        </xs:complexContent>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:complexType name="testsuite">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Contains the results of exexuting a testsuite</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="properties">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="name" use="required">
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:token">
+                                            <xs:minLength value="1"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:attribute>
+                                <xs:attribute name="value" type="xs:string" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:choice minOccurs="0">
+                        <xs:element name="skipped" />
+                        <xs:element name="error" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:simpleContent>
+                                    <xs:extension base="pre-string">
+                                        <xs:attribute name="message" type="xs:string">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="type" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:extension>
+                                </xs:simpleContent>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="failure">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:simpleContent>
+                                    <xs:extension base="pre-string">
+                                        <xs:attribute name="message" type="xs:string">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="type" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:extension>
+                                </xs:simpleContent>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:choice>
+                    <xs:attribute name="name" type="xs:token" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="classname" type="xs:token" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="time" type="xs:decimal" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="system-out">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="pre-string">
+                        <xs:whiteSpace value="preserve"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="system-err">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="pre-string">
+                        <xs:whiteSpace value="preserve"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="hostname" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="tests" type="xs:int" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="failures" type="xs:int" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="errors" type="xs:int" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">The total number of tests in the suite that errored. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="skipped" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">The total number of ignored or skipped tests in the suite.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="time" type="xs:decimal" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:simpleType name="pre-string">
+        <xs:restriction base="xs:string">
+            <xs:whiteSpace value="preserve"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/corellium/junit/src/test/resources/JUnitReport.xml
+++ b/corellium/junit/src/test/resources/JUnitReport.xml
@@ -1,0 +1,314 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<testsuites>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="3" failures="0" errors="0" skipped="0" time="2.028" timestamp="2021-05-03T01:14:33" hostname="localhost">
+    <testcase name="clickRightButton[0]" classname="com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized" time="1.308"/>
+    <testcase name="clickRightButton[1]" classname="com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized" time="0.349"/>
+    <testcase name="clickRightButton[2]" classname="com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized" time="0.372"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="3" failures="0" errors="0" skipped="0" time="1.998" timestamp="2021-05-03T01:14:23" hostname="localhost">
+    <testcase name="clickRightButton[0: toast toast]" classname="com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed" time="1.340"/>
+    <testcase name="clickRightButton[1: alert alert]" classname="com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed" time="0.328"/>
+    <testcase name="clickRightButton[2: exception exception]" classname="com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed" time="0.331"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="0" errors="0" skipped="0" time="1.386" timestamp="2021-05-03T01:14:37" hostname="localhost">
+    <testcase name="test0" classname="com.example.test_app.InstrumentedTest" time="1.386"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="0" errors="0" skipped="0" time="1.374" timestamp="2021-05-03T01:14:24" hostname="localhost">
+    <testcase name="test2" classname="com.example.test_app.InstrumentedTest" time="1.374"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="0" errors="0" skipped="0" time="1.447" timestamp="2021-05-03T01:14:32" hostname="localhost">
+    <testcase name="testFoo" classname="com.example.test_app.foo.FooInstrumentedTest" time="1.447"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="3" failures="0" errors="0" skipped="0" time="0.014" timestamp="2021-05-03T01:14:39" hostname="localhost">
+    <testcase name="shouldHopefullyPass[0]" classname="com.example.test_app.ParameterizedTest" time="0.005"/>
+    <testcase name="shouldHopefullyPass[1]" classname="com.example.test_app.ParameterizedTest" time="0.004"/>
+    <testcase name="shouldHopefullyPass[2]" classname="com.example.test_app.ParameterizedTest" time="0.004"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="6" failures="0" errors="0" skipped="0" time="3.209" timestamp="2021-05-03T01:14:53" hostname="localhost">
+    <testcase name="clickRightButtonFromMethod(toast, toast) [0]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="1.497"/>
+    <testcase name="clickRightButtonFromMethod(alert, alert) [1]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="0.356"/>
+    <testcase name="clickRightButtonFromMethod(exception, exception) [2]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="0.352"/>
+    <testcase name="clickRightButtonFromAnnotation(toast, toast) [0]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="0.352"/>
+    <testcase name="clickRightButtonFromAnnotation(alert, alert) [1]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="0.327"/>
+    <testcase name="clickRightButtonFromAnnotation(exception, exception) [2]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="0.328"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="0" errors="0" skipped="0" time="1.363" timestamp="2021-05-03T01:14:21" hostname="localhost">
+    <testcase name="test1" classname="com.example.test_app.InstrumentedTest" time="1.363"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="0" errors="0" skipped="0" time="1.376" timestamp="2021-05-03T01:14:49" hostname="localhost">
+    <testcase name="testBar" classname="com.example.test_app.bar.BarInstrumentedTest" time="1.376"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="1" errors="0" skipped="0" time="2.020" timestamp="2021-05-03T01:14:41" hostname="localhost">
+    <testcase name="test1" classname="com.example.test_app.InstrumentedTest" time="2.020">
+      <failure>java.lang.AssertionError
+        at org.junit.Assert.fail(Assert.java:86)
+        at org.junit.Assert.assertTrue(Assert.java:41)
+        at org.junit.Assert.assertTrue(Assert.java:52)
+        at com.example.test_app.BaseInstrumentedTest.testMethod(BaseInstrumentedTest.kt:35)
+        at com.example.test_app.InstrumentedTest.test1(InstrumentedTest.kt:19)
+        at java.lang.reflect.Method.invoke(Native Method)
+        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+        at androidx.test.rule.GrantPermissionRule$RequestPermissionStatement.evaluate(GrantPermissionRule.java:134)
+        at androidx.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:531)
+        at com.example.test_app.screenshot.ScreenshotTestRule$apply$1.evaluate(ScreenshotTestRule.kt:58)
+        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+        at androidx.test.ext.junit.runners.AndroidJUnit4.run(AndroidJUnit4.java:154)
+        at org.junit.runners.Suite.runChild(Suite.java:128)
+        at org.junit.runners.Suite.runChild(Suite.java:27)
+        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+        at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
+        at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:395)
+        at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2145)
+      </failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="3" failures="0" errors="0" skipped="0" time="2.137" timestamp="2021-05-03T01:14:32" hostname="localhost">
+    <testcase name="clickRightButton[0: toast toast]" classname="com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed" time="1.385"/>
+    <testcase name="clickRightButton[1: alert alert]" classname="com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed" time="0.325"/>
+    <testcase name="clickRightButton[2: exception exception]" classname="com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed" time="0.426"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="1" errors="0" skipped="0" time="1.901" timestamp="2021-05-03T01:14:20" hostname="localhost">
+    <testcase name="test0" classname="com.example.test_app.InstrumentedTest" time="1.901">
+      <failure>java.lang.AssertionError
+        at org.junit.Assert.fail(Assert.java:86)
+        at org.junit.Assert.assertTrue(Assert.java:41)
+        at org.junit.Assert.assertTrue(Assert.java:52)
+        at com.example.test_app.BaseInstrumentedTest.testMethod(BaseInstrumentedTest.kt:35)
+        at com.example.test_app.InstrumentedTest.test0(InstrumentedTest.kt:16)
+        at java.lang.reflect.Method.invoke(Native Method)
+        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+        at androidx.test.rule.GrantPermissionRule$RequestPermissionStatement.evaluate(GrantPermissionRule.java:134)
+        at androidx.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:531)
+        at com.example.test_app.screenshot.ScreenshotTestRule$apply$1.evaluate(ScreenshotTestRule.kt:58)
+        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+        at androidx.test.ext.junit.runners.AndroidJUnit4.run(AndroidJUnit4.java:154)
+        at org.junit.runners.Suite.runChild(Suite.java:128)
+        at org.junit.runners.Suite.runChild(Suite.java:27)
+        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+        at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
+        at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:395)
+        at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2145)
+      </failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="1" errors="0" skipped="0" time="1.852" timestamp="2021-05-03T01:14:32" hostname="localhost">
+    <testcase name="testBar" classname="com.example.test_app.bar.BarInstrumentedTest" time="1.852">
+      <failure>java.lang.AssertionError
+        at org.junit.Assert.fail(Assert.java:86)
+        at org.junit.Assert.assertTrue(Assert.java:41)
+        at org.junit.Assert.assertTrue(Assert.java:52)
+        at com.example.test_app.BaseInstrumentedTest.testMethod(BaseInstrumentedTest.kt:35)
+        at com.example.test_app.bar.BarInstrumentedTest.testBar(BarInstrumentedTest.kt:13)
+        at java.lang.reflect.Method.invoke(Native Method)
+        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+        at androidx.test.rule.GrantPermissionRule$RequestPermissionStatement.evaluate(GrantPermissionRule.java:134)
+        at androidx.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:531)
+        at com.example.test_app.screenshot.ScreenshotTestRule$apply$1.evaluate(ScreenshotTestRule.kt:58)
+        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+        at androidx.test.ext.junit.runners.AndroidJUnit4.run(AndroidJUnit4.java:154)
+        at org.junit.runners.Suite.runChild(Suite.java:128)
+        at org.junit.runners.Suite.runChild(Suite.java:27)
+        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+        at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
+        at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:395)
+        at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2145)
+      </failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="6" failures="0" errors="0" skipped="0" time="2.958" timestamp="2021-05-03T01:14:29" hostname="localhost">
+    <testcase name="clickRightButtonFromMethod(toast, toast) [0]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="1.271"/>
+    <testcase name="clickRightButtonFromMethod(alert, alert) [1]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="0.337"/>
+    <testcase name="clickRightButtonFromMethod(exception, exception) [2]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="0.388"/>
+    <testcase name="clickRightButtonFromAnnotation(toast, toast) [0]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="0.338"/>
+    <testcase name="clickRightButtonFromAnnotation(alert, alert) [1]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="0.338"/>
+    <testcase name="clickRightButtonFromAnnotation(exception, exception) [2]" classname="com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner" time="0.287"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="1" errors="0" skipped="0" time="2.017" timestamp="2021-05-03T01:14:38" hostname="localhost">
+    <testcase name="testFoo" classname="com.example.test_app.foo.FooInstrumentedTest" time="2.017">
+      <failure>java.lang.AssertionError
+        at org.junit.Assert.fail(Assert.java:86)
+        at org.junit.Assert.assertTrue(Assert.java:41)
+        at org.junit.Assert.assertTrue(Assert.java:52)
+        at com.example.test_app.BaseInstrumentedTest.testMethod(BaseInstrumentedTest.kt:35)
+        at com.example.test_app.foo.FooInstrumentedTest.testFoo(FooInstrumentedTest.kt:13)
+        at java.lang.reflect.Method.invoke(Native Method)
+        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+        at androidx.test.rule.GrantPermissionRule$RequestPermissionStatement.evaluate(GrantPermissionRule.java:134)
+        at androidx.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:531)
+        at com.example.test_app.screenshot.ScreenshotTestRule$apply$1.evaluate(ScreenshotTestRule.kt:58)
+        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+        at androidx.test.ext.junit.runners.AndroidJUnit4.run(AndroidJUnit4.java:154)
+        at org.junit.runners.Suite.runChild(Suite.java:128)
+        at org.junit.runners.Suite.runChild(Suite.java:27)
+        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+        at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
+        at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:395)
+        at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2145)
+      </failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="3" failures="0" errors="0" skipped="0" time="0.014" timestamp="2021-05-03T01:14:50" hostname="localhost">
+    <testcase name="shouldHopefullyPass[0]" classname="com.example.test_app.ParameterizedTest" time="0.005"/>
+    <testcase name="shouldHopefullyPass[1]" classname="com.example.test_app.ParameterizedTest" time="0.005"/>
+    <testcase name="shouldHopefullyPass[2]" classname="com.example.test_app.ParameterizedTest" time="0.005"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="3" failures="0" errors="0" skipped="0" time="2.053" timestamp="2021-05-03T01:14:26" hostname="localhost">
+    <testcase name="clickRightButton[0]" classname="com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized" time="1.288"/>
+    <testcase name="clickRightButton[1]" classname="com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized" time="0.357"/>
+    <testcase name="clickRightButton[2]" classname="com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized" time="0.407"/>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="1" errors="0" skipped="0" time="1.857" timestamp="2021-05-03T01:14:28" hostname="localhost">
+    <testcase name="test2" classname="com.example.test_app.InstrumentedTest" time="1.857">
+      <failure>java.lang.AssertionError
+        at org.junit.Assert.fail(Assert.java:86)
+        at org.junit.Assert.assertTrue(Assert.java:41)
+        at org.junit.Assert.assertTrue(Assert.java:52)
+        at com.example.test_app.BaseInstrumentedTest.testMethod(BaseInstrumentedTest.kt:35)
+        at com.example.test_app.InstrumentedTest.test2(InstrumentedTest.kt:22)
+        at java.lang.reflect.Method.invoke(Native Method)
+        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+        at androidx.test.rule.GrantPermissionRule$RequestPermissionStatement.evaluate(GrantPermissionRule.java:134)
+        at androidx.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:531)
+        at com.example.test_app.screenshot.ScreenshotTestRule$apply$1.evaluate(ScreenshotTestRule.kt:58)
+        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+        at androidx.test.ext.junit.runners.AndroidJUnit4.run(AndroidJUnit4.java:154)
+        at org.junit.runners.Suite.runChild(Suite.java:128)
+        at org.junit.runners.Suite.runChild(Suite.java:27)
+        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+        at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
+        at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:395)
+        at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2145)
+      </failure>
+    </testcase>
+  </testsuite>
+  <testsuite name="NexusLowRes-28-en-portrait" tests="1" failures="0" errors="0" skipped="0" time="1.431" timestamp="2021-05-03T01:14:36" hostname="localhost">
+    <testcase name="test" classname="com.example.test_app.InstrumentedTest" time="1.431"/>
+  </testsuite>
+  <testsuite name="junit-ignored" tests="10" failures="0" errors="0" skipped="10" time="0.0" timestamp="2021-05-03T01:16:23" hostname="localhost">
+    <testcase name="ignoredTestWitSuppress" classname="com.example.test_app.InstrumentedTest" time="0.0">
+      <skipped/>
+    </testcase>
+    <testcase name="ignoredTestWithIgnore" classname="com.example.test_app.InstrumentedTest" time="0.0">
+      <skipped/>
+    </testcase>
+    <testcase name="ignoredTestBar" classname="com.example.test_app.bar.BarInstrumentedTest" time="0.0">
+      <skipped/>
+    </testcase>
+    <testcase name="ignoredTestFoo" classname="com.example.test_app.foo.FooInstrumentedTest" time="0.0">
+      <skipped/>
+    </testcase>
+    <testcase name="ignoredTestWitSuppress" classname="com.example.test_app.InstrumentedTest" time="0.0">
+      <skipped/>
+    </testcase>
+    <testcase name="ignoredTestWithIgnore" classname="com.example.test_app.InstrumentedTest" time="0.0">
+      <skipped/>
+    </testcase>
+    <testcase name="ignoredTestBar" classname="com.example.test_app.bar.BarInstrumentedTest" time="0.0">
+      <skipped/>
+    </testcase>
+    <testcase name="ignoredTestFoo" classname="com.example.test_app.foo.FooInstrumentedTest" time="0.0">
+      <skipped/>
+    </testcase>
+    <testcase name="ignoredTestWithIgnore" classname="com.example.test_app.InstrumentedTest" time="0.0">
+      <skipped/>
+    </testcase>
+    <testcase name="ignoredTestWithSuppress" classname="com.example.test_app.InstrumentedTest" time="0.0">
+      <skipped/>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/corellium/junit/src/test/resources/JUnitReport_empty_1.xml
+++ b/corellium/junit/src/test/resources/JUnitReport_empty_1.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<testsuites/>

--- a/corellium/junit/src/test/resources/JUnitReport_empty_2.xml
+++ b/corellium/junit/src/test/resources/JUnitReport_empty_2.xml
@@ -1,0 +1,3 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<testsuites>
+</testsuites>

--- a/corellium/junit/src/test/resources/JUnitReport_empty_3.xml
+++ b/corellium/junit/src/test/resources/JUnitReport_empty_3.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<testsuites>
+    <testcase/>
+</testsuites>

--- a/corellium/junit/src/test/resources/JUnitReport_invalid.xml
+++ b/corellium/junit/src/test/resources/JUnitReport_invalid.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<invalid/>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ include(
     ":corellium:shard",
     ":corellium:shard:calculate",
     ":corellium:adapter",
+    ":corellium:junit",
 )
 
 plugins {


### PR DESCRIPTION
Fixes #1827 

* The JUnit structures are bases on those taken from the `test_runner` but applying some fixes like reducing the number of nullable fields.
* The `JUnit.xsd` is added just for convenience as a referential scheme.

## Test Plan
> How do we know the code works?

Unit tests pass

## Checklist

- [x] Documented
- [x] Unit tested
