### PR TITLE
refactor: Move files for authentication data refactor

### DIFF
--- a/test_runner/src/main/kotlin/ftl/adapter/GooglePerformanceMetricsFetch.kt
+++ b/test_runner/src/main/kotlin/ftl/adapter/GooglePerformanceMetricsFetch.kt
@@ -3,7 +3,7 @@ package ftl.adapter
 import ftl.adapter.google.toApiModel
 import ftl.adapter.google.toClientModel
 import ftl.api.PerfMetrics
-import ftl.gc.GcToolResults
+import ftl.client.google.GcToolResults
 
 object GooglePerformanceMetricsFetch :
     PerfMetrics.Fetch,

--- a/test_runner/src/main/kotlin/ftl/adapter/GoogleUserAuthorizationRequest.kt
+++ b/test_runner/src/main/kotlin/ftl/adapter/GoogleUserAuthorizationRequest.kt
@@ -1,7 +1,7 @@
 package ftl.adapter
 
-import ftl.adapter.google.UserAuth
-import ftl.data.UserAuthorization
+import ftl.api.UserAuthorization
+import ftl.client.google.UserAuth
 
 object GoogleUserAuthorizationRequest :
     UserAuthorization.Request,

--- a/test_runner/src/main/kotlin/ftl/api/UserAuthorization.kt
+++ b/test_runner/src/main/kotlin/ftl/api/UserAuthorization.kt
@@ -1,4 +1,4 @@
-package ftl.data
+package ftl.api
 
 import ftl.adapter.GoogleUserAuthorizationRequest
 

--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -12,15 +12,15 @@ import com.google.cloud.storage.StorageOptions
 import flank.common.defaultCredentialPath
 import flank.common.isWindows
 import flank.common.logLn
-import ftl.adapter.google.credential
 import ftl.api.downloadAsJunitXML
 import ftl.args.IArgs.Companion.AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE
 import ftl.args.yml.YamlObjectMapper
 import ftl.client.google.GcStorage
+import ftl.client.google.GcToolResults
+import ftl.client.google.credential
 import ftl.config.FtlConstants.GCS_PREFIX
 import ftl.config.FtlConstants.JSON_FACTORY
 import ftl.config.FtlConstants.useMock
-import ftl.gc.GcToolResults
 import ftl.run.exception.FlankConfigurationError
 import ftl.run.exception.FlankGeneralError
 import ftl.shard.Chunk

--- a/test_runner/src/main/kotlin/ftl/client/google/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/AndroidCatalog.kt
@@ -9,7 +9,6 @@ import ftl.api.fetchAndroidOsVersion
 import ftl.environment.android.getDescription
 import ftl.environment.android.toCliTable
 import ftl.environment.getLocaleDescription
