### PR TITLE
feat: Additional config options for test pairs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -661,13 +661,19 @@ flank:
   ## Default: false
   # keep-file-path: false
 
-  ### Additional App/Test APKS 
+  ### Additional App/Test APKS
   ## Include additional app/test apk pairs in the run. Apks are unique by just filename and not by path!
   ## If app is omitted, then the top level app is used for that pair.
+  ## You can overwrite global config per each test pair.
+  ## Currently supported options are: max-test-shards, test-targets, client-details, environment-variables, device
   # additional-app-test-apks:
   #  - app: ../test_projects/android/apks/app-debug.apk
   #    test: ../test_projects/android/apks/app1-debug-androidTest.apk
+  #    device:
+  #      - model: Nexus6P
+  #        version: 27
   #  - test: ../test_projects/android/apks/app2-debug-androidTest.apk
+  #    max-test-shards: 5
 
   ### Run Timeout
   ## The max time this test run can execute before it is cancelled (default: unlimited).

--- a/integration_tests/src/test/kotlin/integration/MultipleApksIT.kt
+++ b/integration_tests/src/test/kotlin/integration/MultipleApksIT.kt
@@ -3,6 +3,7 @@ package integration
 import FlankCommand
 import com.google.common.truth.Truth.assertThat
 import integration.config.AndroidTest
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import run
@@ -48,10 +49,16 @@ class MultipleApksIT {
             "MainActivity_robo_script.json"
         )
 
-        resOutput.findTestDirectoryFromOutput().toJUnitXmlFile().loadAsTestSuite().run {
-            assertTestResultContainsWebLinks()
-            assertTestPass(multipleSuccessfulTests)
-            assertTestFail(multipleFailedTests)
+        val xmlResult = resOutput.findTestDirectoryFromOutput().toJUnitXmlFile().loadAsTestSuite()
+
+        xmlResult.assertTestResultContainsWebLinks()
+        xmlResult.assertTestPass(multipleSuccessfulTests)
+        xmlResult.assertTestFail(multipleFailedTests)
+
+        xmlResult.testSuites.groupBy { it.name }.run {
+            assertEquals(2, get("NexusLowRes-28-en-portrait")?.size)
+            assertEquals(9, get("Pixel2-28-en-portrait")?.size)
+            assertEquals(1, get("Nexus6P-28-en-portrait")?.size)
         }
 
         val outputReport = resOutput.findTestDirectoryFromOutput().toOutputReportFile().json().asOutputReport()

--- a/integration_tests/src/test/kotlin/integration/MultipleApksIT.kt
+++ b/integration_tests/src/test/kotlin/integration/MultipleApksIT.kt
@@ -20,9 +20,9 @@ import utils.assertTestResultContainsWebLinks
 import utils.findTestDirectoryFromOutput
 import utils.json
 import utils.loadAsTestSuite
-import utils.multipleFailedTests
 import utils.multipleSuccessfulTests
 import utils.removeUnicode
+import utils.testResults.TestSuite
 import utils.toJUnitXmlFile
 import utils.toOutputReportFile
 
@@ -53,12 +53,16 @@ class MultipleApksIT {
 
         xmlResult.assertTestResultContainsWebLinks()
         xmlResult.assertTestPass(multipleSuccessfulTests)
-        xmlResult.assertTestFail(multipleFailedTests)
+        xmlResult.assertTestFail(listOf("test2"))
 
-        xmlResult.testSuites.groupBy { it.name }.run {
-            assertEquals(2, get("NexusLowRes-28-en-portrait")?.size)
-            assertEquals(9, get("Pixel2-28-en-portrait")?.size)
-            assertEquals(1, get("Nexus6P-28-en-portrait")?.size)
+        xmlResult.testSuites.groupBy { it.name }.mapValues { it.value.flatMap(TestSuite::testCases) }.run {
+            assertEquals(20, get("NexusLowRes-28-en-portrait")?.size)
+            assertEquals(1, get("Pixel2-28-en-portrait")?.size)
+            assertEquals("com.example.test_app.InstrumentedTest", get("Pixel2-28-en-portrait")?.get(0)?.classname)
+            assertEquals("test2", get("Pixel2-28-en-portrait")?.get(0)?.name)
+            assertEquals(1, get("Nexus6P-27-en-portrait")?.size)
+            assertEquals("com.example.test_app.InstrumentedTest", get("Nexus6P-27-en-portrait")?.get(0)?.classname)
+            assertEquals("test", get("Nexus6P-27-en-portrait")?.get(0)?.name)
         }
 
         val outputReport = resOutput.findTestDirectoryFromOutput().toOutputReportFile().json().asOutputReport()
@@ -76,7 +80,7 @@ class MultipleApksIT {
             .map { it.testAxises }
             .flatten()
 
-        assertThat(testsResults.sumOf { it.suiteOverview.failures }).isEqualTo(5)
-        assertThat(testsResults.sumOf { it.suiteOverview.total }).isEqualTo(41)
+        assertThat(testsResults.sumOf { it.suiteOverview.failures }).isEqualTo(1)
+        assertThat(testsResults.sumOf { it.suiteOverview.total }).isEqualTo(22)
     }
 }

--- a/integration_tests/src/test/resources/cases/flank_android_multiple_apk.yml
+++ b/integration_tests/src/test/resources/cases/flank_android_multiple_apk.yml
@@ -9,7 +9,16 @@ flank:
   output-style: single
   additional-app-test-apks:
     - test: ../test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-success-debug-androidTest.apk
+      max-test-shards: 2
     - test: ../test_runner/src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-error-debug-androidTest.apk
+      device:
+        - model: Pixel2
+          version: 28
+      test-targets:
+        - class com.example.test_app.InstrumentedTest#test2
     - test: gs://flank-open-source.appspot.com/integration/app-single-success-debug-androidTest.apk
+      device:
+        - model: Nexus6P
+          version: 27
   disable-usage-statistics: true
   output-report: json

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -295,10 +295,16 @@ flank:
   ### Additional App/Test APKS
   ## Include additional app/test apk pairs in the run. Apks are unique by just filename and not by path!
   ## If app is omitted, then the top level app is used for that pair.
+  ## You can overwrite global config per each test pair.
+  ## Currently supported options are: max-test-shards, test-targets, client-details, environment-variables, device
   # additional-app-test-apks:
   #  - app: ../test_projects/android/apks/app-debug.apk
   #    test: ../test_projects/android/apks/app1-debug-androidTest.apk
+  #    device:
+  #      - model: Nexus6P
+  #        version: 27
   #  - test: ../test_projects/android/apks/app2-debug-androidTest.apk
+  #    max-test-shards: 5
 
   ### Run Timeout
   ## The max time this test run can execute before it is cancelled (default: unlimited).

--- a/test_runner/src/main/kotlin/ftl/adapter/GoogleTestMatrixAndroid.kt
+++ b/test_runner/src/main/kotlin/ftl/adapter/GoogleTestMatrixAndroid.kt
@@ -9,7 +9,7 @@ import com.google.testing.model.TestMatrix as GoogleTestMatrix
 
 object GoogleTestMatrixAndroid :
     TestMatrixAndroid.Execute,
-    (List<Pair<TestMatrixAndroid.Config, TestMatrixAndroid.Type>>) -> List<TestMatrix.Data> by { configTypePairs ->
+    (List<TestMatrixAndroid.TestSetup>) -> List<TestMatrix.Data> by { configTypePairs ->
         runBlocking {
             executeAndroidTests(configTypePairs).map(GoogleTestMatrix::toApiModel)
         }

--- a/test_runner/src/main/kotlin/ftl/adapter/GoogleTestMatrixAndroid.kt
+++ b/test_runner/src/main/kotlin/ftl/adapter/GoogleTestMatrixAndroid.kt
@@ -9,8 +9,8 @@ import com.google.testing.model.TestMatrix as GoogleTestMatrix
 
 object GoogleTestMatrixAndroid :
     TestMatrixAndroid.Execute,
-    (TestMatrixAndroid.Config, List<TestMatrixAndroid.Type>) -> List<TestMatrix.Data> by { config, types ->
+    (List<Pair<TestMatrixAndroid.Config, TestMatrixAndroid.Type>>) -> List<TestMatrix.Data> by { configTypePairs ->
         runBlocking {
-            executeAndroidTests(config, types).map(GoogleTestMatrix::toApiModel)
+            executeAndroidTests(configTypePairs).map(GoogleTestMatrix::toApiModel)
         }
     }

--- a/test_runner/src/main/kotlin/ftl/api/TestAndroidMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/api/TestAndroidMatrix.kt
@@ -65,7 +65,7 @@ object TestMatrixAndroid {
         ) : Type()
     }
 
-    interface Execute : (Config, List<Type>) -> List<TestMatrix.Data>
+    interface Execute : (List<Pair<Config, Type>>) -> List<TestMatrix.Data>
 }
 
 typealias ShardChunks = List<List<String>>

--- a/test_runner/src/main/kotlin/ftl/api/TestAndroidMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/api/TestAndroidMatrix.kt
@@ -65,7 +65,12 @@ object TestMatrixAndroid {
         ) : Type()
     }
 
-    interface Execute : (List<Pair<Config, Type>>) -> List<TestMatrix.Data>
+    data class TestSetup(
+        val config: Config,
+        val type: Type
+    )
+
+    interface Execute : (List<TestSetup>) -> List<TestMatrix.Data>
 }
 
 typealias ShardChunks = List<List<String>>

--- a/test_runner/src/main/kotlin/ftl/args/ArgsToString.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsToString.kt
@@ -58,7 +58,7 @@ object ArgsToString {
                         .map { it.replace("\n", "\n  ") }
                         .forEach { append(it) }
                 }
-            }
+            }.trimEnd()
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/ArgsToString.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsToString.kt
@@ -3,35 +3,62 @@ package ftl.args
 import ftl.args.yml.AppTestPair
 
 private const val NEW_LINE = '\n'
