### PR TITLE
fix: Fix flank freezes when large number of matrices is launched

### DIFF
--- a/test_runner/src/main/kotlin/ftl/adapter/TestMatrixRefresh.kt
+++ b/test_runner/src/main/kotlin/ftl/adapter/TestMatrixRefresh.kt
@@ -3,12 +3,10 @@ package ftl.adapter
 import ftl.adapter.google.toApiModel
 import ftl.api.TestMatrix
 import ftl.client.google.refreshMatrix
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.coroutineScope
 
-object TestMatrixRefresh :
-    TestMatrix.Refresh,
-    (TestMatrix.Identity) -> TestMatrix.Data by { identity ->
-        runBlocking {
-            refreshMatrix(identity.matrixId, identity.projectId).toApiModel(identity)
-        }
+object TestMatrixRefresh : TestMatrix.Refresh {
+    override suspend fun invoke(identity: TestMatrix.Identity): TestMatrix.Data = coroutineScope {
+        refreshMatrix(identity.matrixId, identity.projectId).toApiModel(identity)
     }
+}

--- a/test_runner/src/main/kotlin/ftl/api/TestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/api/TestMatrix.kt
@@ -94,5 +94,7 @@ object TestMatrix {
     )
 
     interface Cancel : (Identity) -> Unit
-    interface Refresh : (Identity) -> Data
+    interface Refresh {
+        suspend operator fun invoke(identity: Identity): Data
+    }
 }

--- a/test_runner/src/main/kotlin/ftl/run/platform/common/AfterRunTests.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/common/AfterRunTests.kt
@@ -17,7 +17,6 @@ import ftl.run.common.updateMatrixFile
 import ftl.util.StopWatch
 import ftl.util.formatted
 import ftl.util.isInvalid
-import ftl.util.webLink
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
@@ -65,7 +64,7 @@ internal suspend inline fun MatrixMap.printMatricesWebLinks(project: String) = c
     logLn()
 }
 
-private tailrec fun getOrUpdateWebLink(link: String, project: String, matrixId: String): String =
+private tailrec suspend fun getOrUpdateWebLink(link: String, project: String, matrixId: String): String =
     if (link.isNotBlank()) link
     else getOrUpdateWebLink(
         link = refreshTestMatrix(TestMatrix.Identity(matrixId, project)).run { if (isInvalid) "Unable to get web link" else webLink },


### PR DESCRIPTION
Fixes #2021 

## Test Plan
> How do we know the code works?

It is impossible to test whole flow in sensible and reliable way. It would require mocking lots of methods and since the problem is related with multithreading I think it's not the best idea. What's more, test might be unreliable due to differences in CPU configurations on different machines.

@asadsalman was asked to verify fix, as a proof (thanks!)
