### PR TITLE
refactor: Move Config.kt into :tool:config module.

### DIFF
--- a/corellium/cli/build.gradle.kts
+++ b/corellium/cli/build.gradle.kts
@@ -18,10 +18,8 @@ dependencies {
     implementation(Dependencies.PICOCLI)
     implementation(project(":corellium:domain"))
     implementation(project(":corellium:adapter"))
+    implementation(project(":tool:config"))
     implementation(project(":tool:log:format"))
-    implementation(Dependencies.JACKSON_KOTLIN)
-    implementation(Dependencies.JACKSON_YAML)
-    implementation(Dependencies.JACKSON_XML)
     testImplementation(Dependencies.JUNIT)
     testImplementation(Dependencies.MOCKK)
 }

--- a/corellium/cli/src/main/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommand.kt
+++ b/corellium/cli/src/main/kotlin/flank/corellium/cli/RunTestCorelliumAndroidCommand.kt
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import flank.apk.Apk
+import flank.config.ConfigMap
+import flank.config.emptyConfigMap
+import flank.config.loadYaml
+import flank.config.merge
 import flank.corellium.api.AndroidApps
 import flank.corellium.api.AndroidInstance
 import flank.corellium.cli.RunTestCorelliumAndroidCommand.Config
-import flank.corellium.cli.util.ConfigMap
-import flank.corellium.cli.util.emptyConfigMap
-import flank.corellium.cli.util.loadYaml
-import flank.corellium.cli.util.merge
 import flank.corellium.corelliumApi
 import flank.corellium.domain.RunTestCorelliumAndroid
 import flank.corellium.domain.RunTestCorelliumAndroid.Args

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     ":corellium:sandbox",
 
     ":tool:apk",
+    ":tool:config",
     ":tool:filter",
     ":tool:shard",
     ":tool:shard:calculate",

--- a/tool/config/README.md
+++ b/tool/config/README.md
@@ -1,0 +1,9 @@
+# Config
+
+Extension for managing user configuration.
+
+### References
+
+* Module type - [tool](../../../docs/architecture.md#tool)
+* Dependency type - [static](../../../docs/architecture.md#static_dependencies)
+* Public API - [Config.kt](./src/main/kotlin/flank/config/Config.kt)

--- a/tool/config/build.gradle.kts
+++ b/tool/config/build.gradle.kts
@@ -1,0 +1,21 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin(Plugins.Kotlin.PLUGIN_JVM)
+}
+
+repositories {
+    jcenter()
+    mavenCentral()
+    maven(url = "https://kotlin.bintray.com/kotlinx")
+}
+
+tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
+
+dependencies {
+    implementation(Dependencies.KOTLIN_COROUTINES_CORE)
+    api(Dependencies.JACKSON_KOTLIN)
+    api(Dependencies.JACKSON_YAML)
+    api(Dependencies.JACKSON_XML)
+    testImplementation(Dependencies.JUNIT)
+}

--- a/tool/config/src/main/kotlin/flank/config/Config.kt
+++ b/tool/config/src/main/kotlin/flank/config/Config.kt
@@ -1,4 +1,4 @@
-package flank.corellium.cli.util
+package flank.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -8,7 +8,7 @@ import java.io.File
 /**
  * Abstraction for configuration structures
  */
-internal interface ConfigMap {
+interface ConfigMap {
     val data: MutableMap<String, Any?>
 }
 
@@ -20,21 +20,21 @@ internal interface ConfigMap {
  * @param others Other configuration to accumulate in first.
  * @return The [first] parameter with accumulated values.
  */
-internal fun <C : ConfigMap> merge(first: C, vararg others: C): C =
+fun <C : ConfigMap> merge(first: C, vararg others: C): C =
     others.fold(first) { acc, config -> acc.apply { data += config.data } }
 
 /**
  * Factory method for the empty configuration map with null as default value
  */
-internal fun emptyConfigMap(): MutableMap<String, Any?> =
+fun emptyConfigMap(): MutableMap<String, Any?> =
     mutableMapOf<String, Any?>().withDefault { null }
 
 /**
  * Load the yaml configuration file as structure.
  */
-internal inline fun <reified T> loadYaml(path: String): T =
+inline fun <reified T> loadYaml(path: String): T =
     yamlMapper.readValue(File(path), T::class.java)
 
-private val yamlMapper: ObjectMapper by lazy {
+val yamlMapper: ObjectMapper by lazy {
     ObjectMapper(YAMLFactory()).registerKotlinModule()
 }


### PR DESCRIPTION
Just adds module `:tool:config` and moves `Config.kt` for making CLI not defining any tool by itself.