### PR TITLE
refactor: Move legacy execution tool to standalone module.

### DIFF
--- a/corellium/domain/build.gradle.kts
+++ b/corellium/domain/build.gradle.kts
@@ -16,6 +16,7 @@ tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
 dependencies {
     implementation(Dependencies.KOTLIN_COROUTINES_CORE)
     api(project(":corellium:api"))
+    api(project(":tool:execution:linear"))
     api(project(":tool:apk"))
     api(project(":tool:filter"))
     api(project(":tool:shard:calculate"))

--- a/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestCorelliumAndroid.kt
+++ b/corellium/domain/src/main/kotlin/flank/corellium/domain/RunTestCorelliumAndroid.kt
@@ -23,9 +23,9 @@ import flank.corellium.domain.run.test.android.step.loadPreviousDurations
 import flank.corellium.domain.run.test.android.step.parseApksInfo
 import flank.corellium.domain.run.test.android.step.parseTestCasesFromApks
 import flank.corellium.domain.run.test.android.step.prepareShards
-import flank.corellium.domain.util.Transform
-import flank.corellium.domain.util.execute
-import flank.corellium.domain.util.injectLogger
+import flank.exection.linear.Transform
+import flank.exection.linear.execute
+import flank.exection.linear.injectLogger
 import flank.instrument.log.Instrument
 import flank.junit.JUnit
 import flank.log.Event

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,7 @@ include(
     ":tool:log",
     ":tool:log:format",
     ":tool:execution:parallel",
-    ":tool:execution:synchronized",
+    ":tool:execution:linear",
 )
 
 plugins {

--- a/tool/execution/linear/build.gradle.kts
+++ b/tool/execution/linear/build.gradle.kts
@@ -13,6 +13,7 @@ repositories {
 tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
 
 dependencies {
+    api(project(":tool:log"))
     implementation(Dependencies.KOTLIN_COROUTINES_CORE)
     testImplementation(Dependencies.JUNIT)
 }

--- a/tool/execution/linear/src/main/kotlin/flank/exection/linear/Transform.kt
+++ b/tool/execution/linear/src/main/kotlin/flank/exection/linear/Transform.kt
@@ -1,4 +1,4 @@
-package flank.corellium.domain.util
+package flank.exection.linear
 
 import flank.log.Event
 import flank.log.Logger
@@ -14,13 +14,13 @@ import kotlinx.coroutines.flow.fold
  * @receiver Value to apply transformations on it.
  * @return Result of transformations.
  */
-internal suspend infix fun <S> S.execute(operations: Flow<Transform<S>>): S =
+suspend infix fun <S> S.execute(operations: Flow<Transform<S>>): S =
     operations.fold(this) { value, transform -> transform(value) }
 
 /**
  * Simple parameterized factory for generating [Transform] instances.
  */
-internal class CreateTransformation<S> : (Transform<S>) -> Transform<S> by { it }
+class CreateTransformation<S> : (Transform<S>) -> Transform<S> by { it }
 
 /**
  * Type-alias for suspendable transforming operation
@@ -30,7 +30,7 @@ typealias Transform<S> = suspend S.() -> S
 /**
  * Inject log output to the transform function.
  */
-internal fun <S> Logger.injectLogger(
+fun <S> Logger.injectLogger(
     type: Any = Unit,
     transform: suspend S.(Output) -> S
 ): Transform<S> {


### PR DESCRIPTION
Just adds module `:tool:execution:linear` and moves `Transfrom.kt` for making domain not defining any tool by itself.