### PR TITLE
refactor: Structural output list provided software

### DIFF
--- a/test_runner/src/main/kotlin/ftl/client/google/ProvidedSoftwareCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/ProvidedSoftwareCatalog.kt
@@ -1,9 +1,6 @@
 package ftl.client.google
 
-import ftl.environment.common.toCliTable
 import ftl.http.executeWithRetry
-
-fun providedSoftwareAsTable() = getProvidedSoftware().toCliTable()
 
 internal fun getProvidedSoftware() = GcTesting.get.testEnvironmentCatalog()
     .get("provided_software")

--- a/test_runner/src/main/kotlin/ftl/domain/ListProvidedSoftware.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/ListProvidedSoftware.kt
@@ -1,11 +1,10 @@
 package ftl.domain
 
-import flank.common.logLn
 import ftl.api.fetchSoftwareCatalog
-import ftl.environment.common.toCliTable
+import ftl.presentation.Output
 
-interface ListProvidedSoftware
+interface ListProvidedSoftware : Output
 
 operator fun ListProvidedSoftware.invoke() {
-    logLn(fetchSoftwareCatalog().toCliTable())
+    fetchSoftwareCatalog().out()
 }

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/android/orientations/AndroidOrientationsListCommand.kt
@@ -4,7 +4,6 @@ import ftl.api.Orientation
 import ftl.config.FtlConstants
 import ftl.domain.ListAndroidOrientations
 import ftl.domain.invoke
-import ftl.environment.common.toCliTable
 import ftl.presentation.outputLogger
 import ftl.presentation.throwUnknownType
 import picocli.CommandLine

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/environment/TestEnvironmentInfo.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/environment/TestEnvironmentInfo.kt
@@ -7,6 +7,7 @@ import ftl.environment.ios.toCliTable
 import ftl.presentation.cli.firebase.test.android.orientations.toCliTable
 import ftl.presentation.cli.firebase.test.ipblocks.toCliTable
 import ftl.presentation.cli.firebase.test.locale.toCliTable
+import ftl.presentation.cli.firebase.test.providedsoftware.toCliTable
 
 fun TestEnvironment.Android.prepareOutputString() = buildString {
     appendLine(osVersions.toCliTable())

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/providedsoftware/ListProvidedSoftware.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/providedsoftware/ListProvidedSoftware.kt
@@ -1,4 +1,4 @@
-package ftl.environment.common
+package ftl.presentation.cli.firebase.test.providedsoftware
 
 import com.google.testing.model.ProvidedSoftwareCatalog
 import ftl.util.TableColumn

--- a/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/providedsoftware/ProvidedSoftwareListCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/presentation/cli/firebase/test/providedsoftware/ProvidedSoftwareListCommand.kt
@@ -1,7 +1,10 @@
 package ftl.presentation.cli.firebase.test.providedsoftware
 
+import com.google.testing.model.ProvidedSoftwareCatalog
 import ftl.domain.ListProvidedSoftware
 import ftl.domain.invoke
+import ftl.presentation.outputLogger
+import ftl.presentation.throwUnknownType
 import picocli.CommandLine
 
 @CommandLine.Command(
@@ -18,5 +21,13 @@ import picocli.CommandLine
 class ProvidedSoftwareListCommand :
     Runnable,
     ListProvidedSoftware {
+
     override fun run() = invoke()
+
+    override val out = outputLogger {
+        when (this) {
+            is ProvidedSoftwareCatalog -> toCliTable()
+            else -> throwUnknownType()
+        }
+    }
 }

--- a/test_runner/src/test/kotlin/ftl/environment/ListProvidedSoftwareTest.kt
+++ b/test_runner/src/test/kotlin/ftl/environment/ListProvidedSoftwareTest.kt
@@ -2,7 +2,7 @@ package ftl.environment
 
 import com.google.common.truth.Truth.assertThat
 import ftl.api.fetchSoftwareCatalog
-import ftl.environment.common.toCliTable
+import ftl.presentation.cli.firebase.test.providedsoftware.toCliTable
 import ftl.test.util.FlankTestRunner
 import io.mockk.unmockkAll
 import org.junit.After


### PR DESCRIPTION
Fixes #1865

## Test Plan
> How do we know the code works?

Code is refactored according to #1865 
`firebase test provided-software list` works like previously

## Checklist

- [x] Refactored
