### PR TITLE
feat: Add test file column to result table

### DIFF
--- a/integration_tests/src/test/kotlin/utils/OutputReportParser.kt
+++ b/integration_tests/src/test/kotlin/utils/OutputReportParser.kt
@@ -23,7 +23,10 @@ data class OutputReport(
 
 data class Matrix(
     val app: String = "",
-    @JsonProperty("test-axises") val testAxises: List<Outcome> = emptyList()
+    @JsonProperty("test-file")
+    val testFile: String = "",
+    @JsonProperty("test-axises")
+    val testAxises: List<Outcome> = emptyList()
 )
 
 data class Outcome(

--- a/test_runner/src/main/kotlin/ftl/adapter/google/GoogleTestMatrixAdapter.kt
+++ b/test_runner/src/main/kotlin/ftl/adapter/google/GoogleTestMatrixAdapter.kt
@@ -105,11 +105,12 @@ private data class TestFilesPathWrapper(
     private val testsZip: FileReference?,
     private val appIpa: FileReference?,
     private val xctestrun: FileReference?,
-    private val testApk: FileReference?
+    private val testApk: FileReference?,
+    private val roboScript: FileReference?
 ) {
     val gcsPath: String?
         get() = (appApk ?: testsZip ?: appIpa)?.gcsPath
 
     val testFile: String?
-        get() = (testApk ?: xctestrun)?.gcsPath
+        get() = (testApk ?: xctestrun ?: roboScript)?.gcsPath
 }

--- a/test_runner/src/main/kotlin/ftl/adapter/google/GoogleTestMatrixAdapter.kt
+++ b/test_runner/src/main/kotlin/ftl/adapter/google/GoogleTestMatrixAdapter.kt
@@ -30,6 +30,7 @@ fun TestMatrix.toApiModel(identity: ftl.api.TestMatrix.Identity? = null) = Data(
     gcsRootBucket = getGcsRootBucket(),
     webLinkWithoutExecutionDetails = webLinkWithoutExecutionDetails(),
     appFileName = extractAppFileName() ?: fallbackAppName,
+    testFileName = extractTestFileName() ?: fallbackAppName,
     isCompleted = MatrixState.completed(state) &&
         testExecutions?.all { MatrixState.completed(it.state.orEmpty()) } ?: true,
     testExecutions = testExecutions?.toApiModel().orEmpty(),
@@ -81,7 +82,11 @@ fun TestExecution.toApiModel() = ftl.api.TestMatrix.TestExecution(
     toolResultsStep = toolResultsStep
 )
 
-private fun TestMatrix.extractAppFileName() = testSpecification?.run {
+private fun TestMatrix.extractAppFileName() = extractFileName { gcsPath }
+
+private fun TestMatrix.extractTestFileName() = extractFileName { testFile }
+
+private fun TestMatrix.extractFileName(fileName: TestFilesPathWrapper.() -> String?) = testSpecification?.run {
     listOf(
         androidInstrumentationTest,
         androidTestLoop,
@@ -91,15 +96,20 @@ private fun TestMatrix.extractAppFileName() = testSpecification?.run {
     )
         .firstOrNull { it != null }
         ?.toJSONObject()
-        ?.let { prettyPrint.fromJson(it.toString(), AppPath::class.java).gcsPath }
+        ?.let { prettyPrint.fromJson(it.toString(), TestFilesPathWrapper::class.java).fileName() }
         ?.substringAfterLast('/')
 }
 
-private data class AppPath(
+private data class TestFilesPathWrapper(
     private val appApk: FileReference?,
     private val testsZip: FileReference?,
-    private val appIpa: FileReference?
+    private val appIpa: FileReference?,
+    private val xctestrun: FileReference?,
+    private val testApk: FileReference?
 ) {
     val gcsPath: String?
         get() = (appApk ?: testsZip ?: appIpa)?.gcsPath
+
+    val testFile: String?
+        get() = (testApk ?: xctestrun)?.gcsPath
 }

--- a/test_runner/src/main/kotlin/ftl/api/TestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/api/TestMatrix.kt
@@ -11,6 +11,7 @@ val cancelTestMatrix: TestMatrix.Cancel get() = TestMatrixCancel
 val fetchTestSummary: TestMatrix.Summary.Fetch get() = TestMatrixFetch
 
 private const val fallbackAppName = "N/A"
+private const val fallbackTestFileName = "---"
 
 object TestMatrix {
 
@@ -33,6 +34,7 @@ object TestMatrix {
         val webLinkWithoutExecutionDetails: String? = "",
         val axes: List<Outcome> = emptyList(),
         val appFileName: String = fallbackAppName,
+        val testFileName: String = fallbackTestFileName,
         val isCompleted: Boolean = false,
         val testExecutions: List<TestExecution> = emptyList(),
         val testTimeout: Long = 0,

--- a/test_runner/src/main/kotlin/ftl/domain/testmatrix/UpdateTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/testmatrix/UpdateTestMatrix.kt
@@ -43,6 +43,7 @@ private fun TestMatrix.Data.updateProperties(newMatrix: TestMatrix.Data) = copy(
     gcsRootBucket = newMatrix.gcsRootBucket,
     webLinkWithoutExecutionDetails = newMatrix.webLinkWithoutExecutionDetails,
     appFileName = newMatrix.appFileName,
+    testFileName = newMatrix.testFileName,
     isCompleted = MatrixState.completed(state) &&
         newMatrix.testExecutions.all { MatrixState.completed(it.state) },
     testExecutions = newMatrix.testExecutions

--- a/test_runner/src/main/kotlin/ftl/json/SavedMatrixTableUtil.kt
+++ b/test_runner/src/main/kotlin/ftl/json/SavedMatrixTableUtil.kt
@@ -25,6 +25,10 @@ fun List<TestMatrix.Data>.asPrintableTable(): String = buildTable(
         data = flatMapTestAxis { matrix -> matrix.appFileName }
     ),
     TableColumn(
+        header = TEST_APP_NAME_COLUMN_HEADER,
+        data = flatMapTestAxis { matrix -> matrix.testFileName }
+    ),
+    TableColumn(
         header = TEST_AXIS_VALUE_HEADER,
         data = flatMapTestAxis { device }
     ),
@@ -48,5 +52,6 @@ private val TestMatrix.Outcome.outcomeColor
 private const val OUTCOME_COLUMN_HEADER = "OUTCOME"
 private const val MATRIX_ID_COLUMN_HEADER = "MATRIX ID"
 private const val APP_NAME_COLUMN_HEADER = "APP NAME"
+private const val TEST_APP_NAME_COLUMN_HEADER = "TEST FILE NAME"
 private const val TEST_AXIS_VALUE_HEADER = "TEST AXIS VALUE"
 private const val OUTCOME_DETAILS_COLUMN_HEADER = "TEST DETAILS"

--- a/test_runner/src/main/kotlin/ftl/reports/output/OutputReportLoggers.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/output/OutputReportLoggers.kt
@@ -24,6 +24,7 @@ internal fun OutputReport.log(matrices: Collection<TestMatrix.Data>) {
         matrices.map {
             it.matrixId to mapOf(
                 "app" to it.appFileName,
+                "test-file" to it.testFileName,
                 "test-axises" to it.axes
             )
         }.toMap()

--- a/test_runner/src/test/kotlin/ftl/reports/output/OutputReportLoggersTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/output/OutputReportLoggersTest.kt
@@ -47,12 +47,14 @@ class OutputReportLoggersTest {
                 matrixId = "1",
                 axes = listOf(TestMatrix.Outcome("device1")),
                 appFileName = "any.apk",
+                testFileName = "test-debug.apk",
                 historyId = historyId
             )
         )
         val testResults = matrices.map {
             it.matrixId to mapOf(
                 "app" to it.appFileName,
+                "test-file" to it.testFileName,
                 "test-axises" to it.axes
             )
         }.toMap()


### PR DESCRIPTION
Fixes #1803 

## Test Plan
> How do we know the code works?

1. Run `./gradlew flankFullRun`
2. Run any flank test run (android/ios)
3. Result table should have the `TEST FILE` column with the correct debug/xctest/json file name.

## Checklist

- [x] Unit tested
- [x] IT updated