### PR TITLE
refactor: Structural output list network profiles

### DIFF
--- a/test_runner/src/main/kotlin/ftl/domain/ListNetworkProfiles.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/ListNetworkProfiles.kt
@@ -1,13 +1,11 @@
 package ftl.domain
 
-import flank.common.logLn
 import ftl.api.fetchNetworkProfiles
-import ftl.environment.common.toCliTable
+import ftl.presentation.Output
 
-interface ListNetworkProfiles
+interface ListNetworkProfiles : Output
 
 operator fun ListNetworkProfiles.invoke() {
-    // TODO move toCliTable() and printing presentation layer during refactor of presentation after #1728
-    logLn("fetching available network profiles...")
-    logLn(fetchNetworkProfiles().toCliTable())
+    "fetching available network profiles...".out()
+    fetchNetworkProfiles().out()
 }

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/android/locales/AndroidLocalesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/android/locales/AndroidLocalesListCommand.kt
@@ -7,6 +7,7 @@ import ftl.domain.invoke
 import ftl.presentation.cli.firebase.test.locale.toCliTable
 import ftl.presentation.outputLogger
 import ftl.presentation.throwUnknownType
+import ftl.util.asListOrNull
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -30,11 +31,6 @@ class AndroidLocalesListCommand :
     )
     override var configPath: String = FtlConstants.defaultAndroidConfig
 
-    override val out = outputLogger {
-        @Suppress("UNCHECKED_CAST")
-        (this as? List<Locale>)?.toCliTable() ?: throwUnknownType()
-    }
-
     @CommandLine.Option(
         names = ["-h", "--help"],
         usageHelp = true,
@@ -43,4 +39,8 @@ class AndroidLocalesListCommand :
     var usageHelpRequested: Boolean = false
 
     override fun run() = invoke()
+
+    override val out = outputLogger {
+        asListOrNull<Locale>()?.toCliTable() ?: throwUnknownType()
+    }
 }

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
@@ -6,6 +6,7 @@ import ftl.domain.ListAndroidOrientations
 import ftl.domain.invoke
 import ftl.presentation.outputLogger
 import ftl.presentation.throwUnknownType
