### PR TITLE
fix: Corellium client request retry 

### DIFF
--- a/corellium/client/src/main/kotlin/flank/corellium/client/util/Retry.kt
+++ b/corellium/client/src/main/kotlin/flank/corellium/client/util/Retry.kt
@@ -2,10 +2,13 @@ package flank.corellium.client.util
 
 import io.ktor.client.features.ServerResponseException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.mapNotNull
 import kotlin.math.pow
 
 suspend inline fun <R> withRetry(crossinline block: suspend () -> R): R =
-    (0 until 5).mapNotNull { multi ->
+    (0 until 5).asFlow().mapNotNull { multi ->
         try {
             block()
         } catch (e: ServerResponseException) {

--- a/flank-scripts/build.gradle.kts
+++ b/flank-scripts/build.gradle.kts
@@ -26,7 +26,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.9.19"
+version = "1.9.20"
 group = "com.github.flank"
 
 application {

--- a/flank-scripts/src/main/kotlin/flank/scripts/cli/assemble/FlankCommand.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/cli/assemble/FlankCommand.kt
@@ -1,13 +1,22 @@
 package flank.scripts.cli.assemble
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
 import flank.scripts.ops.assemble.buildFlank
 
 object FlankCommand : CliktCommand(
     name = "flank",
     help = "Build Flank"
 ) {
+    private val dirty: Boolean by option(
+        "--dirty", "-d",
+        help = "Do not clean before build"
+    ).flag(
+        default = false
+    )
+
     override fun run() {
-        buildFlank()
+        buildFlank(clean = !dirty)
     }
 }

--- a/flank-scripts/src/main/kotlin/flank/scripts/ops/assemble/BuildFlank.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/ops/assemble/BuildFlank.kt
@@ -7,13 +7,14 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 
-fun buildFlank() {
+fun buildFlank(clean: Boolean = true) {
     createGradleCommand(
         workingDir = rootDirectoryPathString,
-        "-p", rootDirectoryPathString, ":test_runner:clean", ":test_runner:assemble", ":test_runner:shadowJar"
-    )
-        .runCommand()
-
+        "-p", rootDirectoryPathString,
+        ":test_runner:clean".takeIf { clean },
+        ":test_runner:assemble",
+        ":test_runner:shadowJar"
+    ).runCommand()
     copyFlankOutputFile()
 }
 

--- a/flank-scripts/src/main/kotlin/flank/scripts/utils/GradleCommand.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/utils/GradleCommand.kt
@@ -4,8 +4,8 @@ import java.nio.file.Paths
 
 fun createGradleCommand(
     workingDir: String,
-    vararg options: String
-) = createGradleCommand(workingDir, options.asList())
+    vararg options: String?
+) = createGradleCommand(workingDir, options.asList().filterNotNull())
 
 fun createGradleCommand(
     workingDir: String,


### PR DESCRIPTION
The PR is fixing incorrect behaviour of the retry method that was always looping 5 times.

Additionally adds `--dirty` option to `flankScripts assemble flank` this will speed up builds for local testing purpose.