### PR TITLE
feat: Set Google api issues level as DEBUG

### DIFF
--- a/test_runner/src/main/kotlin/ftl/http/ExecuteWithRetry.kt
+++ b/test_runner/src/main/kotlin/ftl/http/ExecuteWithRetry.kt
@@ -6,6 +6,7 @@ import ftl.run.exception.FailureToken
 import ftl.run.exception.PermissionDenied
 import ftl.run.exception.ProjectNotFound
 import ftl.util.report
+import io.sentry.SentryLevel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.IOException
@@ -24,7 +25,7 @@ private inline fun <T> withRetry(crossinline block: () -> T): T = runBlocking {
         } catch (err: IOException) {
             // We want to send every occurrence of Google API error for statistic purposes
             // https://github.com/Flank/flank/issues/701
-            FlankGoogleApiError(err).report()
+            FlankGoogleApiError(err).report(SentryLevel.DEBUG)
 
             lastError = err
             if (err is HttpResponseException) {

--- a/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
+++ b/test_runner/src/main/kotlin/ftl/run/exception/ExceptionHandler.kt
@@ -9,6 +9,7 @@ import ftl.reports.printTotalDuration
 import ftl.run.cancelMatrices
 import ftl.util.closeCrashReporter
 import ftl.util.report
+import io.sentry.SentryLevel
 import kotlinx.coroutines.runBlocking
 import kotlin.system.exitProcess
 
@@ -54,7 +55,7 @@ internal fun withGlobalExceptionHandling(block: () -> Int, exitProcessFunction: 
             }
 
             is InfrastructureError -> {
-                t.report()
+                t.report(SentryLevel.DEBUG)
                 printError("An infrastructure error occurred.")
                 printError("Details: ${t.messageOrUnavailable}")
                 exitProcessFunction(INFRASTRUCTURE_ERROR)

--- a/test_runner/src/main/kotlin/ftl/util/CrashReporter.kt
+++ b/test_runner/src/main/kotlin/ftl/util/CrashReporter.kt
@@ -2,6 +2,7 @@ package ftl.util
 
 import flank.common.config.isTest
 import io.sentry.Sentry
+import io.sentry.SentryLevel
 import java.io.File
 import java.util.UUID
 
@@ -26,10 +27,10 @@ fun disableCrashReporting() {
     configureCrashReporter
 }
 
-fun Throwable.report() {
+fun Throwable.report(logLevel: SentryLevel = SentryLevel.ERROR) {
     if (isTest().not()) {
         configureCrashReporter
-        notify(this)
+        notify(this, logLevel)
     }
 }
 
@@ -66,8 +67,11 @@ fun setCrashReportTag(
     vararg tags: Pair<String, String>
 ) = tags.forEach { (property, value) -> Sentry.setTag(property, value) }
 
-private fun notify(error: Throwable) {
-    Sentry.captureException(error)
+private fun notify(error: Throwable, logLevel: SentryLevel) {
+    Sentry.withScope {
+        it.level = logLevel
+        Sentry.captureException(error)
+    }
 }
 
 fun closeCrashReporter() {


### PR DESCRIPTION
Fixes #1958

## Test Plan
> How do we know the code works?

When a Google infrastructure issue occurs(FlankGoogleApiError, InfrastructureError) it is logged with log level DEBUG.
You could throw this exception on your own `InfrastructureError("test").report(SentryLevel.DEBUG)`. This feature will be used for creating Sentry notification about critical errors to the newly created channel `#sentry-errors`