### PR TITLE
fix: Incorrect calculations in JUnit tool

### DIFF
--- a/tool/junit/src/main/kotlin/flank/junit/internal/MergeDurations.kt
+++ b/tool/junit/src/main/kotlin/flank/junit/internal/MergeDurations.kt
@@ -8,7 +8,7 @@ internal fun List<JUnit.TestResult>.mergeDurations(
     if (isEmpty() || forClasses.isEmpty()) this // Nothing to merge.
     else groupBy { method -> method.className in forClasses }.run { // separate test cases methods to merge.
         getOrDefault(false, emptyList()) + getOrDefault(true, emptyList()) // Sum test cases methods with classes.
-            .groupBy { method -> method.className }.values // Group tests cases to merge by class name.
+            .groupBy { method -> method.className + method.suiteName }.values // Group tests cases to merge by class name and suite name.
             .map { methods -> methods.sortedBy(JUnit.TestResult::startAt) } // Ensure correct order.
             .map { methods -> methods.first().copy(testName = "", endsAt = methods.last().endsAt) } // Merge into class.
     }

--- a/tool/junit/src/main/kotlin/flank/junit/internal/ParseJUnitTestResults.kt
+++ b/tool/junit/src/main/kotlin/flank/junit/internal/ParseJUnitTestResults.kt
@@ -9,7 +9,9 @@ internal val parseJUnitTestResults = JUnit.TestResult.Parse { path ->
     val file = File(path)
     when {
         file.isFile -> sequenceOf(file)
-        file.isDirectory -> file.walkTopDown().filter { next -> next.name == JUnit.REPORT_FILE_NAME }
+        file.isDirectory -> file.walkBottomUp()
+            .filter { next -> next.name == JUnit.REPORT_FILE_NAME }
+            .sortedByDescending(File::lastModified)
         else -> emptySequence()
     }.map { next: File ->
         next.reader().parseJUnitReport().testsuites.mapToTestResults()

--- a/tool/junit/src/test/kotlin/flank/junit/internal/MergeDurationsKtTest.kt
+++ b/tool/junit/src/test/kotlin/flank/junit/internal/MergeDurationsKtTest.kt
@@ -20,14 +20,16 @@ class MergeDurationsKtTest {
             result("b", "b[0]", 10, 110),
             result("b", "b[1]", 110, 120),
             result("b", "b[2]", 120, 140),
-            result("c", "c", 140, 440),
+            result("c", "c", 140, 240),
+            result("c", "c", 240, 440),
             result("d", "d[name: a]", 440, 470),
             result("d", "d[name: b]", 470, 500),
         )
 
         val expected = listOf(
             result("a", "a", 0, 10),
-            result("c", "c", 140, 440),
+            result("c", "c", 140, 240),
+            result("c", "c", 240, 440),
             result("b", "", 10, 140),
             result("d", "", 440, 500),
         )


### PR DESCRIPTION
Related to #2083 

Fixes following behaviors:

* Loads only the latest JUnit results used for calculating durations of previous test cases instead of random.
* Avoids merging parameterized tests cases durations from different shards.
