### PR TITLE
refactor: Add removing stack traces for simple report

### DIFF
--- a/test_runner/src/main/kotlin/ftl/client/junit/PrepareForJUnitResult.kt
+++ b/test_runner/src/main/kotlin/ftl/client/junit/PrepareForJUnitResult.kt
@@ -38,15 +38,6 @@ private fun TestExecutionData.reduceTestCases() = copy(
     }
 )
 
-internal fun List<TestExecutionData>.removeStackTraces(): List<TestExecutionData> =
-    map(TestExecutionData::removeStackTraces)
-
-private fun TestExecutionData.removeStackTraces() = copy(
-    testCases = testCases.onEach {
-        if (it.flaky) it.stackTraces = emptyList()
-    }
-)
-
 // For primary step return stepId instead of primaryStepId
 private val Step.primaryStepId get() = multiStep?.primaryStepId ?: stepId
 

--- a/test_runner/src/main/kotlin/ftl/domain/junit/StackTraceRemover.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/junit/StackTraceRemover.kt
@@ -2,18 +2,14 @@ package ftl.domain.junit
 
 import ftl.api.JUnitTest
 
-fun JUnitTest.Result.removeStackTraces() = JUnitTest.Result(testsuites?.removeStackTraces())
+fun JUnitTest.Result.removeStackTraces() = copy(testsuites = testsuites?.removeStackTraces())
 
 private fun MutableCollection<JUnitTest.Suite>.removeStackTraces() = map { testSuite ->
-    testSuite.copy(testcases = testSuite.testcases?.withRemovedStackTraces()?.toMutableList())
+    testSuite.copy(testcases = testSuite.testcases?.withRemovedStackTraces())
 }.toMutableList()
 
 private fun MutableCollection<JUnitTest.Case>.withRemovedStackTraces() =
-    map { testCase -> testCase.removeFlakyStackTrace() }
+    map { testCase -> testCase.removeFlakyStackTrace() }.toMutableList()
 
-private fun JUnitTest.Case.removeFlakyStackTrace(): JUnitTest.Case = if (flaky == true) {
-    copy(
-        errors = null,
-        failures = null
-    )
-} else this
+private fun JUnitTest.Case.removeFlakyStackTrace(): JUnitTest.Case =
+    if (flaky == true) copy(errors = null, failures = null) else this

--- a/test_runner/src/main/kotlin/ftl/domain/junit/StackTraceRemover.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/junit/StackTraceRemover.kt
@@ -1,0 +1,19 @@
+package ftl.domain.junit
+
+import ftl.api.JUnitTest
+
+fun JUnitTest.Result.removeStackTraces() = JUnitTest.Result(testsuites?.removeStackTraces())
+
+private fun MutableCollection<JUnitTest.Suite>.removeStackTraces() = map { testSuite ->
+    testSuite.copy(testcases = testSuite.testcases?.withRemovedStackTraces()?.toMutableList())
+}.toMutableList()
+
+private fun MutableCollection<JUnitTest.Case>.withRemovedStackTraces() =
+    map { testCase -> testCase.removeFlakyStackTrace() }
+
+private fun JUnitTest.Case.removeFlakyStackTrace(): JUnitTest.Case = if (flaky == true) {
+    copy(
+        errors = null,
+        failures = null
+    )
+} else this

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -17,6 +17,7 @@ import ftl.client.google.GcStorage
 import ftl.config.FtlConstants
 import ftl.domain.junit.merge
 import ftl.domain.junit.mergeTestTimes
+import ftl.domain.junit.removeStackTraces
 import ftl.json.MatrixMap
 import ftl.json.isAllSuccessful
 import ftl.reports.CostReport
@@ -129,7 +130,7 @@ object ReportManager {
         // ios supports only legacy parsing
         args is IosArgs -> processXmlFromFile(matrices, args, parseJUnitTestResultFromFile)
         args.useLegacyJUnitResult -> processXmlFromFile(matrices, args, parseJUnitLegacyTestResultFromFile)
-        else -> generateJUnitTestResultFromApi((args to matrices).toApiIdentity())
+        else -> generateJUnitTestResultFromApi((args to matrices).toApiIdentity()).removeStackTraces()
     }
 
     @VisibleForTesting

