### PR TITLE
feat: Test targets option for Corellium

### DIFF
--- a/corellium/cli/src/test/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommandTest.kt
+++ b/corellium/cli/src/test/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommandTest.kt
@@ -2,6 +2,7 @@ package flank.corellium.cli
 
 import flank.corellium.api.AndroidApps
 import flank.corellium.api.AndroidInstance
+import flank.corellium.api.AndroidTestPlan
 import flank.corellium.api.Authorization
 import flank.corellium.domain.RunTestCorelliumAndroid
 import flank.corellium.domain.RunTestCorelliumAndroid.Args
@@ -33,7 +34,7 @@ import java.io.File
 class RunTestCorelliumAndroidCommandTest {
 
     /**
-     * Apply test values to config. Each value should be different than default.
+     * Apply test values to config. Each value should be different from default.
      */
     private fun RunTestCorelliumAndroidCommand.Config.applyTestValues() = apply {
         auth = "test_auth.yml"
@@ -52,6 +53,10 @@ class RunTestCorelliumAndroidCommandTest {
                     Args.Apk.Test("app2-test2.apk"),
                 )
             ),
+        )
+        testTargets = listOf(
+            "class foo.Foo",
+            "package bar",
         )
         maxTestShards = Int.MAX_VALUE
         localResultsDir = "test_result_dir"
