### PR TITLE
fix: Removed filtering default args when sending statistics to mixpanel

### DIFF
--- a/test_runner/src/main/kotlin/ftl/analytics/PrepareConfiguration.kt
+++ b/test_runner/src/main/kotlin/ftl/analytics/PrepareConfiguration.kt
@@ -8,17 +8,11 @@ import ftl.args.IosArgs
 
 private const val COMMON_ARGS = "commonArgs"
 
-internal fun AndroidArgs.createEventMap(
-    defaultArgs: AndroidArgs = AndroidArgs.default(),
-) = toArgsMap(defaultArgs).plus(commonArgs.toArgsMap(defaultArgs.commonArgs))
+fun AndroidArgs.createEventMap() = toArgsMap().plus(commonArgs.toArgsMap()).removeNotNeededKeys().filterSensitiveValues()
 
-internal fun IosArgs.createEventMap(
-    defaultArgs: IosArgs = IosArgs.default(),
-) = toArgsMap(defaultArgs).plus(commonArgs.toArgsMap(defaultArgs.commonArgs))
+fun IosArgs.createEventMap() = toArgsMap().plus(commonArgs.toArgsMap()).removeNotNeededKeys().filterSensitiveValues()
 
-private fun IArgs.toArgsMap(
-    defaultArgs: IArgs
-) = objectToMap().filterNonCommonArgs().getNonDefaultArgs(defaultArgs.objectToMap())
+private fun IArgs.toArgsMap() = objectToMap().filterNonCommonArgs()
 
 @VisibleForTesting
 internal fun Any.objectToMap() = objectMapper.convertValue(this, object : TypeReference<Map<String, Any>>() {})

--- a/test_runner/src/main/kotlin/ftl/analytics/StatisticDataFilters.kt
+++ b/test_runner/src/main/kotlin/ftl/analytics/StatisticDataFilters.kt
@@ -28,9 +28,9 @@ private fun findMembersWithAnnotation(
     }
 }
 
-internal fun Map<String, Any>.removeNotNeededKeys(defaultArgs: Map<String, Any>) =
-    filterNot { (key, value) ->
-        value == defaultArgs[key] || key in keysToRemove
+internal fun Map<String, Any>.removeNotNeededKeys() =
+    filterNot { (key, _) ->
+        key in keysToRemove
     }
 
 internal fun Map<String, Any>.filterSensitiveValues() = mapValues { it.anonymousSensitiveValues() }

--- a/test_runner/src/main/kotlin/ftl/analytics/UsageStatistics.kt
+++ b/test_runner/src/main/kotlin/ftl/analytics/UsageStatistics.kt
@@ -12,8 +12,4 @@ internal fun IArgs.registerUser(): IArgs = apply {
     ).send()
 }
 
-internal fun Map<String, Any>.getNonDefaultArgs(
-    defaultArgs: Map<String, Any>
-) = removeNotNeededKeys(defaultArgs).filterSensitiveValues()
-
 internal fun Map<*, *>.toJSONObject() = JSONObject(this)

--- a/test_runner/src/test/kotlin/ftl/analytics/UsageStatisticsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/analytics/UsageStatisticsTest.kt
@@ -2,7 +2,6 @@ package ftl.analytics
 
 import com.google.common.truth.Truth.assertThat
 import ftl.args.AndroidArgs
-import ftl.args.IosArgs
 import ftl.test.util.FlankTestRunner
 import ftl.util.readVersion
 import io.mockk.every
@@ -23,67 +22,17 @@ class UsageStatisticsTest {
     }
 
     @Test
-    fun `should filter default args for android`() {
-        val default = AndroidArgs.default()
-        val args = default.copy(
-            appApk = "test"
-        ).objectToMap()
-
-        val nonDefaultArgs = args.filterNonCommonArgs().getNonDefaultArgs(default.objectToMap())
-
-        assertThat(nonDefaultArgs).containsKey("appApk")
-        assertThat(nonDefaultArgs.count()).isEqualTo(1)
-    }
-
-    @Test
-    fun `should filter default args for ios`() {
-        val default = IosArgs.default()
-        val args = default.copy(xctestrunFile = "test").objectToMap()
-
-        val nonDefaultArgs = args.filterNonCommonArgs().getNonDefaultArgs(default.objectToMap())
-
-        assertThat(nonDefaultArgs).containsKey("xctestrunFile")
-        assertThat(nonDefaultArgs.count()).isEqualTo(1)
-    }
-
-    @Test
-    fun `should filter default args for ios with commonArgs`() {
-        val default = IosArgs.default()
-        val args =
-            default.copy(xctestrunFile = "test", commonArgs = default.commonArgs.copy(resultsBucket = "test_bucket"))
-
-        val nonDefaultArgs = args.createEventMap(default)
-
-        assertThat(nonDefaultArgs).containsKey("xctestrunFile")
-        assertThat(nonDefaultArgs).containsKey("resultsBucket")
-        assertThat(nonDefaultArgs.count()).isEqualTo(2)
-    }
-
-    @Test
-    fun `should filter default args for android with commonArgs`() {
-        val default = AndroidArgs.default()
-        val args = default.copy(testApk = "test", commonArgs = default.commonArgs.copy(resultsBucket = "test_bucket"))
-
-        val nonDefaultArgs = args.createEventMap(default)
-
-        assertThat(nonDefaultArgs).containsKey("testApk")
-        assertThat(nonDefaultArgs).containsKey("resultsBucket")
-        assertThat(nonDefaultArgs.count()).isEqualTo(2)
-    }
-
-    @Test
     fun `should anonymize maps to (key,anonymizedValue)`() {
         val default = AndroidArgs.default()
         val args = default.copy(environmentVariables = mapOf("testKey" to "testValue", "testKey2" to "testValue2"))
 
-        val nonDefaultArgs = args.createEventMap(default)
+        val nonDefaultArgs = args.createEventMap()
         (nonDefaultArgs["environmentVariables"] as? Map<*, *>)?.let { environmentVariables ->
             assertThat(environmentVariables.count()).isEqualTo(2)
             assertThat(environmentVariables.values.all { it == "..." }).isTrue()
         }
 
-        assertThat(nonDefaultArgs.count()).isEqualTo(1)
-        assertThat(nonDefaultArgs.keys).containsExactly("environmentVariables")
+        assertThat(nonDefaultArgs.keys).contains("environmentVariables")
     }
 
     @Test


### PR DESCRIPTION
Fixes #1792 

## Test Plan
> How do we know the code works?

In case when we don't have a default project id, Flank should not fail when trying to compare default android configuration and user-defined configuration.

## Checklist

- [X] Unit tested