--- a/test_runner/src/test/kotlin/ftl/domain/junit/StackTraceRemoverTest.kt
+++ b/test_runner/src/test/kotlin/ftl/domain/junit/StackTraceRemoverTest.kt
@@ -1,0 +1,68 @@
+package ftl.domain.junit
+
+import com.google.common.truth.Truth.assertThat
+import ftl.api.JUnitTest
+import org.junit.Test
+
+class StackTraceRemoverTest {
+
+    val testcases = mutableListOf(
+        JUnitTest.Case("name", "class", "time", failures = listOf("fail"), errors = listOf("error")),
+        JUnitTest.Case("name2", "class2", "time2", failures = listOf("fail2"), errors = listOf("error2")),
+    )
+
+    @Test
+    fun `Should remove stack traces for flaky tests`() {
+        // given
+        val testcases = mutableListOf(
+            JUnitTest.Case("name", "class", "time", failures = listOf("fail"), errors = listOf("error")),
+            JUnitTest.Case("name2", "class2", "time2", failures = listOf("fail2"), errors = listOf("error2")),
+        )
+        val junitTestResult = testResultsFor(testcases, flaky = true)
+
+        // when
+        val actual = junitTestResult.removeStackTraces()
+
+        // then
+        actual.testsuites?.forEach { suite ->
+            assertThat(suite.testcases?.all { testCase -> testCase.failures == null }).isTrue()
+            assertThat(suite.testcases?.all { testCase -> testCase.errors == null }).isTrue()
+        }
+    }
+
+    @Test
+    fun `Should not remove stack traces for not flaky test`() {
+        // given
+        val junitTestResult = testResultsFor(testcases, flaky = false)
+
+        // when
+        val actual = junitTestResult.removeStackTraces()
+
+        // then
+        actual.testsuites?.forEach { suite ->
+            assertThat(suite.testcases?.all { testCase -> testCase.failures == null }).isFalse()
+            assertThat(suite.testcases?.all { testCase -> testCase.errors == null }).isFalse()
+        }
+    }
+
+    private fun testResultsFor(testCases: MutableList<JUnitTest.Case>, flaky: Boolean) = JUnitTest.Result(
+        testsuites = mutableListOf(
+            JUnitTest.Suite(
+                "",
+                "-1",
+                "-1",
+                -1,
+                "-1",
+                "-1",
+                "-1",
+                "-1",
+                "-1",
+                "-1",
+                testCases.onEach { it.apply { this.flaky = flaky } },
+                null,
+                null,
+                null
+            )
+        )
+    )
+}

--- a/test_runner/src/test/kotlin/ftl/reports/api/PrepareForJUnitResultKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/api/PrepareForJUnitResultKtTest.kt
@@ -9,7 +9,6 @@ import com.google.testing.model.TestExecution
 import ftl.client.junit.TestExecutionData
 import ftl.client.junit.flaky
 import ftl.client.junit.prepareForJUnitResult
-import ftl.client.junit.removeStackTraces
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -131,42 +130,6 @@ class PrepareForJUnitResultKtTest {
         assertEquals(preparedTestCase.count(), 1)
         assertEquals(preparedTestCase.first().testCases.count(), 1)
         assertEquals(3, preparedTestCase.first().testCases.first().stackTraces.count())
-    }
-
-    @Test
-    fun `should return single prepared test case without stack trace`() {
-        val testCases = listOf(
-            TestCase().apply {
-                startTime = Timestamp().apply {
-                    seconds = 1
-                }
-            },
-            TestCase().apply {
-                startTime = Timestamp().apply {
-                    seconds = 2
-                }
-                stackTraces = listOf(
-                    StackTrace().apply {
-                        exception = "exception"
-                    }
-                )
-            }
-        )
-        val primaryStep = Step().apply {
-            stepId = "1"
-        }
-        val testExecutionDataList = listOf(
-            TestExecutionData(
-                testExecution = TestExecution(),
-                timestamp = Timestamp(),
-                testCases = testCases,
-                step = primaryStep
-            )
-        )
-        val preparedTestCase = testExecutionDataList.prepareForJUnitResult().removeStackTraces()
-        assertEquals(preparedTestCase.count(), 1)
-        assertEquals(preparedTestCase.first().testCases.count(), 1)
-        assertTrue(preparedTestCase.first().testCases.first().stackTraces.isNullOrEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Test Plan
> How do we know the code works?

Simple JunitReport does not contain stack traces for flaky tests

## Checklist

- [x] Unit tested
