### PR TITLE
refactor: Move apk parsers to dedicated module

### DIFF
--- a/corellium/adapter/src/main/kotlin/flank/corellium/Api.kt
+++ b/corellium/adapter/src/main/kotlin/flank/corellium/Api.kt
@@ -3,9 +3,6 @@ package flank.corellium
 import flank.corellium.adapter.executeAndroidTestPlan
 import flank.corellium.adapter.installAndroidApps
 import flank.corellium.adapter.invokeAndroidDevices
-import flank.corellium.adapter.parseApkInfo
-import flank.corellium.adapter.parseApkPackageName
-import flank.corellium.adapter.parseApkTestCases
 import flank.corellium.adapter.requestAuthorization
 import flank.corellium.api.CorelliumApi
 
@@ -20,7 +17,4 @@ fun corelliumApi(
         projectName = projectName
     ),
     executeTest = executeAndroidTestPlan,
-    parseTestCases = parseApkTestCases,
-    parseTestApkInfo = parseApkInfo,
-    parsePackageName = parseApkPackageName
 )

--- a/corellium/api/src/main/kotlin/flank/corellium/api/CorelliumApi.kt
+++ b/corellium/api/src/main/kotlin/flank/corellium/api/CorelliumApi.kt
@@ -8,7 +8,4 @@ class CorelliumApi(
     val invokeAndroidDevices: AndroidInstance.Invoke,
     val installAndroidApps: AndroidApps.Install,
     val executeTest: AndroidTestPlan.Execute,
-    val parseTestCases: Apk.ParseTestCases,
-    val parsePackageName: Apk.ParsePackageName,
-    val parseTestApkInfo: Apk.ParseInfo,
 )

