### PR TITLE
feat: Implement slack notifications for failed release

### DIFF
--- a/.github/workflows/create_new_release.yml
+++ b/.github/workflows/create_new_release.yml
@@ -34,3 +34,12 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           custom_tag: ${{ env.NEXT_RELEASE_TAG }}
           tag_prefix: '' 
+
+      - name: Team notification in case of failure
+        uses: Flank/flank_slack_notifier@master
+        if: failure() && startsWith(github.ref, 'refs/tags/v')
+        with:
+          xoxctoken: ${{ secrets.SLACK_ERROR_NOTIFICATION_XOXCTOKEN }}
+          message: There was a problem with Flank release ${{ env.RELEASE_TAG }}. Check <https://github.com/Flank/flank/actions/runs/${{ github.run_id }}| here!>
+          channel: ${{ secrets.SLACK_ERROR_NOTIFICATION_CHANNEL}}
+          cookie: ${{ secrets.SLACK_ERROR_NOTIFICATION_COOKIE}}

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   copy_properties:
     runs-on: macos-latest
-    if: ${{ github.event.action == 'opened' }}
+    if: github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'release') == false
     steps:
       - uses: actions/checkout@v2
       - name: Download flankScripts and add it to PATH
@@ -24,6 +24,7 @@ jobs:
         run: flankScripts github copy_issue_properties --github-token=${{ secrets.GITHUB_TOKEN }} --pr-number=${{ github.event.number }}
   check_title:
     runs-on: macos-latest
+    if: contains(github.event.pull_request.labels.*.name, 'release') == false
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,3 +116,12 @@ jobs:
         message: Flank ${{ env.RELEASE_TAG }} has been released. View more information <http://github.com/Flank/flank/releases/tag/${{ env.RELEASE_TAG }}| here!>
         channel: ${{ secrets.SLACK_CHANNEL}}
         cookie: ${{ secrets.SLACK_COOKIE}}
+
+    - name: Team notification in case of failure
+      uses: Flank/flank_slack_notifier@master
+      if: failure() && startsWith(github.ref, 'refs/tags/v')
+      with:
+        xoxctoken: ${{ secrets.SLACK_ERROR_NOTIFICATION_XOXCTOKEN }}
+        message: There was a problem with slack release ${{ env.RELEASE_TAG }}. Check <https://github.com/Flank/flank/actions/runs/${{ github.run_id }}| here!>
+        channel: ${{ secrets.SLACK_ERROR_NOTIFICATION_CHANNEL}}
+        cookie: ${{ secrets.SLACK_ERROR_NOTIFICATION_COOKIE}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,6 @@ jobs:
       if: failure() && startsWith(github.ref, 'refs/tags/v')
       with:
         xoxctoken: ${{ secrets.SLACK_ERROR_NOTIFICATION_XOXCTOKEN }}
-        message: There was a problem with slack release ${{ env.RELEASE_TAG }}. Check <https://github.com/Flank/flank/actions/runs/${{ github.run_id }}| here!>
+        message: There was a problem with Flank release ${{ env.RELEASE_TAG }}. Check <https://github.com/Flank/flank/actions/runs/${{ github.run_id }}| here!>
         channel: ${{ secrets.SLACK_ERROR_NOTIFICATION_CHANNEL}}
         cookie: ${{ secrets.SLACK_ERROR_NOTIFICATION_COOKIE}}

--- a/.github/workflows/release_notes_generation.yml
+++ b/.github/workflows/release_notes_generation.yml
@@ -60,3 +60,12 @@ jobs:
           release
         reviewers: bootstraponline,jan-gogo,pawelpasterz,adamfilipow92,piotradamczyk5,Sloox
         draft: false
+
+    - name: Team notification in case of failure
+      uses: Flank/flank_slack_notifier@master
+      if: failure() && startsWith(github.ref, 'refs/tags/v')
+      with:
+        xoxctoken: ${{ secrets.SLACK_ERROR_NOTIFICATION_XOXCTOKEN }}
+        message: There was a problem with Flank release ${{ env.RELEASE_TAG }}. Check <https://github.com/Flank/flank/actions/runs/${{ github.run_id }}| here!>
+        channel: ${{ secrets.SLACK_ERROR_NOTIFICATION_CHANNEL}}
+        cookie: ${{ secrets.SLACK_ERROR_NOTIFICATION_COOKIE}}


### PR DESCRIPTION
Fixes #2006 

What was done?
* 3 new secrets for failure slack notification
* notifications added in crucial release workflows
* PR checks should not be performed for release notes

## Test Plan
> How do we know the code works?

This is impossible to verify PR prior to its merge.

