### PR TITLE
fix: Disable ASCII doc generation (release blocker)

### DIFF
--- a/.github/workflows/release_notes_generation.yml
+++ b/.github/workflows/release_notes_generation.yml
@@ -17,10 +17,11 @@ jobs:
         git fetch --prune --unshallow --tags
         git tag
 
-    - name: Generate documentation
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: "test_runner:processCliAsciiDoc"
+# Temporary disable ASCII doc generation because is failing and blocking crucial release.
+#    - name: Generate documentation
+#      uses: eskatos/gradle-command-action@v1
+#      with:
+#        arguments: "test_runner:processCliAsciiDoc"
 
     - name: Download flankScripts and add it to PATH
       env: 


### PR DESCRIPTION
Fixes: #1995

Generating release is failing because of the ASCII generator task, which is blocking the crucial release.

This PR disables ASCII doc generation as a temporary fix.

references:
* https://github.com/Flank/flank/actions/runs/895343619
* https://scans.gradle.com/s/upwhryz6ss3gy/failure#1