+private const val SPACESx8 = "        "
+private const val SPACESx10 = "          "
 
 object ArgsToString {
 
-    fun mapToString(map: Map<String, String>?): String {
+    fun mapToString(
+        map: Map<String, String>?,
+        transform: (Map.Entry<String, String>) -> String = { (key, value) -> "$SPACESx8$key: $value" }
+    ): String {
         if (map.isNullOrEmpty()) return ""
-        return NEW_LINE + map.map { (key, value) -> "        $key: $value" }
+        return NEW_LINE + map.map(transform)
             .joinToString(System.lineSeparator())
     }
 
-    fun listToString(list: List<String?>?): String {
+    fun listToString(list: List<String?>?, transform: (String) -> String = { "$SPACESx8- $it" }): String {
         if (list.isNullOrEmpty()) return ""
         return NEW_LINE + list.filterNotNull()
-            .joinToString(System.lineSeparator()) { dir -> "        - $dir" }
+            .joinToString(System.lineSeparator(), transform = transform)
     }
 
-    fun objectsToString(objects: List<Any?>?): String {
+    fun objectsToString(objects: List<Any?>?, transform: (Any) -> String = { "$it" }): String {
         if (objects.isNullOrEmpty()) return ""
         return NEW_LINE + objects.filterNotNull()
-            .joinToString(System.lineSeparator()) { "$it" }
+            .joinToString(System.lineSeparator(), transform = transform)
     }
 
     fun listOfListToString(listOfList: List<List<String?>>?): String {
         if (listOfList.isNullOrEmpty()) return ""
         return NEW_LINE + listOfList.map { list -> list.joinToString(",") { " $it" } }
-            .joinToString(System.lineSeparator()) { "        - $it" }
+            .joinToString(System.lineSeparator()) { "$SPACESx8- $it" }
     }
 
     fun apksToString(devices: List<AppTestPair>): String {
         if (devices.isNullOrEmpty()) return ""
-        return NEW_LINE + devices.joinToString(System.lineSeparator()) { (app, test) -> "        - app: $app\n          test: $test" }
+        return NEW_LINE + devices.joinToString(System.lineSeparator()) { pair ->
+            buildString {
+                if (pair.app == null) appendLine("$SPACESx8- test: ${pair.test}")
+                else {
+                    appendLine("$SPACESx8- app: ${pair.app}")
+                    appendLine("$SPACESx8  test: ${pair.test}")
+                }
+                pair.maxTestShards?.let { appendLine("$SPACESx8  max-test-shards: $it") }
+                pair.clientDetails?.let {
+                    append("$SPACESx8  client-details:${mapToString(it) { (key, value) -> "$SPACESx10  $key: $value" }}")
+                }
+                pair.testTargets?.let { list ->
+                    appendLine("$SPACESx8  test-targets:${listToString(list) { "$SPACESx10- $it" }}")
+                }
+                pair.devices?.let { list ->
+                    appendLine("$SPACESx8  device:")
+                    list
+                        .map { "  $it" }
+                        .map { it.replace("\n", "\n  ") }
+                        .forEach { append(it) }
+                }
+            }
+        }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/CreateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateAndroidArgs.kt
@@ -1,6 +1,5 @@
 package ftl.args
 
-import ftl.args.yml.AppTestPair
 import ftl.config.AndroidConfig
 import ftl.config.android.AndroidFlankConfig
 import ftl.config.android.AndroidGcloudConfig
@@ -33,14 +32,9 @@ fun createAndroidArgs(
 
     // flank
     additionalAppTestApks = flank.additionalAppTestApks?.map {
-        AppTestPair(
+        it.copy(
             app = it.app?.normalizeFilePath(),
             test = it.test.normalizeFilePath(),
-            environmentVariables = it.environmentVariables,
-            maxTestShards = it.maxTestShards ?: commonArgs.maxTestShards,
-            clientDetails = commonArgs.clientDetails.orEmpty() + it.clientDetails.orEmpty(),
-            devices = it.devices,
-            testTargets = it.testTargets
         )
     } ?: emptyList(),
     useLegacyJUnitResult = flank::useLegacyJUnitResult.require(),

--- a/test_runner/src/main/kotlin/ftl/args/CreateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CreateAndroidArgs.kt
@@ -33,18 +33,14 @@ fun createAndroidArgs(
 
     // flank
     additionalAppTestApks = flank.additionalAppTestApks?.map {
-        // if additional-pair did not provide certain values, set as top level ones
-        val mergedClientDetails = mutableMapOf<String, String>().apply {
-            // merge additionalAppTestApk's client-details with top-level client-details
-            putAll(commonArgs.clientDetails ?: emptyMap())
-            putAll(it.clientDetails)
-        }
         AppTestPair(
             app = it.app?.normalizeFilePath(),
             test = it.test.normalizeFilePath(),
             environmentVariables = it.environmentVariables,
             maxTestShards = it.maxTestShards ?: commonArgs.maxTestShards,
-            clientDetails = mergedClientDetails
+            clientDetails = commonArgs.clientDetails.orEmpty() + it.clientDetails.orEmpty(),
+            devices = it.devices,
+            testTargets = it.testTargets
         )
     } ?: emptyList(),
     useLegacyJUnitResult = flank::useLegacyJUnitResult.require(),

--- a/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateAndroidArgs.kt
@@ -200,6 +200,22 @@ private fun AndroidArgs.assertAdditionalAppTestApks() {
         .filter { (app, _) -> app == null }
         .map { File(it.test).name }
         .run { if (isNotEmpty()) throw FlankConfigurationError("Cannot resolve app apk pair for $this") }
+
+    additionalAppTestApks
+        .map {
+            copy(
+                appApk = it.app ?: appApk,
+                testApk = it.test,
+                commonArgs = commonArgs.copy(
+                    maxTestShards = it.maxTestShards ?: maxTestShards,
+                    devices = it.devices ?: devices
+                ),
+                additionalAppTestApks = emptyList()
+            )
+        }
+        .forEach {
+            it.validate()
+        }
 }
 
 private fun AndroidArgs.assertApkFilePaths() {

--- a/test_runner/src/main/kotlin/ftl/args/yml/AppTestPair.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/AppTestPair.kt
@@ -13,9 +13,9 @@ data class AppTestPair(
     @JsonProperty("max-test-shards")
     val maxTestShards: Int? = null,
     @JsonProperty("client-details")
-    var clientDetails: Map<String, String>? = null,
+    val clientDetails: Map<String, String>? = null,
     @JsonProperty("test-targets")
-    var testTargets: List<String>? = null,
-    @set:JsonProperty("device")
-    var devices: List<Device>? = null
+    val testTargets: List<String>? = null,
+    @JsonProperty("device")
+    val devices: List<Device>? = null
 )

--- a/test_runner/src/main/kotlin/ftl/args/yml/AppTestPair.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/AppTestPair.kt
@@ -2,6 +2,7 @@ package ftl.args.yml
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import ftl.config.Device
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class AppTestPair(
@@ -12,5 +13,9 @@ data class AppTestPair(
     @JsonProperty("max-test-shards")
     val maxTestShards: Int? = null,
     @JsonProperty("client-details")
-    var clientDetails: Map<String, String> = emptyMap()
+    var clientDetails: Map<String, String>? = null,
+    @JsonProperty("test-targets")
+    var testTargets: List<String>? = null,
+    @set:JsonProperty("device")
+    var devices: List<Device>? = null
 )

--- a/test_runner/src/main/kotlin/ftl/client/google/run/android/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/run/android/GcAndroidTestMatrix.kt
@@ -32,11 +32,10 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
 suspend fun executeAndroidTests(
-    config: TestMatrixAndroid.Config,
-    testMatrixTypes: List<TestMatrixAndroid.Type>,
-): List<TestMatrix> = testMatrixTypes
-    .foldIndexed(emptyList<Deferred<TestMatrix>>()) { testMatrixTypeIndex, testMatrices, testMatrixType ->
-        testMatrices + executeAndroidTestMatrix(testMatrixType, testMatrixTypeIndex, config)
+    typeConfigPairs: List<Pair<TestMatrixAndroid.Config, TestMatrixAndroid.Type>>
+): List<TestMatrix> = typeConfigPairs
+    .foldIndexed(emptyList<Deferred<TestMatrix>>()) { testMatrixTypeIndex, testMatrices, testPair ->
+        testMatrices + executeAndroidTestMatrix(testPair.second, testMatrixTypeIndex, testPair.first)
     }.awaitAll()
 
 private suspend fun executeAndroidTestMatrix(
@@ -58,10 +57,8 @@ private fun createAndroidTestMatrix(
     runIndex: Int
 ): Testing.Projects.TestMatrices.Create {
 
-    val clientDetails = config.clientInfo(testMatrixType)
-
     val testMatrix = TestMatrix()
-        .setClientInfo(clientDetails)
+        .setClientInfo(config.clientInfo)
         .setTestSpecification(getTestSpecification(testMatrixType, config))
         .setResultStorage(config.resultsStorage(contextIndex, runIndex))
         .setEnvironmentMatrix(config.environmentMatrix)
@@ -73,18 +70,11 @@ private fun createAndroidTestMatrix(
     }.getOrElse { e -> throw FlankGeneralError(e) }
 }
 
-fun TestMatrixAndroid.Config.clientInfo(matrix: TestMatrixAndroid.Type): ClientInfo {
-    return if (matrix is TestMatrixAndroid.Type.Instrumentation && matrix.clientDetails.isNotEmpty()) {
-        ClientInfo()
-            .setName("Flank")
-            .setClientInfoDetails(matrix.clientDetails.toClientInfoDetailList())
-    } else {
-        // https://github.com/bootstraponline/studio-google-cloud-testing/blob/203ed2890c27a8078cd1b8f7ae12cf77527f426b/firebase-testing/src/com/google/gct/testing/launcher/CloudTestsLauncher.java#L120
-        ClientInfo()
-            .setName("Flank")
-            .setClientInfoDetails(clientDetails?.toClientInfoDetailList())
-    }
-}
+// https://github.com/bootstraponline/studio-google-cloud-testing/blob/203ed2890c27a8078cd1b8f7ae12cf77527f426b/firebase-testing/src/com/google/gct/testing/launcher/CloudTestsLauncher.java#L120
+private val TestMatrixAndroid.Config.clientInfo
+    get() = ClientInfo()
+        .setName("Flank")
+        .setClientInfoDetails(clientDetails?.toClientInfoDetailList())
 
 private val TestMatrixAndroid.Config.environmentMatrix
     get() = EnvironmentMatrix()

--- a/test_runner/src/main/kotlin/ftl/client/google/run/android/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/run/android/GcAndroidTestMatrix.kt
@@ -32,10 +32,10 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
 suspend fun executeAndroidTests(
-    typeConfigPairs: List<Pair<TestMatrixAndroid.Config, TestMatrixAndroid.Type>>
-): List<TestMatrix> = typeConfigPairs
-    .foldIndexed(emptyList<Deferred<TestMatrix>>()) { testMatrixTypeIndex, testMatrices, testPair ->
-        testMatrices + executeAndroidTestMatrix(testPair.second, testMatrixTypeIndex, testPair.first)
+    testSetups: List<TestMatrixAndroid.TestSetup>
+): List<TestMatrix> = testSetups
+    .foldIndexed(emptyList<Deferred<TestMatrix>>()) { testMatrixTypeIndex, testMatrices, setUp ->
+        testMatrices + executeAndroidTestMatrix(setUp.type, testMatrixTypeIndex, setUp.config)
     }.awaitAll()
 
 private suspend fun executeAndroidTestMatrix(

--- a/test_runner/src/main/kotlin/ftl/config/android/AndroidFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/android/AndroidFlankConfig.kt
@@ -20,8 +20,10 @@ data class AndroidFlankConfig @JsonIgnore constructor(
         names = ["--additional-app-test-apks"],
         split = ",",
         description = [
-            "A list of app & test apks to include in the run. " +
-                "Useful for running multiple module tests within a single Flank run."
+            "A list of app & test apks to include in the run. Useful for running multiple module tests " +
+                "within a single Flank run.",
+            "You can overwrite global config per each test pair. Currently supported options are: " +
+                "max-test-shards, test-targets, client-details, environment-variables, device"
         ]
     )
     fun additionalAppTestApks(map: Map<String, String>?) {

--- a/test_runner/src/main/kotlin/ftl/config/android/AndroidFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/android/AndroidFlankConfig.kt
@@ -7,7 +7,6 @@ import ftl.args.yml.AppTestPair
 import ftl.args.yml.IYmlKeys
 import ftl.args.yml.ymlKeys
 import ftl.config.Config
-import ftl.config.Device
 import picocli.CommandLine
 
 /** Flank specific parameters for Android */
@@ -25,7 +24,7 @@ data class AndroidFlankConfig @JsonIgnore constructor(
                 "Useful for running multiple module tests within a single Flank run."
         ]
     )
-    fun additionalAppTestApks(map: Map<String, Any>?) {
+    fun additionalAppTestApks(map: Map<String, String>?) {
         if (map.isNullOrEmpty()) return
         if (additionalAppTestApks == null) additionalAppTestApks = mutableListOf()
 
@@ -37,9 +36,8 @@ data class AndroidFlankConfig @JsonIgnore constructor(
                 AppTestPair(
                     app = appApk.toString(),
                     test = testApk.toString(),
-                    maxTestShards = map["max-test-shards"]?.toString()?.toInt(),
-                    testTargets = map["test-targets"] as? List<String>,
-                    devices = map["device"] as? List<Device>
+                    maxTestShards = map["max-test-shards"]?.toInt(),
+                    testTargets = map["test-targets"]?.split(",")
                 )
             )
         }

--- a/test_runner/src/main/kotlin/ftl/config/android/AndroidFlankConfig.kt
+++ b/test_runner/src/main/kotlin/ftl/config/android/AndroidFlankConfig.kt
@@ -7,6 +7,7 @@ import ftl.args.yml.AppTestPair
 import ftl.args.yml.IYmlKeys
 import ftl.args.yml.ymlKeys
 import ftl.config.Config
+import ftl.config.Device
 import picocli.CommandLine
 
 /** Flank specific parameters for Android */
@@ -24,7 +25,7 @@ data class AndroidFlankConfig @JsonIgnore constructor(
                 "Useful for running multiple module tests within a single Flank run."
         ]
     )
-    fun additionalAppTestApks(map: Map<String, String>?) {
+    fun additionalAppTestApks(map: Map<String, Any>?) {
         if (map.isNullOrEmpty()) return
         if (additionalAppTestApks == null) additionalAppTestApks = mutableListOf()
 
@@ -34,9 +35,11 @@ data class AndroidFlankConfig @JsonIgnore constructor(
         if (testApk != null) {
             additionalAppTestApks?.add(
                 AppTestPair(
-                    app = appApk,
-                    test = testApk,
-                    maxTestShards = map["max-test-shards"]?.toInt()
+                    app = appApk.toString(),
+                    test = testApk.toString(),
+                    maxTestShards = map["max-test-shards"]?.toString()?.toInt(),
+                    testTargets = map["test-targets"] as? List<String>,
+                    devices = map["device"] as? List<Device>
                 )
             )
         }

--- a/test_runner/src/main/kotlin/ftl/run/model/AndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/model/AndroidTestContext.kt
@@ -6,11 +6,7 @@ import ftl.args.AndroidArgs
 import ftl.args.IgnoredTestCases
 import ftl.shard.Chunk
 
-interface WithArgs {
-    val args: AndroidArgs
-}
-
-sealed class AndroidTestContext : WithArgs
+sealed class AndroidTestContext(open val args: AndroidArgs)
 
 data class InstrumentationTestContext(
     val app: FileReference,
@@ -20,22 +16,22 @@ data class InstrumentationTestContext(
     val environmentVariables: Map<String, String> = emptyMap(),
     val testTargetsForShard: ShardChunks = emptyList(),
     override val args: AndroidArgs
-) : AndroidTestContext()
+) : AndroidTestContext(args)
 
 data class RoboTestContext(
     val app: FileReference,
     val roboScript: FileReference,
     override val args: AndroidArgs
-) : AndroidTestContext()
+) : AndroidTestContext(args)
 
 data class GameLoopContext(
     val app: FileReference,
     val scenarioLabels: List<String>,
     val scenarioNumbers: List<String>,
     override val args: AndroidArgs
-) : AndroidTestContext()
+) : AndroidTestContext(args)
 
 data class SanityRoboTestContext(
     val app: FileReference,
     override val args: AndroidArgs
-) : AndroidTestContext()
+) : AndroidTestContext(args)

--- a/test_runner/src/main/kotlin/ftl/run/model/AndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/model/AndroidTestContext.kt
@@ -2,10 +2,15 @@ package ftl.run.model
 
 import ftl.api.FileReference
 import ftl.api.ShardChunks
+import ftl.args.AndroidArgs
 import ftl.args.IgnoredTestCases
 import ftl.shard.Chunk
 
-sealed class AndroidTestContext
+interface WithArgs {
+    val args: AndroidArgs
+}
+
+sealed class AndroidTestContext : WithArgs
 
 data class InstrumentationTestContext(
     val app: FileReference,
@@ -14,21 +19,23 @@ data class InstrumentationTestContext(
     val ignoredTestCases: IgnoredTestCases = emptyList(),
     val environmentVariables: Map<String, String> = emptyMap(),
     val testTargetsForShard: ShardChunks = emptyList(),
-    val maxTestShards: Int? = null,
-    val clientDetails: Map<String, String> = emptyMap(),
+    override val args: AndroidArgs
 ) : AndroidTestContext()
 
 data class RoboTestContext(
     val app: FileReference,
-    val roboScript: FileReference
+    val roboScript: FileReference,
+    override val args: AndroidArgs
 ) : AndroidTestContext()
 
 data class GameLoopContext(
     val app: FileReference,
     val scenarioLabels: List<String>,
     val scenarioNumbers: List<String>,
+    override val args: AndroidArgs
 ) : AndroidTestContext()
 
 data class SanityRoboTestContext(
-    val app: FileReference
+    val app: FileReference,
+    override val args: AndroidArgs
 ) : AndroidTestContext()

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -45,8 +45,8 @@ internal suspend fun AndroidArgs.runAndroidTests(): TestResult = coroutineScope 
                 allTestShardChunks += context.shards
             }
         }
-        .map { context -> createAndroidTestMatrixType(context) }
-        .run { executeTestMatrixAndroid(createAndroidTestConfig(args), toList()) }
+        .map { context -> createAndroidTestConfig(context.args) to createAndroidTestMatrixType(context) }
+        .run { executeTestMatrixAndroid(this) }
         .takeIf { it.isNotEmpty() }
         ?: throw FlankGeneralError("There are no Android tests to run.")
 

--- a/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/RunAndroidTests.kt
@@ -3,6 +3,7 @@ package ftl.run.platform
 import flank.common.join
 import flank.common.logLn
 import ftl.api.RemoteStorage
+import ftl.api.TestMatrixAndroid
 import ftl.api.executeTestMatrixAndroid
 import ftl.api.uploadToRemoteStorage
 import ftl.args.AndroidArgs
@@ -45,7 +46,7 @@ internal suspend fun AndroidArgs.runAndroidTests(): TestResult = coroutineScope 
                 allTestShardChunks += context.shards
             }
         }
-        .map { context -> createAndroidTestConfig(context.args) to createAndroidTestMatrixType(context) }
+        .map { createTestSetup(it) }
         .run { executeTestMatrixAndroid(this) }
         .takeIf { it.isNotEmpty() }
         ?: throw FlankGeneralError("There are no Android tests to run.")
@@ -82,4 +83,9 @@ private fun AndroidMatrixTestShards.saveShards(config: AndroidArgs) = saveShardC
     shards = this,
     size = size,
     obfuscatedOutput = config.obfuscateDumpShards
+)
+
+private suspend fun createTestSetup(context: AndroidTestContext) = TestMatrixAndroid.TestSetup(
+    config = createAndroidTestConfig(context.args),
+    type = context.args.createAndroidTestMatrixType(context)
 )

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
@@ -41,7 +41,7 @@ private suspend fun List<AndroidTestContext>.setupShards(
 ): List<AndroidTestContext> = coroutineScope {
     map { testContext ->
         async {
-            val newArgs = args.prepareArgsForSharding(testContext)
+            val newArgs = testContext.args
             when {
                 testContext !is InstrumentationTestContext -> testContext
                 newArgs.useCustomSharding -> testContext.userShards(newArgs.customSharding)
@@ -50,11 +50,6 @@ private suspend fun List<AndroidTestContext>.setupShards(
             }
         }
     }.awaitAll().dropEmptyInstrumentationTest()
-}
-private fun AndroidArgs.prepareArgsForSharding(context: AndroidTestContext): AndroidArgs {
-    return if (context is InstrumentationTestContext && context.maxTestShards != null) {
-        copy(commonArgs = commonArgs.copy(maxTestShards = context.maxTestShards))
-    } else this
 }
 
 private fun InstrumentationTestContext.userShards(customShardingMap: Map<String, AndroidTestShards>) = customShardingMap

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestContext.kt
@@ -31,22 +31,20 @@ import kotlinx.coroutines.coroutineScope
 import java.io.File
 import ftl.shard.TestMethod as ShardTestMethod
 
-suspend fun AndroidArgs.createAndroidTestContexts(): List<AndroidTestContext> = resolveApks().setupShards(this)
+suspend fun AndroidArgs.createAndroidTestContexts(): List<AndroidTestContext> = resolveApks().setupShards()
 
 private val customTestAnnotations = listOf("org.junit.experimental.theories.Theory")
 
-private suspend fun List<AndroidTestContext>.setupShards(
-    args: AndroidArgs,
-    testFilter: TestFilter = TestFilters.fromTestTargets(args.testTargets, args.testTargetsForShard)
-): List<AndroidTestContext> = coroutineScope {
+private suspend fun List<AndroidTestContext>.setupShards(): List<AndroidTestContext> = coroutineScope {
     map { testContext ->
         async {
             val newArgs = testContext.args
+            val filters = TestFilters.fromTestTargets(newArgs.testTargets, newArgs.testTargetsForShard)
             when {
                 testContext !is InstrumentationTestContext -> testContext
                 newArgs.useCustomSharding -> testContext.userShards(newArgs.customSharding)
-                newArgs.useTestTargetsForShard -> testContext.downloadApks().calculateDummyShards(newArgs, testFilter)
-                else -> testContext.downloadApks().calculateShards(newArgs, testFilter)
+                newArgs.useTestTargetsForShard -> testContext.downloadApks().calculateDummyShards(newArgs, filters)
+                else -> testContext.downloadApks().calculateShards(newArgs, filters)
             }
         }
     }.awaitAll().dropEmptyInstrumentationTest()

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestMatrixType.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/CreateAndroidTestMatrixType.kt
@@ -40,7 +40,7 @@ internal fun AndroidArgs.createInstrumentationConfig(
     keepTestTargetsEmpty = disableSharding && testTargets.isEmpty(),
     environmentVariables = testApk.environmentVariables,
     testTargetsForShard = testTargetsForShard,
-    clientDetails = testApk.clientDetails
+    clientDetails = clientDetails.orEmpty()
 )
 
 internal fun AndroidArgs.createRoboConfig(

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
@@ -24,11 +24,12 @@ private fun AndroidArgs.mainApkContext() = appApk?.let { appApk ->
             app = appApk.asFileReference(),
             test = testApk.asFileReference(),
             environmentVariables = emptyMap(),
-            testTargetsForShard = testTargetsForShard
+            testTargetsForShard = testTargetsForShard,
+            args = this
         )
-        roboScript != null -> RoboTestContext(app = appApk.asFileReference(), roboScript = roboScript.asFileReference())
-        isSanityRobo -> SanityRoboTestContext(app = appApk.asFileReference())
-        isGameLoop -> GameLoopContext(appApk.asFileReference(), scenarioLabels, scenarioNumbers)
+        roboScript != null -> RoboTestContext(app = appApk.asFileReference(), roboScript = roboScript.asFileReference(), this)
+        isSanityRobo -> SanityRoboTestContext(app = appApk.asFileReference(), this)
+        isGameLoop -> GameLoopContext(appApk.asFileReference(), scenarioLabels, scenarioNumbers, this)
         else -> null
     }
 }
@@ -41,7 +42,13 @@ private fun AndroidArgs.additionalApksContexts() = additionalAppTestApks.map {
         test = it.test.asFileReference(),
         environmentVariables = it.environmentVariables,
         testTargetsForShard = testTargetsForShard,
-        maxTestShards = it.maxTestShards,
-        clientDetails = it.clientDetails,
+        args = copy(
+            commonArgs = commonArgs.copy(
+                maxTestShards = it.maxTestShards ?: maxTestShards,
+                devices = it.devices ?: devices,
+                clientDetails = it.clientDetails ?: clientDetails
+            ),
+            testTargets = it.testTargets ?: testTargets
+        )
     )
 }.toTypedArray()

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/UploadApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/UploadApks.kt
@@ -45,7 +45,7 @@ private fun GameLoopContext.upload(rootGcsBucket: String, runGcsPath: String) = 
 )
 
 private fun SanityRoboTestContext.upload(rootGcsBucket: String, runGcsPath: String) =
-    SanityRoboTestContext(app.uploadIfNeeded(rootGcsBucket, runGcsPath))
+    SanityRoboTestContext(app.uploadIfNeeded(rootGcsBucket, runGcsPath), args)
 
 suspend fun AndroidArgs.uploadAdditionalApks() =
     additionalApks.uploadToGcloudIfNeeded(resultsDir, resultsBucket)

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -1233,6 +1233,31 @@ AndroidArgs
     }
 
     @Test
+    fun `cli additional-app-test-apks with test-targets override`() {
+        val cli = AndroidRunCommand()
+        CommandLine(cli).parseArgs("--additional-app-test-apks=app=$appApk,test=$testFlakyApk,test-targets=class any.class.TestClass")
+
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+        flank:
+          additional-app-test-apks:
+          - app: $appApk
+            test: $testErrorApk
+      """
+        assertEquals(
+            listOf(AppTestPair(appApkAbsolutePath, testErrorApkAbsolutePath)),
+            AndroidArgs.load(yaml).validate().additionalAppTestApks
+        )
+
+        assertEquals(
+            listOf(AppTestPair(appApkAbsolutePath, testFlakyApkAbsolutePath, testTargets = listOf("class any.class.TestClass"))),
+            AndroidArgs.load(yaml, cli).validate().additionalAppTestApks
+        )
+    }
+
+    @Test
     fun `additional-app-test-apks inherit top level client-details`() {
         val yaml = """
         gcloud:

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -143,6 +143,12 @@ class AndroidArgsTest {
           additional-app-test-apks:
             - app: $appApk
               test: $testErrorApk
+              max-test-shards: 123
+              test-targets:
+              - class any.additional.TestClass#test1
+              device:
+              - model: Nexus9
+                version: 23
           run-timeout: 20m
           ignore-failed-tests: true
           output-style: single
@@ -374,6 +380,14 @@ AndroidArgs
       additional-app-test-apks:
         - app: $appApkAbsolutePath
           test: $testErrorApkAbsolutePath
+          max-test-shards: 123
+          test-targets:
+          - class any.additional.TestClass#test1
+          device:
+          - model: Nexus9
+            version: 23
+            locale: en
+            orientation: portrait
       run-timeout: 20m
       legacy-junit-result: false
       ignore-failed-tests: true
@@ -1183,12 +1197,12 @@ AndroidArgs
             test: $testErrorApk
       """
         assertEquals(
-            listOf(AppTestPair(appApkAbsolutePath, testErrorApkAbsolutePath, maxTestShards = 1, clientDetails = emptyMap())),
+            listOf(AppTestPair(appApkAbsolutePath, testErrorApkAbsolutePath)),
             AndroidArgs.load(yaml).validate().additionalAppTestApks
         )
 
         assertEquals(
-            listOf(AppTestPair(appApkAbsolutePath, testFlakyApkAbsolutePath, maxTestShards = 1, clientDetails = emptyMap())),
+            listOf(AppTestPair(appApkAbsolutePath, testFlakyApkAbsolutePath)),
             AndroidArgs.load(yaml, cli).validate().additionalAppTestApks
         )
     }
@@ -1208,12 +1222,12 @@ AndroidArgs
             test: $testErrorApk
       """
         assertEquals(
-            listOf(AppTestPair(appApkAbsolutePath, testErrorApkAbsolutePath, maxTestShards = 1, clientDetails = emptyMap())),
+            listOf(AppTestPair(appApkAbsolutePath, testErrorApkAbsolutePath)),
             AndroidArgs.load(yaml).validate().additionalAppTestApks
         )
 
         assertEquals(
-            listOf(AppTestPair(appApkAbsolutePath, testFlakyApkAbsolutePath, maxTestShards = 4, clientDetails = emptyMap())),
+            listOf(AppTestPair(appApkAbsolutePath, testFlakyApkAbsolutePath, maxTestShards = 4)),
             AndroidArgs.load(yaml, cli).validate().additionalAppTestApks
         )
     }

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -1183,12 +1183,12 @@ AndroidArgs
             test: $testErrorApk
       """
         assertEquals(
-            listOf(AppTestPair(appApkAbsolutePath, testErrorApkAbsolutePath, maxTestShards = 1)),
+            listOf(AppTestPair(appApkAbsolutePath, testErrorApkAbsolutePath, maxTestShards = 1, clientDetails = emptyMap())),
             AndroidArgs.load(yaml).validate().additionalAppTestApks
         )
 
         assertEquals(
-            listOf(AppTestPair(appApkAbsolutePath, testFlakyApkAbsolutePath, maxTestShards = 1)),
+            listOf(AppTestPair(appApkAbsolutePath, testFlakyApkAbsolutePath, maxTestShards = 1, clientDetails = emptyMap())),
             AndroidArgs.load(yaml, cli).validate().additionalAppTestApks
         )
     }
@@ -1208,12 +1208,12 @@ AndroidArgs
             test: $testErrorApk
       """
         assertEquals(
-            listOf(AppTestPair(appApkAbsolutePath, testErrorApkAbsolutePath, maxTestShards = 1)),
+            listOf(AppTestPair(appApkAbsolutePath, testErrorApkAbsolutePath, maxTestShards = 1, clientDetails = emptyMap())),
             AndroidArgs.load(yaml).validate().additionalAppTestApks
         )
 
         assertEquals(
-            listOf(AppTestPair(appApkAbsolutePath, testFlakyApkAbsolutePath, maxTestShards = 4)),
+            listOf(AppTestPair(appApkAbsolutePath, testFlakyApkAbsolutePath, maxTestShards = 4, clientDetails = emptyMap())),
             AndroidArgs.load(yaml, cli).validate().additionalAppTestApks
         )
     }
@@ -1675,7 +1675,8 @@ AndroidArgs
                 shards = listOf(
                     Chunk(listOf(TestMethod(name = "test", time = 0.0))),
                     Chunk(listOf(TestMethod(name = "test", time = 0.0)))
-                )
+                ),
+                args = args
             )
         )
         val testSpecification = TestSpecification().setupAndroidTest(androidTestConfig)
@@ -1702,7 +1703,8 @@ AndroidArgs
                 shards = listOf(
                     Chunk(listOf(TestMethod(name = "test", time = 0.0))),
                     Chunk(listOf(TestMethod(name = "test", time = 0.0)))
-                )
+                ),
+                args = args
             )
         )
         val testSpecification = TestSpecification().setupAndroidTest(androidTestConfig)
@@ -2412,7 +2414,8 @@ AndroidArgs
             GameLoopContext(
                 app = "app".asFileReference(),
                 scenarioNumbers = args.scenarioNumbers,
-                scenarioLabels = args.scenarioLabels
+                scenarioLabels = args.scenarioLabels,
+                args = args
             )
         )
         val testSpecification = TestSpecification().setupAndroidTest(androidTestConfig)

