### PR TITLE
refactor: Make the domain a source of defaults

### DIFF
--- a/corellium/api/src/main/kotlin/flank/corellium/api/Authorization.kt
+++ b/corellium/api/src/main/kotlin/flank/corellium/api/Authorization.kt
@@ -13,10 +13,13 @@ object Authorization {
      * @property host the host part of base Corellium API url "https://[host]/api/v1".
      */
     data class Credentials(
-        val host: String,
-        val username: String,
-        val password: String,
+        val host: String = "",
+        val username: String = "",
+        val password: String = "",
     )
+
+    val Empty = Credentials()
+
     /**
      * The authorization API call.
      * The successful return is making the rest of API functions available.

--- a/corellium/cli/src/main/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommand.kt
+++ b/corellium/cli/src/main/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommand.kt
@@ -165,14 +165,18 @@ class RunTestCorelliumAndroidCommand :
 }
 
 private fun defaultConfig() = Config().apply {
-    project = "Default Project"
-    auth = "corellium_auth.yml"
-    apks = emptyList()
-    maxTestShards = 1
-    localResultsDir = null
-    obfuscate = false
-    gpuAcceleration = true
-    scanPreviousDurations = 10
+    project = Args.DEFAULT_PROJECT
+    auth = Args.AUTH_FILE
+    this += Args.Default
+}
+
+private operator fun Config.plusAssign(args: Args) {
+    apks = args.apks
+    maxTestShards = args.maxShardsCount
+    localResultsDir = args.outputDir
+    obfuscate = args.obfuscateDumpShards
+    gpuAcceleration = args.gpuAcceleration
+    scanPreviousDurations = args.scanPreviousDurations
 }
 
 private fun RunTestCorelliumAndroidCommand.yamlConfig(): Config =
@@ -182,7 +186,7 @@ private fun RunTestCorelliumAndroidCommand.createArgs() = Args(
     credentials = loadYaml(config.auth!!),
     apks = config.apks!!,
     maxShardsCount = config.maxTestShards!!,
-    outputDir = config.localResultsDir ?: Args.DefaultOutputDir.new,
+    outputDir = config.localResultsDir!!,
     obfuscateDumpShards = config.obfuscate!!,
     gpuAcceleration = config.gpuAcceleration!!,
     scanPreviousDurations = config.scanPreviousDurations!!,

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestCorelliumAndroid.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestCorelliumAndroid.kt
@@ -65,14 +65,21 @@ object RunTestCorelliumAndroid {
      * @param scanPreviousDurations Scan the specified amount of JUnitReport.xml files to obtain test cases durations necessary for optimized sharding. The [outputDir] is used for searching JUnit reports.
      */
     data class Args(
-        val credentials: Authorization.Credentials,
-        val apks: List<Apk.App>,
-        val maxShardsCount: Int,
+        val credentials: Authorization.Credentials = Authorization.Empty,
+        val apks: List<Apk.App> = emptyList(),
+        val maxShardsCount: Int = 1,
         val obfuscateDumpShards: Boolean = false,
         val outputDir: String = DefaultOutputDir.new,
         val gpuAcceleration: Boolean = true,
         val scanPreviousDurations: Int = 10,
     ) {
+
+        companion object {
+            val Default = Args()
+            const val DEFAULT_PROJECT = "Default Project"
+            const val AUTH_FILE = "corellium_auth.yml"
+        }
+
         /**
          * Default output directory scheme.
          *


### PR DESCRIPTION
This PR is fixing a bad design where the CLI layer is defining default arguments. 
The change is the CLI now is depending on defaults from the domain module.
