### PR TITLE
fix: Service account as default 

### DIFF
--- a/test_runner/src/main/kotlin/ftl/client/google/Credentials.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/Credentials.kt
@@ -23,8 +23,7 @@ val credential: GoogleCredentials by lazy {
             }.getOrElse {
                 when {
                     isWindows -> loadCredentialsWindows()
-                    UserAuth.exists() -> UserAuth.load()
-                    else -> throw FlankGeneralError("Error: Failed to read service account credential.\n${it.message}")
+                    else -> loadUserAuth(it.message.orEmpty())
                 }
             }
     }
@@ -33,8 +32,7 @@ val credential: GoogleCredentials by lazy {
 private fun loadCredentialsWindows() = runCatching {
     loadGoogleAccountCredentials()
 }.getOrElse {
-    if (UserAuth.exists()) UserAuth.load()
-    else throw FlankGeneralError("Error: Failed to read service account credential.\n${it.message}")
+    loadUserAuth(it.message.orEmpty())
 }
 
 private fun loadGoogleAccountCredentials(): GoogleCredentials = try {
@@ -42,6 +40,10 @@ private fun loadGoogleAccountCredentials(): GoogleCredentials = try {
 } catch (e: IOException) {
     throw FlankGeneralError("Error: Failed to read service account credential.\n${e.message}")
 }
+
+private fun loadUserAuth(topLevelErrorMessage: String) =
+    if (UserAuth.exists()) UserAuth.load()
+    else throw FlankGeneralError("Error: Failed to read service account credential.\n$topLevelErrorMessage")
 
 val httpCredential: HttpRequestInitializer by lazy {
     if (FtlConstants.useMock) {


### PR DESCRIPTION
Fixes #1792 #1831 

This pr contains changes requested in #1831 and may fix #1792. 

## Test Plan
> How do we know the code works?

1. Flank firstly should try to use credentials from env variable ```GOOGLE_APPLICATION_CREDENTIALS``` [here](https://github.com/Flank/flank/blob/c643f859e053dfdb890170a087d783c23eacbb11/test_runner/src/main/kotlin/ftl/client/google/Credentials.kt#L22)
1. If this method fails Flank should try to load credentials from ```./user_home/.flank``` directory [here](https://github.com/Flank/flank/blob/c643f859e053dfdb890170a087d783c23eacbb11/test_runner/src/main/kotlin/ftl/client/google/Credentials.kt#L26) or if it's windows from ```%USER_HOME%/.config/gcloud/application_default_credentials.json``` [here](https://github.com/Flank/flank/blob/c643f859e053dfdb890170a087d783c23eacbb11/test_runner/src/main/kotlin/ftl/client/google/Credentials.kt#L34)
