### PR TITLE
feat:  Disable window animation in tests by default

### DIFF
--- a/corellium/instrument/command/src/main/kotlin/flank/instrument/command/FormatAmInstrumentCommand.kt
+++ b/corellium/instrument/command/src/main/kotlin/flank/instrument/command/FormatAmInstrumentCommand.kt
@@ -15,26 +15,34 @@ package flank.instrument.command
  * "package package.name"
  * ```
  *
- * @param packageName the package name of the android test apk.
- * @param testRunner the test runner full name.
- * @param testCases the list of test cases names.
+ * @param packageName The package name of the android test apk.
+ * @param testRunner The test runner full name.
+ * @param testCases The list of test cases names.
+ * @param noWindowAnimation Adds `--no-window-animation` to command.
  */
 fun formatAmInstrumentCommand(
     packageName: String,
     testRunner: String,
     testCases: List<String>,
+    noWindowAnimation: Boolean = true,
 ): String {
     val testCasesChunk = testCases // example: listOf("class foo.Bar#baz")
         .map { it.split(" ") } // example: listOf(listOf("class", "foo.Bar#baz"))
         .groupBy({ it.first() }, { it.last() }) // example: first => "class", last => "foo.Bar#baz"
         .toList().joinToString("") { (type, tests: List<String>) ->
             "-e $type ${tests.joinToString(",")} " // example: "-e class foo.Bar#baz"
-        } // example: "-e class foo.Bar#baz1,foo.Bar#baz2 -e package foo.test "
+        }.trimEnd() // example: "-e class foo.Bar#baz1,foo.Bar#baz2 -e package foo.test"
 
     val runnerChunk = "$packageName/$testRunner"
 
-    // example: "am instrument -r -w -e class foo.Bar#baz foo.test/androidx.test.runner.AndroidJUnitRunner"
-    return AM_INSTRUMENT + testCasesChunk + runnerChunk
+    // example: "am instrument -r -w --no-window-animation -e class foo.Bar#baz foo.test/androidx.test.runner.AndroidJUnitRunner"
+    return listOfNotNull(
+        AM_INSTRUMENT,
+        NO_WINDOW_ANIMATION.takeIf { noWindowAnimation },
+        testCasesChunk,
+        runnerChunk
+    ).joinToString(" ")
 }
 
-private const val AM_INSTRUMENT = "am instrument -r -w "
+private const val AM_INSTRUMENT = "am instrument -r -w"
+private const val NO_WINDOW_ANIMATION = "--no-window-animation"

--- a/corellium/instrument/command/src/test/kotlin/flank/instrument/command/FormatAmInstrumentCommandKtTest.kt
+++ b/corellium/instrument/command/src/test/kotlin/flank/instrument/command/FormatAmInstrumentCommandKtTest.kt
@@ -8,6 +8,7 @@ class FormatAmInstrumentCommandKtTest {
     @Test
     fun test() {
         val expected = "am instrument -r -w" +
+            " --no-window-animation" +
             " -e class com.package.Test1#testMethod1,com.package.Test2#testMethod1,com.package.Test2#testMethod2" +
             " -e package com.package.nested1,com.package.nested2 com.package/AnyRunner"
 
@@ -20,7 +21,8 @@ class FormatAmInstrumentCommandKtTest {
                 "class com.package.Test2#testMethod2",
                 "package com.package.nested1",
                 "package com.package.nested2",
-            )
+            ),
+            // noWindowAnimation = true, // No window animation should be disable by default
         )
 
         assertEquals(expected, actual)


### PR DESCRIPTION
Espresso tests require animations to be disabled. On firebase test lab, animations are disabled by default.

This PR is adding `--no-window-animation` to `am instrument` command

## Test Plan

1. Run `flank corellium test android run -c="./test_configs/flank-corellium.yml"`
2. Observe log lines like: `Sending command: am instrument -r -w --no-window-animation -e class com.example...`

## Checklist

- [x] Documented
- [x] Unit tested
