### PR TITLE
Fix: bucket not found but can't be created

### DIFF
--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -158,12 +158,11 @@ object ArgsHelper {
         val storageLocation = "us-central1"
 
         val bucketListOption = Storage.BucketListOption.prefix(bucket)
-        val storageList = emptyList<String>()
-
-        try {
-            storage.list(bucketListOption).values?.map { it.name }
+        val storageList = try {
+            storage.list(bucketListOption).values?.map { it.name } ?: emptyList()
         } catch (e: Exception) {
             // User may not have list permission
+            emptyList()
         }
 
         if (storageList.contains(bucket)) return bucket


### PR DESCRIPTION
Flank was showing:
> Warning: Failed to make bucket for ...
> Cause: Sorry, that name is not available. Please try a different one.

It didn't find the bucket but it was there, the reason is the list of buckets was never set.

It's been broken since: https://github.com/Flank/flank/pull/531/files#diff-81920894b2478868a06b5f2210f003afaf3ca682d7cb61afe1c8dec2cecdb191R127

## Test Plan
Tested manually but looking if on how to write an automated test

## Checklist

- [ ] Documented
- [ ] Unit tested
- [ ] Integration tests updated


I have read the CLA Document and I hereby sign the CLA