### PR TITLE
feat: Public API of corellium domain layer

### DIFF
--- a/corellium/domain/build.gradle.kts
+++ b/corellium/domain/build.gradle.kts
@@ -1,0 +1,29 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin(Plugins.Kotlin.PLUGIN_JVM)
+    kotlin(Plugins.Kotlin.PLUGIN_SERIALIZATION) version Versions.KOTLIN
+}
+
+repositories {
+    jcenter()
+    mavenCentral()
+    maven(url = "https://kotlin.bintray.com/kotlinx")
+}
+
+tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
+
+dependencies {
+    implementation(Dependencies.KOTLIN_COROUTINES_CORE)
+    implementation(project(":corellium:api"))
+    implementation(project(":corellium:shard:calculate"))
+    implementation(project(":corellium:log"))
+
+    testImplementation(Dependencies.JUNIT)
+}
+
+tasks.test {
+    maxHeapSize = "3072m"
+    minHeapSize = "512m"
+    dependsOn(":resolveArtifacts")
+}

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestAndroidCorellium.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestAndroidCorellium.kt
@@ -1,0 +1,79 @@
+package flank.corellium.domain
+
+import flank.corellium.api.Authorization
+import flank.corellium.api.CorelliumApi
+import flank.corellium.domain.RunTestAndroidCorellium.Context
+import flank.corellium.domain.RunTestAndroidCorellium.State
+import flank.corellium.domain.util.CreateTransformation
+import flank.corellium.domain.util.execute
+import flank.corellium.log.Instrument
+import flank.corellium.shard.Shard
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import java.util.Date
+
+object RunTestAndroidCorellium {
+
+    /**
+     * The context of android test execution on corellium.
+     * Is providing all necessary data and operations for [Context.invoke].
+     */
+    interface Context {
+        val api: CorelliumApi
+        val config: Config
+    }
+
+    /**
+     * The user configuration for invocation.
+     */
+    data class Config(
+        val credentials: Authorization.Credentials,
+        val apks: List<Apk.App>,
+        val maxShardsCount: Int,
+        val outputDir: String = "results/corellium/android/" + Date(),
+    )
+
+    sealed class Apk {
+        abstract val path: String
+
+        data class App(
+            override val path: String,
+            val tests: List<Test>,
+        ) : Apk()
+
+        data class Test(
+            override val path: String
+        ) : Apk()
+    }
+
+    /**
+     * The State structure is holding all necessary data collected during the execution process.
+     * For convenience the properties are sorted in order equal to its initialization.
+     *
+     * @param testCases key - path to the test apk, value - list of test method names.
+     * @param shards each item is representing list of apps to run on another device instance.
+     * @param ids the ids of corellium device instances.
+     * @param packageNames key - path to the test apk, value - package name.
+     * @param testRunners key - path to the test apk, value - fully qualified test runner name.
+     */
+    internal data class State(
+        val testCases: Map<String, List<String>> = emptyMap(),
+        val shards: List<List<Shard.App>> = emptyList(),
+        val ids: List<String> = emptyList(),
+        val packageNames: Map<String, String> = emptyMap(),
+        val testRunners: Map<String, String> = emptyMap(),
+        val testResult: List<List<Instrument>> = emptyList(),
+    )
+
+    /**
+     * The reference to the step factory function.
+     * Invoke it to generate new execution step.
+     */
+    internal val step = CreateTransformation<State>()
+}
+
+operator fun Context.invoke(): Unit = runBlocking {
+    State() execute flowOf(
+        // TODO steps will be added in next PR
+    )
+}

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/util/Transform.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/util/Transform.kt
@@ -1,0 +1,23 @@
+package flank.corellium.domain.util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.fold
+
+/**
+ * Execute flow of suspendable transformations on a given value.
+ *
+ * @receiver Value to apply transformations on it.
+ * @return Result of transformations.
+ */
+internal suspend infix fun <S> S.execute(operations: Flow<Transform<S>>): S =
+    operations.fold(this) { value, transform -> transform(value) }
+
+/**
+ * Simple parameterized factory for generating [Transform] instances.
+ */
+internal class CreateTransformation<S> : (Transform<S>) -> Transform<S> by { it }
+
+/**
+ * Type-alias for suspendable transforming operation
+ */
+private typealias Transform<S> = suspend S.() -> S

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ include(
     ":corellium:shard:dump",
     ":corellium:adapter",
     ":corellium:junit",
+    ":corellium:domain",
 )
 
 plugins {


### PR DESCRIPTION
Related to #1802 

The public API of the domain layer is required for CLI integration.
The rest of the domain layer implementation will be added in another PR.

## Checklist

- [x] Documented