--- a/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-multiple-mixed.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-multiple-mixed.yml
@@ -14,4 +14,6 @@ flank:
     - test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk
       max-test-shards: 1
     - test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-flaky-debug-androidTest.apk
+      test-targets:
+        - class any.test.TestClass#test1
     - test: ../test_projects/android/apks/invalid.apk

--- a/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-multiple-mixed.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/test_app_cases/flank-multiple-mixed.yml
@@ -15,5 +15,5 @@ flank:
       max-test-shards: 1
     - test: ./src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-flaky-debug-androidTest.apk
       test-targets:
-        - class any.test.TestClass#test1
+        - class com.example.test_app.InstrumentedTest
     - test: ../test_projects/android/apks/invalid.apk

--- a/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
@@ -1,6 +1,7 @@
 package ftl.gc
 
 import com.google.testing.model.TestSetup
+import ftl.api.TestMatrixAndroid
 import ftl.api.TestMatrixAndroid.Type
 import ftl.args.AndroidArgs
 import ftl.client.google.run.android.executeAndroidTests
@@ -49,7 +50,7 @@ class GcAndroidTestMatrixTest {
             )
             val config = createAndroidTestConfig(androidArgs)
 
-            executeAndroidTests(listOf(config to type))
+            executeAndroidTests(listOf(TestMatrixAndroid.TestSetup(config, type)))
         }
     }
 