+import ftl.util.asListOrNull
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -39,7 +40,6 @@ class AndroidOrientationsListCommand :
     override fun run() = invoke()
 
     override val out = outputLogger {
-        @Suppress("UNCHECKED_CAST")
-        (this as? List<Orientation>)?.toCliTable() ?: throwUnknownType()
+        asListOrNull<Orientation>()?.toCliTable() ?: throwUnknownType()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/environment/TestEnvironmentInfo.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/environment/TestEnvironmentInfo.kt
@@ -2,13 +2,12 @@ package ftl.presentation.cli.firebase.test.environment
 
 import ftl.api.TestEnvironment
 import ftl.environment.android.toCliTable
-import ftl.environment.common.toCliTable
 import ftl.environment.ios.toCliTable
 import ftl.presentation.cli.firebase.test.android.orientations.toCliTable
 import ftl.presentation.cli.firebase.test.ipblocks.toCliTable
 import ftl.presentation.cli.firebase.test.locale.toCliTable
-import ftl.presentation.cli.firebase.test.providedsoftware.toCliTable
 import ftl.presentation.cli.firebase.test.networkprofiles.toCliTable
+import ftl.presentation.cli.firebase.test.providedsoftware.toCliTable
 
 fun TestEnvironment.Android.prepareOutputString() = buildString {
     appendLine(osVersions.toCliTable())

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/environment/TestEnvironmentInfo.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/environment/TestEnvironmentInfo.kt
@@ -8,6 +8,7 @@ import ftl.presentation.cli.firebase.test.android.orientations.toCliTable
 import ftl.presentation.cli.firebase.test.ipblocks.toCliTable
 import ftl.presentation.cli.firebase.test.locale.toCliTable
 import ftl.presentation.cli.firebase.test.providedsoftware.toCliTable
+import ftl.presentation.cli.firebase.test.networkprofiles.toCliTable
 
 fun TestEnvironment.Android.prepareOutputString() = buildString {
     appendLine(osVersions.toCliTable())

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/ios/configuration/IosLocalesDescribeCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/ios/configuration/IosLocalesDescribeCommand.kt
@@ -9,7 +9,6 @@ import ftl.presentation.outputLogger
 import ftl.presentation.throwUnknownType
 import picocli.CommandLine
 
-@Suppress("UNCHECKED_CAST")
 @CommandLine.Command(
     name = "describe",
     headerHeading = "",

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/ios/configuration/IosLocalesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/ios/configuration/IosLocalesListCommand.kt
@@ -7,6 +7,7 @@ import ftl.domain.invoke
 import ftl.presentation.cli.firebase.test.locale.toCliTable
 import ftl.presentation.outputLogger
 import ftl.presentation.throwUnknownType
+import ftl.util.asListOrNull
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -40,7 +41,6 @@ class IosLocalesListCommand :
     override fun run() = invoke()
 
     override val out = outputLogger {
-        @Suppress("UNCHECKED_CAST")
-        (this as? List<Locale>)?.toCliTable() ?: throwUnknownType()
+        asListOrNull<Locale>()?.toCliTable() ?: throwUnknownType()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/ios/orientations/IosOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/ios/orientations/IosOrientationsListCommand.kt
@@ -5,8 +5,10 @@ import ftl.config.FtlConstants
 import ftl.domain.ListIosOrientations
 import ftl.domain.invoke
 import ftl.presentation.cli.firebase.test.android.orientations.toCliTable
+import ftl.presentation.cli.firebase.test.locale.toCliTable
 import ftl.presentation.outputLogger
 import ftl.presentation.throwUnknownType
+import ftl.util.asListOrNull
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -40,7 +42,6 @@ class IosOrientationsListCommand :
     override fun run() = invoke()
 
     override val out = outputLogger {
-        @Suppress("UNCHECKED_CAST")
-        (this as? List<Orientation>)?.toCliTable() ?: throwUnknownType()
+        asListOrNull<Orientation>()?.toCliTable() ?: throwUnknownType()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/networkprofiles/ListNetworkConfiguration.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/networkprofiles/ListNetworkConfiguration.kt
@@ -1,4 +1,4 @@
-package ftl.environment.common
+package ftl.presentation.cli.firebase.test.networkprofiles
 
 import ftl.api.NetworkProfile
 import ftl.environment.TestEnvironmentInfo

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
@@ -1,7 +1,11 @@
 package ftl.presentation.cli.firebase.test.networkprofiles
 
+import ftl.api.NetworkProfile
 import ftl.domain.ListNetworkProfiles
 import ftl.domain.invoke
+import ftl.environment.common.toCliTable
+import ftl.presentation.outputLogger
+import ftl.presentation.throwUnknownType
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -19,4 +23,14 @@ class NetworkProfilesListCommand :
     Runnable,
     ListNetworkProfiles {
     override fun run() = invoke()
+
+    override val out = outputLogger {
+
+        @Suppress("UNCHECKED_CAST")
+        when {
+            (this as? List<NetworkProfile>) != null -> this.toCliTable()
+            this is String -> this
+            else -> throwUnknownType()
+        }
+    }
 }

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/networkprofiles/NetworkProfilesListCommand.kt
@@ -3,9 +3,10 @@ package ftl.presentation.cli.firebase.test.networkprofiles
 import ftl.api.NetworkProfile
 import ftl.domain.ListNetworkProfiles
 import ftl.domain.invoke
-import ftl.environment.common.toCliTable
 import ftl.presentation.outputLogger
 import ftl.presentation.throwUnknownType
+import ftl.util.asList
+import ftl.util.asListOrNull
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -25,10 +26,8 @@ class NetworkProfilesListCommand :
     override fun run() = invoke()
 
     override val out = outputLogger {
-
-        @Suppress("UNCHECKED_CAST")
         when {
-            (this as? List<NetworkProfile>) != null -> this.toCliTable()
+            asListOrNull<NetworkProfile>() != null -> asList<NetworkProfile>().toCliTable()
             this is String -> this
             else -> throwUnknownType()
         }

--- a/test_runner/src/main/kotlin/ftl/util/CastingUtils.kt
+++ b/test_runner/src/main/kotlin/ftl/util/CastingUtils.kt
@@ -1,0 +1,7 @@
+package ftl.util
+
+@Suppress("UNCHECKED_CAST")
+fun <T> Any.asList(): List<T> = this as List<T>
+
+@Suppress("UNCHECKED_CAST")
+fun <T> Any.asListOrNull(): List<T>? = this as? List<T>

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/networkprofiles/NetworkProfilesListCommandTest.kt
@@ -2,8 +2,8 @@ package ftl.cli.firebase.test.networkprofiles
 
 import ftl.api.NetworkProfile
 import ftl.api.fetchNetworkProfiles
-import ftl.environment.common.toCliTable
 import ftl.presentation.cli.firebase.test.networkprofiles.NetworkProfilesListCommand
+import ftl.presentation.cli.firebase.test.networkprofiles.toCliTable
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll


### PR DESCRIPTION
Fixes #1864

## Test Plan
> How do we know the code works?

- code is refactored as described in #1864
- `flank firebase test network-profiles list` works like before

## Checklist

- [x] Refactored