@@ -78,6 +83,7 @@ class RunTestCorelliumAndroidCommandTest {
                 "--project=$project",
                 "--auth=$auth",
                 "--apks=app1.apk=app1-test1.apk;app2.apk=app2-test1.apk,app2-test2.apk",
+                "--test-targets=class foo.Foo,package bar",
                 "--max-test-shards=$maxTestShards",
                 "--local-result-dir=$localResultsDir",
                 "--obfuscate=$obfuscate",
@@ -98,6 +104,9 @@ apks:
   tests:
   - path: "app2-test1.apk"
   - path: "app2-test2.apk"
+test-targets:
+  - class foo.Foo
+  - package bar
 max-test-shards: $maxTestShards
 local-result-dir: $localResultsDir
 obfuscate: $obfuscate
@@ -162,6 +171,7 @@ scan-previous-durations: $scanPreviousDurations
             Args(
                 credentials = expectedCredentials,
                 apks = apks!!,
+                testTargets = testTargets!!,
                 maxShardsCount = maxTestShards!!,
                 outputDir = localResultsDir!!,
                 obfuscateDumpShards = obfuscate!!,
@@ -230,6 +240,14 @@ password: $password
             Unit event InvokeDevices.Status(AndroidInstance.Event.Creating(7)),
             Unit event InvokeDevices.Status(AndroidInstance.Event.Waiting),
             Unit event InvokeDevices.Status(AndroidInstance.Event.Ready("123456")),
+            Unit event ExecuteTests.Plan(
+                AndroidTestPlan.Config(
+                    mapOf(
+                        "123456" to listOf("command a", "command b"),
+                        "654321" to listOf("command c", "command d"),
+                    )
+                )
+            ),
             Unit event ExecuteTests.Status(
                 id = "123456",
                 status = Instrument.Status(

--- a/corellium/domain/build.gradle.kts
+++ b/corellium/domain/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(Dependencies.KOTLIN_COROUTINES_CORE)
     api(project(":corellium:api"))
     api(project(":tool:apk"))
+    // api(project(":tool:filter"))
     api(project(":tool:shard:calculate"))
     api(project(":tool:shard:obfuscate"))
     api(project(":tool:shard:dump"))

--- a/corellium/domain/build.gradle.kts
+++ b/corellium/domain/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(Dependencies.KOTLIN_COROUTINES_CORE)
     api(project(":corellium:api"))
     api(project(":tool:apk"))
-    // api(project(":tool:filter"))
+    api(project(":tool:filter"))
     api(project(":tool:shard:calculate"))
     api(project(":tool:shard:obfuscate"))
     api(project(":tool:shard:dump"))

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ExecuteTests.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ExecuteTests.kt
@@ -42,6 +42,7 @@ internal fun RunTestCorelliumAndroid.Context.executeTests() = step(ExecuteTests)
     val outputDir = File(args.outputDir, ExecuteTests.ADB_LOG).apply { mkdir() }
     val testPlan: AndroidTestPlan.Config = prepareTestPlan()
     val list = coroutineScope {
+        ExecuteTests.Plan(testPlan).out()
         api.executeTest(testPlan).map { (id, flow) ->
             async {
                 var read = 0

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseTestCases.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseTestCases.kt
@@ -1,5 +1,6 @@
 package flank.corellium.domain.run.test.android.step
 
+import flank.apk.Apk
 import flank.corellium.domain.RunTestCorelliumAndroid
 import flank.corellium.domain.RunTestCorelliumAndroid.ParseTestCases
 import flank.corellium.domain.step
@@ -11,11 +12,15 @@ import flank.corellium.domain.step
  * * [RunTestCorelliumAndroid.State.testCases]
  */
 internal fun RunTestCorelliumAndroid.Context.parseTestCasesFromApks() = step(ParseTestCases) {
+    val config = Apk.ParseTestCases.Config(
+        // filterTest = createTestCasesFilter(args.testTargets), TODO after merge https://github.com/Flank/flank/pull/2055
+        filterClass = setOf(Apk.Runner.JUnitParamsRunner, Apk.Runner.Parameterized)
+    )
     copy(
         testCases = args.apks
             // Get the list of paths to test apks
             .flatMap { app -> app.tests.map { test -> test.path } }
             // Associate parsed test methods to each apk path
-            .associateWith(apk.parseTestCases)
+            .associateWith(apk.parseTestCases(config))
     )
 }

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseTestCases.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/run/test/android/step/ParseTestCases.kt
@@ -4,6 +4,7 @@ import flank.apk.Apk
 import flank.corellium.domain.RunTestCorelliumAndroid
 import flank.corellium.domain.RunTestCorelliumAndroid.ParseTestCases
 import flank.corellium.domain.step
+import flank.filter.createTestCasesFilter
 
 /**
  * The step is parsing the test methods from each test apk.
@@ -13,7 +14,7 @@ import flank.corellium.domain.step
  */
 internal fun RunTestCorelliumAndroid.Context.parseTestCasesFromApks() = step(ParseTestCases) {
     val config = Apk.ParseTestCases.Config(
-        // filterTest = createTestCasesFilter(args.testTargets), TODO after merge https://github.com/Flank/flank/pull/2055
+        filterTest = createTestCasesFilter(args.testTargets),
         filterClass = setOf(Apk.Runner.JUnitParamsRunner, Apk.Runner.Parameterized)
     )
     copy(

--- a/corellium/domain/src/test/kotlin/flank/corellium/domain/RunTestAndroidCorelliumTestMockApiAndroid.kt
+++ b/corellium/domain/src/test/kotlin/flank/corellium/domain/RunTestAndroidCorelliumTestMockApiAndroid.kt
@@ -71,10 +71,12 @@ class RunTestAndroidCorelliumTestMockApiAndroid : RunTestCorelliumAndroid.Contex
     )
 
     override val apk = Apk.Api(
-        parseTestCases = { path ->
-            println(path)
-            (1..path.last().toString().toInt()).map {
-                path.replace("/", ".") + ".Test#test$it"
+        parseTestCases = {
+            { path ->
+                println(path)
+                (1..path.last().toString().toInt()).map {
+                    path.replace("/", ".") + ".Test#test$it"
+                }
             }
         },
         parsePackageName = { path ->

--- a/docs/flank_corellium.md
+++ b/docs/flank_corellium.md
@@ -87,7 +87,6 @@ $ flank.jar corellium test android run -c="./flank_corellium.yml"
 The example configuration file looks following:
 
 ```yaml
-
 ### Test apks
 ## The list of app and test apks.
 ## Each app apk must have one or more corresponding test apks.
@@ -100,6 +99,17 @@ apks:
       - path: "app2-test1.apk"
       - path: "app2-test2.apk"
 
+### Test Targets
+## A list of one or more test target filters to apply (default: run all test targets).
+## Each target filter must be fully qualified with the package name, class name, or test annotation desired.
+## Supported test filters by am instrument -e … include:
+## class, notClass, size, annotation, notAnnotation, package, notPackage, testFile, notTestFile
+## See https://developer.android.com/reference/android/support/test/runner/AndroidJUnitRunner for more information.
+# test-targets:
+#  - class com.example.app.ExampleUiTest#testPasses
+#  - package com.example.app.foo
+#  - notPackage com.example.app.bar
+
 ### Authorization file
 ## Path to YAML file with host address and credentials.
 ## default: corellium_auth.yml
@@ -111,7 +121,7 @@ apks:
 # project: "project name"
 
 ### Max Test Shards
-## test shards - the amount of groups to split the test suite into.
+## The amount of groups to split the test suite into.
 ## default: 1
 # max-test-shards: 10000
 
@@ -191,6 +201,7 @@ To see the source of the problem check the log file referenced in the error mess
 
 # Features
 
+* Filtering tests using test-targets.
 * Calculating multi-module shards.
 * Reusing test cases duration for sharding.
 * Creating or reusing instances (devices).
@@ -204,6 +215,5 @@ To see the source of the problem check the log file referenced in the error mess
 
 * Cleaning devices after test execution.
 * Flaky test detection.
-* Structural logging.
 * iOS support.
 * and much more...

--- a/test_configs/flank-corellium.yml
+++ b/test_configs/flank-corellium.yml
@@ -3,7 +3,9 @@ apks:
   - path: "test_artifacts/master/apk/app-debug.apk"
     tests:
       - path: "test_artifacts/master/apk/app-multiple-flaky-debug-androidTest.apk"
-test-targets:
-  - "package com.example.test_app"
-#  - "notClass com.example.test_app.InstrumentedTest#test0"
+#test-targets:
+#  - "package com.example.test_app.parametrized"
+#  - "notClass com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized"
+#  - "package com.example.test_app.foo"
+#  - "class com.example.test_app.InstrumentedTest#test0"
 max-test-shards: 3

--- a/test_configs/flank-corellium.yml
+++ b/test_configs/flank-corellium.yml
@@ -3,4 +3,7 @@ apks:
   - path: "test_artifacts/master/apk/app-debug.apk"
     tests:
       - path: "test_artifacts/master/apk/app-multiple-flaky-debug-androidTest.apk"
+test-targets:
+  - "package com.example.test_app"
+#  - "notClass com.example.test_app.InstrumentedTest#test0"
 max-test-shards: 3

--- a/tool/apk/src/main/kotlin/flank/apk/Apk.kt
+++ b/tool/apk/src/main/kotlin/flank/apk/Apk.kt
@@ -23,7 +23,13 @@ object Apk {
     /**
      * @return The full list of test methods from parsed apk.
      */
-    fun interface ParseTestCases : (LocalPath) -> TestCases
+    fun interface ParseTestCases : (ParseTestCases.Config) -> (LocalPath) -> TestCases {
+
+        data class Config(
+            val filterClass: TestRunners = emptySet(),
+            val filterTest: TestFilter = { true },
+        )
+    }
 
     /**
      * @return The [PackageName] for given apk.
@@ -34,7 +40,22 @@ object Apk {
      * @return The [Info] for given apk.
      */
     fun interface ParseInfo : (LocalPath) -> Info
+
+    object Runner {
+        const val JUnitParamsRunner = "junitparams.JUnitParamsRunner"
+        const val Parameterized = "org.junit.runners.Parameterized"
+    }
 }
+
+/**
+ * Test runners simple names
+ */
+typealias TestRunners = Set<String>
+
+/**
+ * Check if given a pair of test name with list of annotations can should be filtered.
+ */
+typealias TestFilter = (Pair<String, List<String>>) -> Boolean
 
 /**
  * Local path to the test apk file.

--- a/tool/apk/src/main/kotlin/flank/apk/internal/Info.kt
+++ b/tool/apk/src/main/kotlin/flank/apk/internal/Info.kt
@@ -1,20 +1,10 @@
 package flank.apk.internal
 
-import com.linkedin.dex.parser.DexParser
-import com.linkedin.dex.parser.TestMethod
 import flank.apk.Apk
 import net.dongliu.apk.parser.ApkFile
 import org.xml.sax.InputSource
 import java.io.StringReader
 import javax.xml.parsers.DocumentBuilderFactory
-
-internal val parseApkTestCases = Apk.ParseTestCases { path ->
-    DexParser.findTestMethods(path).map(TestMethod::testName)
-}
-
-internal val parseApkPackageName = Apk.ParsePackageName { path ->
-    ApkFile(path).apkMeta.packageName
-}
 
 internal val parseApkInfo = Apk.ParseInfo { path ->
     val apkFile = ApkFile(path)

--- a/tool/apk/src/main/kotlin/flank/apk/internal/PackageName.kt
+++ b/tool/apk/src/main/kotlin/flank/apk/internal/PackageName.kt
@@ -1,0 +1,8 @@
+package flank.apk.internal
+
+import flank.apk.Apk
+import net.dongliu.apk.parser.ApkFile
+
+internal val parseApkPackageName = Apk.ParsePackageName { path ->
+    ApkFile(path).apkMeta.packageName
+}

--- a/tool/apk/src/main/kotlin/flank/apk/internal/TestCases.kt
+++ b/tool/apk/src/main/kotlin/flank/apk/internal/TestCases.kt
@@ -25,7 +25,6 @@ internal val parseApkTestCases = Apk.ParseTestCases { config ->
             filter { it.testName.split("#").first() !in toDrop }
         }
 
-
         return (testMethods + testClasses)
             .filter { method -> config.filterTest(method.plain()) }
             .map(TestMethod::testName)

--- a/tool/apk/src/main/kotlin/flank/apk/internal/TestCases.kt
+++ b/tool/apk/src/main/kotlin/flank/apk/internal/TestCases.kt
@@ -1,0 +1,58 @@
+package flank.apk.internal
+
+import com.linkedin.dex.parser.DecodedValue
+import com.linkedin.dex.parser.DexParser
+import com.linkedin.dex.parser.TestAnnotation
+import com.linkedin.dex.parser.TestMethod
+import com.linkedin.dex.parser.formatClassName
+import com.linkedin.dex.parser.getAnnotationsDirectory
+import com.linkedin.dex.parser.getClassAnnotationValues
+import com.linkedin.dex.spec.ClassDefItem
+import com.linkedin.dex.spec.DexFile
+import flank.apk.Apk
+
+internal val parseApkTestCases = Apk.ParseTestCases { config ->
+    fun TestMethod.plain(): Pair<String, List<String>> =
+        testName to annotations.map(TestAnnotation::name)
+
+    fun(path: String): List<String> {
+        val testClasses = getTestClasses(path) { classDef ->
+            isRunWith(classDef, config.filterClass)
+        }
+
+        val testMethods = DexParser.findTestMethods(path).run {
+            val toDrop = testClasses.map(TestMethod::testName).toSet()
+            filter { it.testName.split("#").first() !in toDrop }
+        }
+
+
+        return (testMethods + testClasses)
+            .filter { method -> config.filterTest(method.plain()) }
+            .map(TestMethod::testName)
+    }
+}
+
+private fun getTestClasses(path: String, filter: DexFile.(ClassDefItem) -> Boolean): List<TestMethod> =
+    DexParser.readDexFiles(path).fold(emptyList()) { accumulator, file: DexFile ->
+        accumulator + file.run {
+            classDefs.filter { item -> filter(item) }.map { item ->
+                TestMethod(
+                    testName = formatClassName(item).dropLast(1),
+                    annotations = getClassAnnotationValues(getAnnotationsDirectory(item))
+                )
+            }
+        }
+    }
+
+private fun DexFile.isRunWith(classDef: ClassDefItem, oneOfRunners: Set<String>): Boolean {
+    // parse "Lorg/junit/runners/Parameterized;" to "org.junit.runners.Parameterized"
+    fun DecodedValue.DecodedType.parsePackage() = value.drop(1).dropLast(1).replace("/", ".")
+
+    return getClassAnnotationValues(getAnnotationsDirectory(classDef)).let { annotations: List<TestAnnotation> ->
+        annotations.any { it.name.contains("RunWith", ignoreCase = true) } && annotations
+            .flatMap { it.values.values }
+            .filterIsInstance<DecodedValue.DecodedType>()
+            .map { it.parsePackage() }
+            .any { it in oneOfRunners }
+    }
+}

--- a/tool/apk/src/test/kotlin/flank/apk/ParseApkTest.kt
+++ b/tool/apk/src/test/kotlin/flank/apk/ParseApkTest.kt
@@ -3,21 +3,45 @@ package flank.apk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-private const val TEST_APK_PATH = "../../test_artifacts/master/apk/app-single-success-debug-androidTest.apk"
+private const val TEST_APK_PATH = "../../test_artifacts/master/apk/app-multiple-success-debug-androidTest.apk"
 
 class ParseApkTest {
 
     private val apk = Apk.Api()
 
+    /**
+     * Parse test cases with following filters conditions:
+     *
+     * 1. Classes annotated by @RunWith(JUnitParamsRunner::class) wouldn't be split into test methods but delivered as class.
+     * 2. Filter out test case named test0 and test cases annotated with org.junit.Ignore
+     */
     @Test
     fun parseTestCases() {
+        val config = Apk.ParseTestCases.Config(
+            filterClass = setOf(Apk.Runner.JUnitParamsRunner),
+            filterTest = { (name, annotations) ->
+                println("$name $annotations")
+                name != "com.example.test_app.InstrumentedTest#test0" && !annotations.contains("org.junit.Ignore")
+            }
+        )
+
         assertEquals(
             listOf(
-                "com.example.test_app.InstrumentedTest#ignoredTestWithIgnore",
-                "com.example.test_app.InstrumentedTest#ignoredTestWithSuppress",
-                "com.example.test_app.InstrumentedTest#test",
+                "com.example.test_app.InstrumentedTest#ignoredTestWitSuppress",
+                // "com.example.test_app.InstrumentedTest#ignoredTestWithIgnore",
+                // "com.example.test_app.InstrumentedTest#test0",
+                "com.example.test_app.InstrumentedTest#test1",
+                "com.example.test_app.InstrumentedTest#test2",
+                "com.example.test_app.ParameterizedTest#shouldHopefullyPass",
+                // "com.example.test_app.bar.BarInstrumentedTest#ignoredTestBar",
+                "com.example.test_app.bar.BarInstrumentedTest#testBar",
+                // "com.example.test_app.foo.FooInstrumentedTest#ignoredTestFoo",
+                "com.example.test_app.foo.FooInstrumentedTest#testFoo",
+                "com.example.test_app.parametrized.EspressoParametrizedClassParameterizedNamed#clickRightButton",
+                "com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized#clickRightButton",
+                "com.example.test_app.parametrized.EspressoParametrizedMethodTestJUnitParamsRunner",
             ),
-            apk.parseTestCases(TEST_APK_PATH)
+            apk.parseTestCases(config)(TEST_APK_PATH)
         )
     }
 


### PR DESCRIPTION
Fixes #2051

Requires #2055

Enchanted by #2062

## Changes

* Add test targets argument for filtering test cases.
* Add filtering option to Apk.ParseTestCases.
* Log AndroidTestPlan.Config on ExecuteTests start.
* Refactor `:tool:apk` module

## Test Plan
> How do we know the code works?

build flank
```shell
. .env
flankScripts assemble flank -d
```
and run 
```shell
flank corellium test android run -c="./test_configs/flank-corellium.yml"
```
using configuration
```yml
auth: "test_configs/corellium_auth.yml"
apks:
  - path: "test_artifacts/master/apk/app-debug.apk"
    tests:
      - path: "test_artifacts/master/apk/app-multiple-flaky-debug-androidTest.apk"
test-targets:
  - "package com.example.test_app.parametrized"
  - "notClass com.example.test_app.parametrized.EspressoParametrizedClassTestParameterized"
  - "package com.example.test_app.foo"
  - "class com.example.test_app.InstrumentedTest#test0"
max-test-shards: 3
```
As a results Flank should execute only test cases restricted by test targets.

## Checklist

- [x] Documented
- [x] Unit tested
- [x] Integrated with a filtering tool