@@ -78,7 +79,7 @@ class GcAndroidTestMatrixTest {
 
             val config = createAndroidTestConfig(androidArgs)
 
-            executeAndroidTests(listOf(config to type))
+            executeAndroidTests(listOf(TestMatrixAndroid.TestSetup(config, type)))
         }
     }
 
@@ -112,7 +113,7 @@ class GcAndroidTestMatrixTest {
 
             val config = createAndroidTestConfig(androidArgs)
 
-            executeAndroidTests(listOf(config to type))
+            executeAndroidTests(listOf(TestMatrixAndroid.TestSetup(config, type)))
         }
     }
 

--- a/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/gc/GcAndroidTestMatrixTest.kt
@@ -49,7 +49,7 @@ class GcAndroidTestMatrixTest {
             )
             val config = createAndroidTestConfig(androidArgs)
 
-            executeAndroidTests(config, listOf(type))
+            executeAndroidTests(listOf(config to type))
         }
     }
 
@@ -78,7 +78,7 @@ class GcAndroidTestMatrixTest {
 
             val config = createAndroidTestConfig(androidArgs)
 
-            executeAndroidTests(config, listOf(type))
+            executeAndroidTests(listOf(config to type))
         }
     }
 
@@ -112,7 +112,7 @@ class GcAndroidTestMatrixTest {
 
             val config = createAndroidTestConfig(androidArgs)
 
-            executeAndroidTests(config, listOf(type))
+            executeAndroidTests(listOf(config to type))
         }
     }
 

