### PR TITLE
fix: Fix calculating total test cost in Mixpanel

### DIFF
--- a/test_runner/src/main/kotlin/ftl/reports/CostReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/CostReport.kt
@@ -35,7 +35,7 @@ object CostReport : IReport {
             events = mapOf(
                 "virtual_cost" to virtualCost,
                 "physical_cost" to physicalCost,
-                "total_cost" to calculateTotalCost(
+                "cost_total" to calculateTotalCost(
                     virtualCost,
                     physicalCost
                 )

--- a/test_runner/src/main/kotlin/ftl/reports/CostReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/CostReport.kt
@@ -28,13 +28,16 @@ object CostReport : IReport {
             totalBillablePhysicalMinutes += it.billableMinutes.physical
         }
 
+        val virtualCost = calculateVirtualCost(totalBillableVirtualMinutes.toBigDecimal())
+        val physicalCost = calculatePhysicalCost(totalBillablePhysicalMinutes.toBigDecimal())
+
         args.sendConfiguration(
             events = mapOf(
-                "virtual_cost" to calculateVirtualCost(totalBillableVirtualMinutes.toBigDecimal()),
-                "physical_cost" to calculatePhysicalCost(totalBillablePhysicalMinutes.toBigDecimal()),
+                "virtual_cost" to virtualCost,
+                "physical_cost" to physicalCost,
                 "total_cost" to calculateTotalCost(
-                    totalBillablePhysicalMinutes.toBigDecimal(),
-                    totalBillableVirtualMinutes.toBigDecimal()
+                    virtualCost,
+                    physicalCost
                 )
             ),
             eventName = "devices_cost"


### PR DESCRIPTION
Fixes #

## Test Plan
> How do we know the code works?

In mixpanel ```devices_cost. total_cost ``` event should be the sum of virtual cost and physical cost instead of the sum of physical and virtual minutes