-import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
 /**

--- a/test_runner/src/main/kotlin/ftl/client/google/Credentials.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/Credentials.kt
@@ -1,4 +1,4 @@
-package ftl.adapter.google
+package ftl.client.google
 
 import com.google.api.client.http.GoogleApiLogger
 import com.google.api.client.http.HttpRequestInitializer

--- a/test_runner/src/main/kotlin/ftl/client/google/DeviceIpBlocks.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/DeviceIpBlocks.kt
@@ -2,7 +2,6 @@ package ftl.client.google
 
 import com.google.testing.model.Date
 import com.google.testing.model.DeviceIpBlock
-import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 import ftl.reports.api.twoDigitString
 

--- a/test_runner/src/main/kotlin/ftl/client/google/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/GcStorage.kt
@@ -9,7 +9,6 @@ import com.google.cloud.storage.StorageOptions
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
 import com.google.common.annotations.VisibleForTesting
 import flank.common.join
-import ftl.adapter.google.credential
 import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.GCS_PREFIX

--- a/test_runner/src/main/kotlin/ftl/client/google/GcTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/GcTestMatrix.kt
@@ -2,7 +2,6 @@ package ftl.client.google
 
 import com.google.testing.model.CancelTestMatrixResponse
 import com.google.testing.model.TestMatrix
-import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 import ftl.run.exception.FlankGeneralError
 import kotlinx.coroutines.Dispatchers

--- a/test_runner/src/main/kotlin/ftl/client/google/GcTesting.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/GcTesting.kt
@@ -1,7 +1,6 @@
-package ftl.gc
+package ftl.client.google
 
 import com.google.testing.Testing
-import ftl.adapter.google.httpCredential
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.JSON_FACTORY
 import ftl.config.FtlConstants.applicationName

--- a/test_runner/src/main/kotlin/ftl/client/google/GcToolResults.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/GcToolResults.kt
@@ -1,4 +1,4 @@
-package ftl.gc
+package ftl.client.google
 
 import com.google.api.services.toolresults.ToolResults
 import com.google.api.services.toolresults.model.Environment
@@ -14,8 +14,6 @@ import com.google.testing.model.TestExecution
 import com.google.testing.model.ToolResultsExecution
 import com.google.testing.model.ToolResultsHistory
 import com.google.testing.model.ToolResultsStep
-import ftl.adapter.google.UserAuth
-import ftl.adapter.google.httpCredential
 import ftl.args.IArgs
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.JSON_FACTORY

--- a/test_runner/src/main/kotlin/ftl/client/google/GoogleNetworkProfileFetch.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/GoogleNetworkProfileFetch.kt
@@ -1,6 +1,5 @@
 package ftl.client.google
 
-import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
 fun getGoogleNetworkConfiguration() = GcTesting.get.testEnvironmentCatalog()

--- a/test_runner/src/main/kotlin/ftl/client/google/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/IosCatalog.kt
@@ -7,7 +7,6 @@ import ftl.config.Device
 import ftl.environment.getLocaleDescription
 import ftl.environment.ios.getDescription
 import ftl.environment.ios.iosVersionsToCliTable
-import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
 /**

--- a/test_runner/src/main/kotlin/ftl/client/google/OsVersion.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/OsVersion.kt
@@ -2,7 +2,6 @@ package ftl.client.google
 
 import com.google.testing.model.AndroidVersion
 import com.google.testing.model.IosVersion
-import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
 fun androidOsVersions(projectId: String): List<AndroidVersion> =

--- a/test_runner/src/main/kotlin/ftl/client/google/ProvidedSoftwareCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/ProvidedSoftwareCatalog.kt
@@ -1,7 +1,6 @@
 package ftl.client.google
 
 import ftl.environment.common.toCliTable
-import ftl.gc.GcTesting
 import ftl.http.executeWithRetry
 
 fun providedSoftwareAsTable() = getProvidedSoftware().toCliTable()

--- a/test_runner/src/main/kotlin/ftl/client/google/TestOutcomeContext.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/TestOutcomeContext.kt
@@ -7,7 +7,6 @@ import com.google.common.annotations.VisibleForTesting
 import com.google.testing.model.ToolResultsExecution
 import flank.common.logLn
 import ftl.api.TestMatrix
-import ftl.gc.GcToolResults
 import ftl.json.getDetails
 import ftl.reports.outcome.axisValue
 import ftl.reports.outcome.createTestSuiteOverviewData

--- a/test_runner/src/main/kotlin/ftl/client/google/UserAuth.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/UserAuth.kt
@@ -1,4 +1,4 @@
-package ftl.adapter.google
+package ftl.client.google
 
 import com.google.auth.oauth2.ClientId
 import com.google.auth.oauth2.MemoryTokensStorage

--- a/test_runner/src/main/kotlin/ftl/client/junit/CreateTestExecutionData.kt
+++ b/test_runner/src/main/kotlin/ftl/client/junit/CreateTestExecutionData.kt
@@ -5,7 +5,7 @@ import com.google.api.services.toolresults.model.TestCase
 import com.google.api.services.toolresults.model.Timestamp
 import com.google.testing.model.TestExecution
 import com.google.testing.model.ToolResultsStep
-import ftl.gc.GcToolResults
+import ftl.client.google.GcToolResults
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll

--- a/test_runner/src/main/kotlin/ftl/domain/LoginGoogleAccount.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/LoginGoogleAccount.kt
@@ -1,6 +1,6 @@
 package ftl.domain
 
-import ftl.data.requestUserAuthorization
+import ftl.api.requestUserAuthorization
 
 interface LoginGoogleAccount
 

--- a/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
@@ -15,6 +15,7 @@ import com.google.testing.model.ToolResultsHistory
 import flank.common.join
 import ftl.args.AndroidArgs
 import ftl.args.isDontAutograntPermissions
+import ftl.client.google.GcTesting
 import ftl.gc.android.mapGcsPathsToApks
 import ftl.gc.android.mapToDeviceFiles
 import ftl.gc.android.mapToDeviceObbFiles

--- a/test_runner/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
@@ -11,6 +11,7 @@ import com.google.testing.model.TestMatrix
 import com.google.testing.model.TestSpecification
 import com.google.testing.model.ToolResultsHistory
 import ftl.args.IosArgs
+import ftl.client.google.GcTesting
 import ftl.gc.android.mapGcsPathsToFileReference
 import ftl.gc.android.mapToIosDeviceFiles
 import ftl.gc.android.toIosDeviceFile

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -10,10 +10,10 @@ import ftl.api.uploadToRemoteStorage
 import ftl.args.AndroidArgs
 import ftl.args.isInstrumentationTest
 import ftl.args.shardsFilePath
+import ftl.client.google.GcToolResults
 import ftl.config.FtlConstants
 import ftl.gc.GcAndroidDevice
 import ftl.gc.GcAndroidTestMatrix
-import ftl.gc.GcToolResults
 import ftl.http.executeWithRetry
 import ftl.run.exception.FlankGeneralError
 import ftl.run.model.AndroidMatrixTestShards

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunIosTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunIosTests.kt
@@ -8,10 +8,10 @@ import ftl.api.uploadToRemoteStorage
 import ftl.args.IosArgs
 import ftl.args.isXcTest
 import ftl.args.shardsFilePath
+import ftl.client.google.GcToolResults
 import ftl.config.FtlConstants
 import ftl.gc.GcIosMatrix
 import ftl.gc.GcIosTestMatrix
-import ftl.gc.GcToolResults
 import ftl.http.executeWithRetry
 import ftl.ios.xctest.flattenShardChunks
 import ftl.run.dumpShards

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/BeforeRunTests.kt
@@ -3,9 +3,9 @@ package ftl.run.platform.common
 import flank.common.logLn
 import ftl.args.IArgs
 import ftl.client.google.GcStorage
+import ftl.client.google.GcTesting
+import ftl.client.google.GcToolResults
 import ftl.config.FtlConstants
-import ftl.gc.GcTesting
-import ftl.gc.GcToolResults
 import ftl.run.exception.FlankGeneralError
 import ftl.util.StopWatch
 import java.io.File

--- a/test_runner/src/test/kotlin/ftl/adapter/google/UserAuthTest.kt
+++ b/test_runner/src/test/kotlin/ftl/adapter/google/UserAuthTest.kt
@@ -1,7 +1,8 @@
 package ftl.adapter.google
 
 import com.google.common.truth.Truth.assertThat
-import ftl.adapter.google.UserAuth.Companion.userToken
+import ftl.client.google.UserAuth
+import ftl.client.google.UserAuth.Companion.userToken
 import ftl.run.exception.FlankGeneralError
 import ftl.test.util.TestHelper.getThrowable
 import io.mockk.every

--- a/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
@@ -3,7 +3,7 @@ package ftl.gc
 import com.google.testing.model.AndroidDeviceList
 import com.google.testing.model.TestSetup
 import ftl.args.AndroidArgs
-import ftl.gc.GcToolResults.createToolResultsHistory
+import ftl.client.google.GcToolResults.createToolResultsHistory
 import ftl.gc.android.setEnvironmentVariables
 import ftl.run.platform.android.AndroidTestConfig
 import ftl.test.util.FlankTestRunner

--- a/test_runner/src/test/kotlin/ftl/gc/GcIosTestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcIosTestMatrixTest.kt
@@ -3,6 +3,7 @@ package ftl.gc
 import com.google.testing.model.IosDeviceList
 import flank.common.isWindows
 import ftl.args.IosArgs
+import ftl.client.google.GcToolResults
 import ftl.ios.xctest.FIXTURES_PATH
 import ftl.run.model.XcTestContext
 import ftl.test.util.FlankTestRunner

--- a/test_runner/src/test/kotlin/ftl/gc/GcToolResultsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcToolResultsTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.testing.model.ToolResultsHistory
 import com.google.testing.model.ToolResultsStep
 import ftl.args.AndroidArgs
+import ftl.client.google.GcToolResults
 import ftl.config.FtlConstants
 import ftl.run.exception.FailureToken
 import ftl.run.exception.FlankGeneralError

--- a/test_runner/src/test/kotlin/ftl/reports/api/CreateTestExecutionDataKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/api/CreateTestExecutionDataKtTest.kt
@@ -6,9 +6,9 @@ import com.google.api.services.toolresults.model.TestCase
 import com.google.api.services.toolresults.model.Timestamp
 import com.google.testing.model.TestExecution
 import com.google.testing.model.ToolResultsStep
+import ftl.client.google.GcToolResults
 import ftl.client.junit.TestExecutionData
 import ftl.client.junit.createTestExecutionDataListAsync
-import ftl.gc.GcToolResults
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject

--- a/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
@@ -4,8 +4,8 @@ import com.google.api.services.toolresults.model.Step
 import com.google.testing.model.AndroidModel
 import ftl.client.google.BillableMinutes
 import ftl.client.google.DeviceType
-import ftl.client.google.calculateAndroidBillableMinutes
 import ftl.client.google.GcTesting
+import ftl.client.google.calculateAndroidBillableMinutes
 import ftl.http.executeWithRetry
 import io.mockk.every
 import io.mockk.mockkObject

--- a/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
@@ -5,7 +5,7 @@ import com.google.testing.model.AndroidModel
 import ftl.client.google.BillableMinutes
 import ftl.client.google.DeviceType
 import ftl.client.google.calculateAndroidBillableMinutes
-import ftl.gc.GcTesting
+import ftl.client.google.GcTesting
 import ftl.http.executeWithRetry
 import io.mockk.every
 import io.mockk.mockkObject

--- a/test_runner/src/test/kotlin/task/UpdateCatalogFixtures.kt
+++ b/test_runner/src/test/kotlin/task/UpdateCatalogFixtures.kt
@@ -1,7 +1,7 @@
 package task
 
 import com.google.api.client.json.GenericJson
-import ftl.gc.GcTesting
+import ftl.client.google.GcTesting
 import java.nio.file.Files
 import java.nio.file.Paths
 


### PR DESCRIPTION
## Test Plan
> How do we know the code works?

This PR contains additional fixes for refactoring authentication #1809
It brings `presentation > domain > API > adapter > client` package structure