--- a/test_runner/src/test/kotlin/ftl/run/DumpShardsKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/DumpShardsKtTest.kt
@@ -55,24 +55,16 @@ class DumpShardsKtTest {
     "test": "$path/src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-flaky-debug-androidTest.apk",
     "shards": {
       "shard-0": [
-        "class com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed",
-        "class com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized",
-        "class com.example.test_app.InstrumentedTest#test1",
-        "class com.example.test_app.InstrumentedTest#test2"
+        "class com.example.test_app.InstrumentedTest#test0"
       ],
       "shard-1": [
-        "class com.example.test_app.ParameterizedTest",
-        "class com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner",
-        "class com.example.test_app.InstrumentedTest#test0",
-        "class com.example.test_app.bar.BarInstrumentedTest#testBar",
-        "class com.example.test_app.foo.FooInstrumentedTest#testFoo"
+        "class com.example.test_app.InstrumentedTest#test1",
+        "class com.example.test_app.InstrumentedTest#test2"
       ]
     },
     "junit-ignored": [
       "class com.example.test_app.InstrumentedTest#ignoredTestWitSuppress",
-      "class com.example.test_app.InstrumentedTest#ignoredTestWithIgnore",
-      "class com.example.test_app.bar.BarInstrumentedTest#ignoredTestBar",
-      "class com.example.test_app.foo.FooInstrumentedTest#ignoredTestFoo"
+      "class com.example.test_app.InstrumentedTest#ignoredTestWithIgnore"
     ]
   }
 }