--- a/corellium/apk/build.gradle.kts
+++ b/corellium/apk/build.gradle.kts
@@ -13,9 +13,15 @@ repositories {
 tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
 
 dependencies {
-    implementation(project(":corellium:api"))
-    implementation(project(":corellium:client"))
     implementation(Dependencies.KOTLIN_COROUTINES_CORE)
+    implementation(Dependencies.DEX_TEST_PARSER)
+    implementation(Dependencies.APK_PARSER)
+
     testImplementation(Dependencies.JUNIT)
 }
 
+tasks.test {
+    maxHeapSize = "3072m"
+    minHeapSize = "512m"
+    dependsOn(":resolveArtifacts")
+}

--- a/corellium/apk/src/main/kotlin/flank/apk/Apk.kt
+++ b/corellium/apk/src/main/kotlin/flank/apk/Apk.kt
@@ -1,9 +1,19 @@
-package flank.corellium.api
+package flank.apk
+
+import flank.apk.internal.parseApkInfo
+import flank.apk.internal.parseApkPackageName
+import flank.apk.internal.parseApkTestCases
 
 /**
  * Structured representation of the parsed test apk file.
  */
 object Apk {
+
+    class Api(
+        val parseTestCases: ParseTestCases = parseApkTestCases,
+        val parsePackageName: ParsePackageName = parseApkPackageName,
+        val parseInfo: ParseInfo = parseApkInfo
+    )
 
     data class Info(
         val packageName: String,

--- a/corellium/apk/src/main/kotlin/flank/apk/internal/Parse.kt
+++ b/corellium/apk/src/main/kotlin/flank/apk/internal/Parse.kt
@@ -1,23 +1,23 @@
-package flank.corellium.adapter
+package flank.apk.internal
 
 import com.linkedin.dex.parser.DexParser
 import com.linkedin.dex.parser.TestMethod
-import flank.corellium.api.Apk
+import flank.apk.Apk
 import net.dongliu.apk.parser.ApkFile
 import org.xml.sax.InputSource
 import java.io.StringReader
 import javax.xml.parsers.DocumentBuilderFactory
 
-val parseApkTestCases = Apk.ParseTestCases { path ->
+internal val parseApkTestCases = Apk.ParseTestCases { path ->
     DexParser.findTestMethods(path)
         .map(TestMethod::testName)
 }
 
-val parseApkPackageName = Apk.ParsePackageName { path ->
+internal val parseApkPackageName = Apk.ParsePackageName { path ->
     ApkFile(path).apkMeta.packageName
 }
 
-val parseApkInfo = Apk.ParseInfo { path ->
+internal val parseApkInfo = Apk.ParseInfo { path ->
     Apk.Info(
         packageName = ApkFile(path).apkMeta.packageName,
         testRunner = DocumentBuilderFactory.newInstance()

--- a/corellium/apk/src/test/kotlin/flank/apk/ParseApkTest.kt
+++ b/corellium/apk/src/test/kotlin/flank/apk/ParseApkTest.kt
@@ -1,12 +1,13 @@
-package flank.corellium.adapter
+package flank.apk
 
-import flank.corellium.api.Apk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 private const val TEST_APK_PATH = "../../test_artifacts/master/apk/app-single-success-debug-androidTest.apk"
 
 class ParseApkTest {
+
+    private val apk = Apk.Api()
 
     @Test
     fun parseTestCases() {
@@ -16,7 +17,7 @@ class ParseApkTest {
                 "com.example.test_app.InstrumentedTest#ignoredTestWithSuppress",
                 "com.example.test_app.InstrumentedTest#test",
             ),
-            parseApkTestCases(TEST_APK_PATH)
+            apk.parseTestCases(TEST_APK_PATH)
         )
     }
 
@@ -24,7 +25,7 @@ class ParseApkTest {
     fun parsePackageName() {
         assertEquals(
             "com.example.test_app.test",
-            parseApkPackageName(TEST_APK_PATH)
+            apk.parsePackageName(TEST_APK_PATH)
         )
     }
 
@@ -35,7 +36,7 @@ class ParseApkTest {
                 packageName = "com.example.test_app.test",
                 testRunner = "androidx.test.runner.AndroidJUnitRunner"
             ),
-            parseApkInfo(TEST_APK_PATH)
+            apk.parseInfo(TEST_APK_PATH)
         )
     }
 }

--- a/corellium/cli/build.gradle.kts
+++ b/corellium/cli/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(project(":corellium:api"))
     implementation(project(":corellium:domain"))
     implementation(project(":corellium:adapter"))
+    implementation(project(":corellium:apk"))
     implementation(Dependencies.JACKSON_KOTLIN)
     implementation(Dependencies.JACKSON_YAML)
     implementation(Dependencies.JACKSON_XML)

--- a/corellium/cli/src/main/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommand.kt
+++ b/corellium/cli/src/main/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommand.kt
@@ -3,6 +3,7 @@ package flank.corellium.cli
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import flank.apk.Apk
 import flank.corellium.cli.RunTestCorelliumAndroidCommand.Config
 import flank.corellium.cli.util.ConfigMap
 import flank.corellium.cli.util.emptyConfigMap
@@ -103,6 +104,8 @@ class RunTestCorelliumAndroidCommand :
     internal val config by lazy { merge(defaultConfig(), yamlConfig(), cliConfig) }
 
     override val api by lazy { corelliumApi(config.project!!) }
+
+    override val apk = Apk.Api()
 
     override val args by lazy { createArgs() }
 

--- a/corellium/domain/build.gradle.kts
+++ b/corellium/domain/build.gradle.kts
@@ -16,6 +16,7 @@ tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
 dependencies {
     implementation(Dependencies.KOTLIN_COROUTINES_CORE)
     implementation(project(":corellium:api"))
+    implementation(project(":corellium:apk"))
     implementation(project(":corellium:shard:calculate"))
     implementation(project(":corellium:shard:obfuscate"))
     implementation(project(":corellium:shard:dump"))

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestCorelliumAndroid.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestCorelliumAndroid.kt
@@ -1,5 +1,6 @@
 package flank.corellium.domain
 
+import flank.apk.Apk
 import flank.corellium.api.Authorization
 import flank.corellium.api.CorelliumApi
 import flank.corellium.domain.RunTestCorelliumAndroid.Context
@@ -33,6 +34,7 @@ object RunTestCorelliumAndroid {
      */
     interface Context {
         val api: CorelliumApi
+        val apk: Apk.Api
         val args: Args
     }
 

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseApkInfo.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseApkInfo.kt
@@ -14,10 +14,10 @@ internal fun RunTestCorelliumAndroid.Context.parseApksInfo() = RunTestCorelliumA
     val packageNames = mutableMapOf<String, String>()
     val testRunners = mutableMapOf<String, String>()
     args.apks.map { app ->
-        packageNames[app.path] = api.parsePackageName(app.path)
+        packageNames[app.path] = apk.parsePackageName(app.path)
 
         app.tests.map { test ->
-            val info = api.parseTestApkInfo(test.path)
+            val info = apk.parseInfo(test.path)
             packageNames[test.path] = info.packageName
             testRunners[test.path] = info.testRunner
         }

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseTestCases.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseTestCases.kt
@@ -15,6 +15,6 @@ internal fun RunTestCorelliumAndroid.Context.parseTestCasesFromApks() = RunTestC
             // Get the list of paths to test apks
             .flatMap { app -> app.tests.map { test -> test.path } }
             // Associate parsed test methods to each apk path
-            .associateWith(api.parseTestCases)
+            .associateWith(apk.parseTestCases)
     )
 }

--- a/corellium/domain/src/test/kotlin/flank/corellium/domain/RunTestAndroidCorelliumExample.kt
+++ b/corellium/domain/src/test/kotlin/flank/corellium/domain/RunTestAndroidCorelliumExample.kt
@@ -1,9 +1,11 @@
 package flank.corellium.domain
 
+import flank.apk.Apk
 import flank.corellium.corelliumApi
 
 object RunTestAndroidCorelliumExample : RunTestCorelliumAndroid.Context {
     override val api = corelliumApi("Default Project")
+    override val apk = Apk.Api()
     override val args = RunTestCorelliumAndroid.Args(
         credentials = loadedCredentials,
         apks = fewTestArtifactsApks(APK_PATH_MAIN),

--- a/corellium/domain/src/test/kotlin/flank/corellium/domain/RunTestAndroidCorelliumTestMockApiAndroid.kt
+++ b/corellium/domain/src/test/kotlin/flank/corellium/domain/RunTestAndroidCorelliumTestMockApiAndroid.kt
@@ -1,6 +1,6 @@
 package flank.corellium.domain
 
-import flank.corellium.api.Apk
+import flank.apk.Apk
 import flank.corellium.api.CorelliumApi
 import flank.corellium.domain.RunTestCorelliumAndroid.Args
 import kotlinx.coroutines.flow.asFlow
@@ -48,12 +48,6 @@ class RunTestAndroidCorelliumTestMockApiAndroid : RunTestCorelliumAndroid.Contex
             assertEquals(args.credentials, credentials)
             completeJob
         },
-        parseTestCases = { path ->
-            println(path)
-            (1..path.last().toString().toInt()).map {
-                path.replace("/", ".") + ".Test#test$it"
-            }
-        },
         invokeAndroidDevices = { (amount) ->
             assertEquals(expectedShardsCount, amount)
             (1..amount).asFlow().map(Int::toString)
@@ -63,21 +57,30 @@ class RunTestAndroidCorelliumTestMockApiAndroid : RunTestCorelliumAndroid.Contex
             assertEquals(expectedShardsCount, list.size)
             completeJob
         },
+        executeTest = { (instances) ->
+            println(instances)
+            assertEquals(expectedShardsCount, instances.size)
+            emptyList()
+        },
+    )
+
+    override val apk = Apk.Api(
+        parseTestCases = { path ->
+            println(path)
+            (1..path.last().toString().toInt()).map {
+                path.replace("/", ".") + ".Test#test$it"
+            }
+        },
         parsePackageName = { path ->
             println(path)
             path
         },
-        parseTestApkInfo = { path ->
+        parseInfo = { path ->
             println(path)
             Apk.Info(
                 packageName = path,
                 testRunner = path
             )
-        },
-        executeTest = { (instances) ->
-            println(instances)
-            assertEquals(expectedShardsCount, instances.size)
-            emptyList()
         },
     )
 

--- a/corellium/domain/src/test/kotlin/flank/corellium/domain/RunTestAndroidCorelliumTestParsingAndroid.kt
+++ b/corellium/domain/src/test/kotlin/flank/corellium/domain/RunTestAndroidCorelliumTestParsingAndroid.kt
@@ -1,8 +1,6 @@
 package flank.corellium.domain
 
-import flank.corellium.adapter.parseApkInfo
-import flank.corellium.adapter.parseApkPackageName
-import flank.corellium.adapter.parseApkTestCases
+import flank.apk.Apk
 import flank.corellium.api.CorelliumApi
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
@@ -25,9 +23,6 @@ class RunTestAndroidCorelliumTestParsingAndroid : RunTestCorelliumAndroid.Contex
     }
 
     override val api = CorelliumApi(
-        parseTestCases = parseApkTestCases,
-        parsePackageName = parseApkPackageName,
-        parseTestApkInfo = parseApkInfo,
         authorize = { credentials ->
             println(credentials)
             assertEquals(args.credentials, credentials)
@@ -59,6 +54,8 @@ class RunTestAndroidCorelliumTestParsingAndroid : RunTestCorelliumAndroid.Contex
             emptyList()
         },
     )
+
+    override val apk = Apk.Api()
 
     @Test
     fun test(): Unit = invoke()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ include(
     ":corellium:client",
     ":corellium:log",
     ":corellium:api",
+    ":corellium:apk",
     ":corellium:shard",
     ":corellium:shard:calculate",
     ":corellium:shard:obfuscate",


### PR DESCRIPTION
This PR is fixing the wrong design which mixes parsers with API adapters by moving parsers to the dedicated module.