### PR TITLE
refactor: Data field should not be serialized

### DIFF
--- a/test_runner/src/main/kotlin/ftl/args/CommonArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/CommonArgs.kt
@@ -6,6 +6,7 @@ import ftl.reports.output.OutputReportType
 import ftl.run.status.OutputStyle
 
 data class CommonArgs(
+    @Transient // we don't want to have this field saved in outputReport.json
     override val data: String,
 
     // Gcloud


### PR DESCRIPTION
Fixes #2018 

`commonArgs` -> `data` field is redundant. It is represented by yml file read as a raw string. Flank copies `yml` file and all values (from config) are present in report json in dedicated fields. Therefor I think we can make it transient (not serializable)

## Test Plan
> How do we know the code works?

1. run any flank test
2. open `outputReport.json`
3. There should be no `data` field in `commonArgs`