@@ -95,8 +87,8 @@ class DumpShardsKtTest {
         val notExpected = """
 {
   "matrix-0": {
-    "app": "/pathToApk/app-debug.apk",
-    "test": "/pathToApk/app-single-success-debug-androidTest.apk",
+    "app": "pathToApk/src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk",
+    "test": "pathToApk/src/test/kotlin/ftl/fixtures/tmp/apk/app-single-success-debug-androidTest.apk",
     "shards": {
       "shard-0": [
         "class com.example.test_app.InstrumentedTest#test"
@@ -108,28 +100,20 @@ class DumpShardsKtTest {
     ]
   },
   "matrix-1": {
-    "app": "/pathToApk/app-debug.apk",
-    "test": "/pathToApk/app-multiple-flaky-debug-androidTest.apk",
+    "app": "pathToApk/src/test/kotlin/ftl/fixtures/tmp/apk/app-debug.apk",
+    "test": "pathToApk/src/test/kotlin/ftl/fixtures/tmp/apk/app-multiple-flaky-debug-androidTest.apk",
     "shards": {
       "shard-0": [
-        "class com.example.test_app.InstrumentedTest#test1",
-        "class com.example.test_app.InstrumentedTest#test2",
-        "class com.example.test_app.ParameterizedTest",
-        "class com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed"
+        "class com.example.test_app.InstrumentedTest#test0"
       ],
       "shard-1": [
-        "class com.example.test_app.InstrumentedTest#test0",
-        "class com.example.test_app.bar.BarInstrumentedTest#testBar",
-        "class com.example.test_app.foo.FooInstrumentedTest#testFoo",
-        "class com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized",
-        "class com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner"
+        "class com.example.test_app.InstrumentedTest#test1",
+        "class com.example.test_app.InstrumentedTest#test2"
       ]
     },
     "junit-ignored": [
-      "class com.example.test_app.InstrumentedTest#ignoredTestWithIgnore",
-      "class com.example.test_app.InstrumentedTest#ignoredTestWithSuppress",
-      "class com.example.test_app.bar.BarInstrumentedTest#ignoredTestBar",
-      "class com.example.test_app.foo.FooInstrumentedTest#ignoredTestFoo"
+      "class com.example.test_app.InstrumentedTest#ignoredTestWitSuppress",
+      "class com.example.test_app.InstrumentedTest#ignoredTestWithIgnore"
     ]
   }
 }

--- a/test_runner/src/test/kotlin/ftl/run/platform/RunAndroidTestsKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/RunAndroidTestsKtTest.kt
@@ -22,10 +22,10 @@ class RunAndroidTestsKtTest {
             should { map.size == 3 },
             listOf(
                 should { size == 1 },
-                should { size == 4 },
-                should { size == 5 }
+                should { size == 1 },
+                should { size == 2 }
             ),
-            should { size == 6 }
+            should { size == 4 }
         )
 
         // when

--- a/test_runner/src/test/kotlin/ftl/run/platform/android/CreateAndroidTestContextKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/android/CreateAndroidTestContextKtTest.kt
@@ -62,8 +62,8 @@ class CreateAndroidTestContextKtTest {
                 app = should { local.endsWith("app-debug.apk") },
                 test = should { local.endsWith("app-multiple-flaky-debug-androidTest.apk") },
                 shards = should { size == 2 },
-                ignoredTestCases = should { size == 4 },
-                args = should { testTargets == listOf("class any.test.TestClass#test1") }
+                ignoredTestCases = should { size == 2 },
+                args = should { testTargets == listOf("class com.example.test_app.InstrumentedTest") }
             )
         )
 
@@ -73,7 +73,7 @@ class CreateAndroidTestContextKtTest {
         }
 
         // then
-        assertEquals(expected, actual)
+        actual.forEachIndexed { index, androidTestContext -> assertEquals(expected[index], androidTestContext) }
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/run/platform/android/ResolveApksKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/android/ResolveApksKtTest.kt
@@ -21,46 +21,45 @@ class ResolveApksKtTest {
 
     @Test
     fun `should resolve apks from global app and test`() {
+        val args = mockk<AndroidArgs> {
+            every { appApk } returns "app"
+            every { testApk } returns "test"
+            every { additionalApks } returns emptyList()
+            every { additionalAppTestApks } returns emptyList()
+            every { testTargetsForShard } returns emptyList()
+            every { customSharding } returns emptyMap()
+        }
         assertArrayEquals(
             arrayOf(
                 InstrumentationTestContext(
                     app = "app".asFileReference(),
-                    test = "test".asFileReference()
+                    test = "test".asFileReference(),
+                    args = args
                 )
             ),
-            mockk<AndroidArgs> {
-                every { appApk } returns "app"
-                every { testApk } returns "test"
-                every { additionalApks } returns emptyList()
-                every { additionalAppTestApks } returns emptyList()
-                every { testTargetsForShard } returns emptyList()
-                every { customSharding } returns emptyMap()
-            }.resolveApks().toTypedArray()
+            args.resolveApks().toTypedArray()
         )
     }
 
     @Test
     fun `should resolve apks from additionalAppTestApks`() {
+        val args = AndroidArgs.default().copy(
+            additionalAppTestApks = listOf(
+                AppTestPair(
+                    app = "app",
+                    test = "test"
+                )
+            )
+        )
         assertArrayEquals(
             arrayOf(
                 InstrumentationTestContext(
                     app = "app".asFileReference(),
-                    test = "test".asFileReference()
+                    test = "test".asFileReference(),
+                    args = args
                 )
             ),
-            mockk<AndroidArgs> {
-                every { appApk } returns null
-                every { testApk } returns null
-                every { additionalApks } returns emptyList()
-                every { additionalAppTestApks } returns listOf(
-                    AppTestPair(
-                        app = "app",
-                        test = "test"
-                    )
-                )
-                every { testTargetsForShard } returns emptyList()
-                every { customSharding } returns emptyMap()
-            }.resolveApks().toTypedArray()
+            args.resolveApks().toTypedArray()
         )
     }
 
@@ -90,7 +89,7 @@ class ResolveApksKtTest {
             every { type } returns Type.ROBO
         }
         assertArrayEquals(
-            arrayOf(SanityRoboTestContext("app".asFileReference())),
+            arrayOf(SanityRoboTestContext("app".asFileReference(), androidArgs)),
             androidArgs.resolveApks().toTypedArray()
         )
     }

--- a/test_runner/src/test/kotlin/ftl/test/util/TestHelper.kt
+++ b/test_runner/src/test/kotlin/ftl/test/util/TestHelper.kt
@@ -50,9 +50,8 @@ inline fun <reified T : Any> should(crossinline match: T.() -> Boolean): T = moc
         val value = slot.captured
         value.match().also { matches ->
             matched = matches
-            if (matches)
-                println("${this@mockk} match succeed: $value") else
-                println("${this@mockk} match failed: $value")
+            if (matches) println("${this@mockk} match succeed: $value")
+            else println("${this@mockk} match failed: $value")
         }
     }
     every { this@mockk.toString() } answers {


### PR DESCRIPTION
Fixes #1815

This PR introduces a couple of changes:
1. from now on each android test context will have its own copy of `AndroidConfig`
2. each copy will be overwritten with values defined by the user
3. each copy will be validated

With the above enhancements, we can extend `additional-test-app-pairs` easier in the future. For now, only community-requested options are implemented.

## Test Plan
> How do we know the code works?

1. Run `./gradlew flankFullRun`
2. Example config:
    ```yaml
    gcloud:
      app: ...
      test: ...
    flank:
      max-test-shards: 2
      additional-app-test-apks:
        - test: ...
          max-test-shards: 5
        - test: ...
          device:
            - model: Nexus6P
              version: 27
    ```
3. Yous should receive 3 matrices with different set up:
    1. 2 shards, NexusLowRes device (default one)
    2. 5 shards, NexusLowRes device
    3. 2 shards, Nexus6P device
## Checklist

- [x] Documented
- [x] Unit tested
- [x] Integration tests updated
