### PR TITLE
feat: Enable GPU acceleration for new instances

### DIFF
--- a/corellium/api/src/main/kotlin/flank/corellium/api/AndroidInstance.kt
+++ b/corellium/api/src/main/kotlin/flank/corellium/api/AndroidInstance.kt
@@ -12,10 +12,12 @@ object AndroidInstance {
     /**
      * Configuration for devices to invoke.
      *
-     * @property amount the amount of devices to invoke.
+     * @property amount The amount of devices to invoke.
+     * @property gpuAcceleration Enables gpu acceleration for virtual devices.
      */
     data class Config(
-        val amount: Int
+        val amount: Int,
+        val gpuAcceleration: Boolean
     )
 
     /**
@@ -23,7 +25,7 @@ object AndroidInstance {
      *
      * After successful invoke, the devices specified in th [Config] should be running and ready for use.
      *
-     * @return list of invoked device ids.
+     * @return List of invoked device ids.
      */
     fun interface Invoke : (Config) -> Flow<String>
 }

--- a/corellium/cli/src/main/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommand.kt
+++ b/corellium/cli/src/main/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommand.kt
@@ -90,6 +90,17 @@ class RunTestCorelliumAndroidCommand :
             ]
         )
         var obfuscate: Boolean? by data
+
+        @set:CommandLine.Option(
+            names = ["--gpu-acceleration"],
+            description = [
+                "Enable cloud GPU acceleration (Extra costs incurred)." +
+                    "Currently this option only works for newly devices created." +
+                    "To create new device pool with gpu-acceleration, remove old devices manually and let Flank recreate the pool."
+            ]
+        )
+        @set:JsonProperty("gpu-acceleration")
+        var gpuAcceleration: Boolean? by data
     }
 
     @CommandLine.Mixin
@@ -119,6 +130,7 @@ private fun defaultConfig() = Config().apply {
     maxTestShards = 1
     localResultsDir = null
     obfuscate = false
+    gpuAcceleration = true
 }
 
 private fun RunTestCorelliumAndroidCommand.yamlConfig(): Config =
@@ -130,4 +142,5 @@ private fun RunTestCorelliumAndroidCommand.createArgs() = Args(
     maxShardsCount = config.maxTestShards!!,
     outputDir = config.localResultsDir ?: Args.DefaultOutputDir.new,
     obfuscateDumpShards = config.obfuscate!!,
+    gpuAcceleration = config.gpuAcceleration!!
 )

--- a/corellium/cli/src/test/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommandTest.kt
+++ b/corellium/cli/src/test/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommandTest.kt
@@ -34,6 +34,7 @@ class RunTestCorelliumAndroidCommandTest {
         maxTestShards = Int.MAX_VALUE
         localResultsDir = "test_result_dir"
         obfuscate = true
+        gpuAcceleration = false
     }
 
     /**
@@ -57,6 +58,7 @@ class RunTestCorelliumAndroidCommandTest {
                 "--max-test-shards=$maxTestShards",
                 "--local-result-dir=$localResultsDir",
                 "--obfuscate=$obfuscate",
+                "--gpu-acceleration=$gpuAcceleration",
             )
         }
 
@@ -75,6 +77,7 @@ apks:
 max-test-shards: $maxTestShards
 local-result-dir: $localResultsDir
 obfuscate: $obfuscate
+gpu-acceleration: $gpuAcceleration
             """.trimIndent()
         }
 
@@ -136,7 +139,8 @@ obfuscate: $obfuscate
                 apks = apks!!,
                 maxShardsCount = maxTestShards!!,
                 outputDir = localResultsDir!!,
-                obfuscateDumpShards = obfuscate!!
+                obfuscateDumpShards = obfuscate!!,
+                gpuAcceleration = gpuAcceleration!!,
             )
         }
 

--- a/corellium/client/src/main/kotlin/flank/corellium/client/data/DTOs.kt
+++ b/corellium/client/src/main/kotlin/flank/corellium/client/data/DTOs.kt
@@ -38,14 +38,29 @@ data class Instance(
         val info: String = ""
     )
 
+    /**
+     * @param udid Predefined Unique Device ID (UDID) for iOS device
+     * @param screen Change the screen metrics for Ranchu devices `XxY[:DPI]`, e.g. `720x1280:280`
+     * @param additionalTags features to utilize for the device, valid options include. Check [AdditionalTags]
+     */
     @Serializable
     data class BootOptions(
         val bootArgs: String = "",
         val restoreBootArgs: String = "",
         val udid: String = "",
         val ecid: String = "",
-        val screen: String = ""
-    )
+        val screen: String = "",
+        val additionalTags: List<String> = emptyList(),
+    ) {
+        /**
+         * @property GPU Enable cloud GPU acceleration (Extra costs incurred, cloud only).
+         * @property KALLOC Enable kalloc/kfree trace access via GDB (Enterprise only).
+         */
+        object AdditionalTags {
+            const val GPU = "gpu"
+            const val KALLOC = "kalloc"
+        }
+    }
 }
 
 @Serializable

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestCorelliumAndroid.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestCorelliumAndroid.kt
@@ -49,6 +49,7 @@ object RunTestCorelliumAndroid {
      * @param maxShardsCount Maximum amount of shards to create. For each shard Flank is invoking dedicated device instance, so do not use values grater than maximum number available instances in the Corellium account.
      * @param obfuscateDumpShards Obfuscate the test names in shards before dumping to file.
      * @param outputDir Set output dir. Default value is [DefaultOutputDir.new]
+     * @param gpuAcceleration Enable gpu acceleration for newly created virtual devices.
      */
     data class Args(
         val credentials: Authorization.Credentials,
@@ -56,6 +57,7 @@ object RunTestCorelliumAndroid {
         val maxShardsCount: Int,
         val obfuscateDumpShards: Boolean = false,
         val outputDir: String = DefaultOutputDir.new,
+        val gpuAcceleration: Boolean = true,
     ) {
         /**
          * Default output directory scheme.

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/InvokeDevices.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/InvokeDevices.kt
@@ -16,5 +16,9 @@ import kotlinx.coroutines.flow.toList
  */
 internal fun RunTestCorelliumAndroid.Context.invokeDevices() = RunTestCorelliumAndroid.step {
     println("* Invoking devices")
-    copy(ids = api.invokeAndroidDevices(AndroidInstance.Config(shards.size)).toList())
+    val config = AndroidInstance.Config(
+        amount = shards.size,
+        gpuAcceleration = args.gpuAcceleration
+    )
+    copy(ids = api.invokeAndroidDevices(config).toList())
 }


### PR DESCRIPTION
Fixes #1983 

## Test Plan
> How do we know the code works?

1. Remove previously created virtual devices in Corellium project.
2. Run `flank corellium test android run -c="./flank_corellium.yml"`
3. Check the newly created devices have enabled GPU acceleration
    * Debug `RunTestAndroidCorelliumExample` and check `flank.corellium.adapter.getCreatedInstances` are returning instances with properly configured `BootOptions`|
    * Or find another way for checking if GPU acceleration is enabled.

## Checklist

- [x] Documented
- [x] Unit tested
