### PR TITLE
feat: Add tools for structural logging

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,10 +16,10 @@ include(
 
     ":corellium:cli",
     ":corellium:domain",
-    ":corellium:sandbox",
     ":corellium:api",
     ":corellium:adapter",
     ":corellium:client",
+    ":corellium:sandbox",
 
     ":tool:apk",
     ":tool:shard",
@@ -29,6 +29,8 @@ include(
     ":tool:instrument:command",
     ":tool:instrument:log",
     ":tool:junit",
+    ":tool:log",
+    ":tool:log:format",
 )
 
 plugins {

--- a/tool/log/README.md
+++ b/tool/log/README.md
@@ -1,0 +1,9 @@
+# Structural logging
+
+Basic API for structural logging
+
+### References
+
+* Module type - [tool](../../../docs/architecture.md#tool)
+* Dependency type - [static](../../../docs/architecture.md#static_dependencies)
+* Public API - [flank.log](./src/main/kotlin/flank/log)

--- a/tool/log/build.gradle.kts
+++ b/tool/log/build.gradle.kts
@@ -1,0 +1,19 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin(Plugins.Kotlin.PLUGIN_JVM)
+}
+
+repositories {
+    jcenter()
+    mavenCentral()
+    maven(url = "https://kotlin.bintray.com/kotlinx")
+}
+
+tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
+
+dependencies {
+    implementation(Dependencies.KOTLIN_COROUTINES_CORE)
+
+    testImplementation(Dependencies.JUNIT)
+}

--- a/tool/log/format/README.md
+++ b/tool/log/format/README.md
@@ -1,0 +1,10 @@
+# Structural log formatting
+
+Extension for formatting structural logs into specified type.
+
+### References
+
+* Module type - [tool](../../../docs/architecture.md#tool)
+* Dependency type - [static](../../../docs/architecture.md#static_dependencies)
+* Public API - [flank.log](./src/main/kotlin/flank/log)
+* Example usage - [LoggingTest.kt](./src/test/kotlin/flank/log/LoggingTest.kt)

--- a/tool/log/format/build.gradle.kts
+++ b/tool/log/format/build.gradle.kts
@@ -1,0 +1,20 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin(Plugins.Kotlin.PLUGIN_JVM)
+}
+
+repositories {
+    jcenter()
+    mavenCentral()
+    maven(url = "https://kotlin.bintray.com/kotlinx")
+}
+
+tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
+
+dependencies {
+    implementation(Dependencies.KOTLIN_COROUTINES_CORE)
+    api(project(":tool:log"))
+
+    testImplementation(Dependencies.JUNIT)
+}

--- a/tool/log/format/src/main/kotlin/flank/log/Builder.kt
+++ b/tool/log/format/src/main/kotlin/flank/log/Builder.kt
@@ -1,0 +1,70 @@
+package flank.log
+
+import kotlin.reflect.KClass
+
+/**
+ * Factory method for building and creating generic [Formatter].
+ */
+fun <T> buildFormatter(build: Builder<T>.() -> Unit): Formatter<T> =
+    Builder<T>().apply(build).run {
+        @Suppress("UNCHECKED_CAST")
+        Formatter(
+            static = static as Map<StaticMatcher, Format<Any, T>>,
+            dynamic = dynamic as Map<DynamicMatcher, Format<Any, T>>,
+        )
+    }
+
+/**
+ * Generic formatters builder.
+ */
+class Builder<T> internal constructor() {
+
+    internal val static = mutableMapOf<StaticMatcher, Format<*, T>>()
+    internal val dynamic = mutableMapOf<DynamicMatcher, Format<*, T>>()
+
+    /**
+     * Registers [V] formatter with [KClass] based static matcher.
+     *
+     * @receiver [KClass] as a identifier.
+     * @param context Optional context.
+     * @param format Reference to formatting function.
+     */
+    operator fun <V : Event.Data> KClass<V>.invoke(
+        context: Any? = null,
+        format: Format<V, T>,
+    ) {
+        static += listOfNotNull(context, java) to format
+    }
+
+    /**
+     * Registers [V] formatter with [Event.Type] based static matcher.
+     *
+     * @receiver [Event.Type] as a identifier.
+     * @param context Optional context.
+     * @param format Reference to formatting function.
+     */
+    operator fun <V> Event.Type<V>.invoke(
+        context: Any? = null,
+        format: Format<V, T>
+    ) {
+        static += listOfNotNull(context, this) to format
+    }
+
+    /**
+     * Creates matcher function.
+     */
+    fun <V> match(f: (Any.(Any) -> V?)) = f
+
+    /**
+     * Registers [V] formatter with dynamic matcher function.
+     *
+     * @receiver Matching event function. The receiver is a context where
+     * @param format Reference to formatting function.
+     */
+    infix fun <V> (Any.(Any) -> V?).to(
+        format: Format<V, T>
+    ) {
+        val wrap: DynamicMatcher = { invoke(this, it) != null }
+        dynamic += wrap to format
+    }
+}

--- a/tool/log/format/src/main/kotlin/flank/log/Formatter.kt
+++ b/tool/log/format/src/main/kotlin/flank/log/Formatter.kt
@@ -1,0 +1,36 @@
+package flank.log
+
+/**
+ * Generic formatter.
+ */
+class Formatter<T> internal constructor(
+    val static: Map<StaticMatcher, Format<Any, T>>,
+    val dynamic: Map<DynamicMatcher, Format<Any, T>>,
+)
+
+internal typealias StaticMatcher = List<Any>
+internal typealias DynamicMatcher = Any.(Any) -> Boolean
+internal typealias Format<V, T> = V.(Any) -> T?
+
+/**
+ * Format given [Event] into [T].
+ */
+operator fun <T> Formatter<T>.invoke(event: Event<*>): T? = event.run {
+    val format = static[listOf(context, type)]
+        ?: static[listOf(type)]
+        ?: dynamic.toList().firstOrNull { (match, _) -> match.invoke(context, value) }?.second
+
+    format?.invoke(value, context)
+}
+
+/**
+ * Creates [println] log [Output] from a given [Formatter].
+ */
+val Formatter<String>.output: Output get() = output(::println).filter()
+
+/**
+ * Creates [GenericOutput] for [log] using a given [Formatter].
+ *
+ * Conditionally invoking given [log] with formatted values.
+ */
+fun <T> Formatter<T>.output(log: (T) -> Unit): GenericOutput<Event<*>> = { invoke(this)?.let(log) }

--- a/tool/log/format/src/test/kotlin/flank/log/LoggingTest.kt
+++ b/tool/log/format/src/test/kotlin/flank/log/LoggingTest.kt
@@ -1,0 +1,55 @@
+package flank.log
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private const val STATIC = "static"
+private const val VALUE = "value"
+private const val CLASS = "class"
+private const val STRING = "string"
+
+/**
+ * Complete logger API test.
+ */
+class LoggingTest {
+
+    private object Singleton : Event.Type<Unit>
+    private object Value : Event.Type<String>
+    private data class Class(val value: String) : Event.Data
+
+    /**
+     * Test logging API.
+     *
+     * * Build [Formatter] with different types of formatting functions.
+     * * Create output with events wrapper.
+     * * Pass various objects to logger output.
+     */
+    @Test
+    fun test() {
+        // Given
+        val expected = listOf(STATIC, VALUE, CLASS, STRING)
+        val actual = mutableListOf<String>()
+
+        // Specify formatter for converting registered types into string values
+        val formatter = buildFormatter<String> {
+            Singleton { STATIC }
+            Value { this }
+            Class::class { value }
+            match { it as? String } to { this }
+        }
+
+        // Prepare log output from string formatter
+        val out: Output = formatter
+            .output { formatted -> actual += formatted }
+            .normalize { next -> Unit event next }
+
+        // When
+        Singleton.out()
+        Value(VALUE).out()
+        Class(CLASS).out()
+        STRING.out()
+
+        // Then
+        assertEquals(expected, actual)
+    }
+}

--- a/tool/log/src/main/kotlin/flank/log/Event.kt
+++ b/tool/log/src/main/kotlin/flank/log/Event.kt
@@ -1,0 +1,45 @@
+package flank.log
+
+/**
+ * Structural log representation
+ *
+ * @property type Unique identifier for value. Could be a KClass of [Event.Type] depending on value type.
+ * @property value Logged value
+ */
+data class Event<V : Any> internal constructor(
+    val context: Any,
+    val type: Any,
+    val value: V,
+) {
+    /**
+     * Interface of event data identified by KClass
+     */
+    interface Data
+
+    /**
+     * Interface of unique key for [T] event data.
+     */
+    interface Type<T> {
+        operator fun invoke(value: T) = this to value
+    }
+
+    /**
+     * Notify task was started
+     */
+    object Start : Type<Unit>
+
+    /**
+     * Notify task was stopped
+     */
+    object Stop : Type<Unit>
+}
+
+/**
+ * Creates [Event] from [this] context and given [any] type or value.
+ */
+infix fun Any.event(any: Any): Event<out Any> = when (any) {
+    is Pair<*, *> -> Event(this, any.first!!, any.second!!)
+    is Event.Data -> Event(this, any::class.java, any)
+    is Event.Type<*> -> Event(this, any, Unit)
+    else -> Event(this, any::class.java, any) // Consider to disallow anonymous types
+}

--- a/tool/log/src/main/kotlin/flank/log/Logger.kt
+++ b/tool/log/src/main/kotlin/flank/log/Logger.kt
@@ -1,0 +1,30 @@
+package flank.log
+
+/**
+ * Logger with provided output.
+ */
+interface Logger {
+    val out: Output
+}
+
+/**
+ * Logging function signature.
+ */
+typealias Output = Any.() -> Unit
+
+/**
+ * Generic logging function signature.
+ */
+typealias GenericOutput<T> = T.() -> Unit
+
+/**
+ * Normalizes [GenericOutput] into [Output] using [transform] function.
+ */
+fun <T> GenericOutput<T>.normalize(transform: (Any) -> T?): Output =
+    { transform(this)?.let(this@normalize) }
+
+/**
+ * Normalizes [GenericOutput] into [Output] by filtering values of type [T]
+ */
+inline fun <reified T> GenericOutput<T>.filter(): Output =
+    normalize { this as? T }


### PR DESCRIPTION
Related to #1999 

This PR is adding simple tools for structural logging and formatting, required by PR #2032. 
Merging this will simplify #2032.

## Test Plan
> How do we know the code works?

Unit test passes.

## Checklist

- [x] Documented
- [x] Unit tested
