### PR TITLE
feat: Improvements for :tool:execution:parallel

### DIFF
--- a/tool/execution/parallel/src/main/kotlin/flank/exection/parallel/Create.kt
+++ b/tool/execution/parallel/src/main/kotlin/flank/exection/parallel/Create.kt
@@ -53,3 +53,10 @@ inline fun <reified T : Any> type(): Parallel.Type<T> = type(T::class.java)
  * Factory function for creating dynamic [Parallel.Type].
  */
 fun <T : Any> type(type: Class<T>): Parallel.Type<T> = DynamicType(type)
+
+// ======================= Property =======================
+
+/**
+ * Factory function for creating property with value of specified type.
+ */
+operator fun <T : Any> Parallel.Type<T>.plus(value: T) = this to value

--- a/tool/execution/parallel/src/main/kotlin/flank/exection/parallel/Parallel.kt
+++ b/tool/execution/parallel/src/main/kotlin/flank/exection/parallel/Parallel.kt
@@ -94,9 +94,9 @@ object Parallel {
     object Sequence : Type<Unit>
 
     object DependenciesError {
-        data class Missing(val data: TypeDependencies) : Error("Missing dependencies $data")
-        data class Duplicate(val data: DuplicateDependencies) : Error("Duplicate dependencies $data")
-        data class Cycles(val data: List<List<Type<*>>>) : Error("Found cycles in graph $data")
+        data class Missing(val data: TypeDependencies) : Error("Missing dependencies:")
+        data class Duplicate(val data: DuplicateDependencies) : Error("Duplicate dependencies:")
+        data class Cycles(val data: List<List<Type<*>>>) : Error("Found cycles in graph:")
     }
 }
 

--- a/tool/execution/parallel/src/main/kotlin/flank/exection/parallel/Select.kt
+++ b/tool/execution/parallel/src/main/kotlin/flank/exection/parallel/Select.kt
@@ -4,4 +4,4 @@ package flank.exection.parallel
  * Select value by type.
  */
 @Suppress("UNCHECKED_CAST")
-fun <T : Any> ParallelState.select(type: Parallel.Type<T>) = get(type) as T
+infix fun <T : Any> ParallelState.select(type: Parallel.Type<T>) = get(type) as T

--- a/tool/execution/parallel/src/main/kotlin/flank/exection/parallel/internal/ContextProvider.kt
+++ b/tool/execution/parallel/src/main/kotlin/flank/exection/parallel/internal/ContextProvider.kt
@@ -2,16 +2,21 @@ package flank.exection.parallel.internal
 
 import flank.exection.parallel.ExecuteTask
 import flank.exection.parallel.Parallel
+import flank.exection.parallel.ParallelState
 import flank.exection.parallel.validator
 
 /**
- * Abstract factory for creating task function.
+ * Abstract factory for wrapping state into context and creating task function.
  */
-abstract class ContextProvider<X : Parallel.Context> internal constructor() {
+abstract class ContextProvider<X : Parallel.Context>
+internal constructor() : (ParallelState) -> X {
     protected abstract val context: () -> X
 
-    operator fun <R> invoke(body: suspend X.() -> R): ExecuteTask<R> =
-        { context().also { it.state = this }.body() }
+    override fun invoke(state: ParallelState): X =
+        context().also { it.state = state }
+
+    operator fun <R> invoke(body: suspend X.(ParallelState) -> R): ExecuteTask<R> =
+        { invoke(this).body(this) }
 
     val validate by lazy { validator(context) }
 }

--- a/tool/execution/parallel/src/main/kotlin/flank/exection/parallel/internal/Execution.kt
+++ b/tool/execution/parallel/src/main/kotlin/flank/exection/parallel/internal/Execution.kt
@@ -176,8 +176,8 @@ private fun Execution.isFinished(state: ParallelState): Boolean =
 private fun Execution.filterTasksFor(state: ParallelState): Map<Set<Type<*>>, List<Task<*>>> =
     remaining.filterKeys(state.keys::containsAll).apply {
 
-        // Check if execution is not detached, other words some of tasks cannot be run because of missing values in state.
-        // Typically will fail if broken graph was not validated before execution.
+        // Check if execution is not detached, other words some tasks cannot be run because of missing values in state.
+        // Typically, will fail if broken graph was not validated before execution.
         isNotEmpty() || // Found tasks to execute.
             jobs.any { (_, job) -> job.isActive } || // some jobs still are running, is required to wait for values from them.
             channel.isEmpty.not() || // some values are waiting in the channel queue.
@@ -188,7 +188,7 @@ private fun Execution.filterTasksFor(state: ParallelState): Map<Set<Type<*>>, Li
     }
 
 /**
- * Typically can occurs when execution is running on broken graph of tasks.
+ * Typically, can occur when execution is running on broken graph of tasks.
  */
 private data class DeadlockError(
     val state: ParallelState,
@@ -196,10 +196,12 @@ private data class DeadlockError(
     val remaining: Map<Set<Type<*>>, List<Task<*>>>,
 ) : Error() {
     override fun toString(): String = listOf(
+        "Execution cannot be fulfilled due to unresolved dependencies, use function `Tasks.validate(initial: ParallelState)` before run for getting details.",
+        "",
         "Parallel execution dump:",
-        state,
-        jobs,
-        remaining,
+        "state:     $state",
+        "jobs:      $jobs",
+        "remaining: $remaining",
         "", super.toString(),
     ).joinToString("\n")
 }

--- a/tool/log/src/main/kotlin/flank/log/Event.kt
+++ b/tool/log/src/main/kotlin/flank/log/Event.kt
@@ -41,6 +41,7 @@ data class Event<V : Any> internal constructor(
  * Creates [Event] from [this] context and given [any] type or value.
  */
 infix fun Any.event(any: Any): Event<out Any> = when (any) {
+    is Event<*> -> any
     is Pair<*, *> -> Event(this, any.first!!, any.second!!)
     is Event.Data -> Event(this, any::class.java, any)
     is Event.Type<*> -> Event(this, any, Unit)


### PR DESCRIPTION
Related to #2083

* Expose function for wrapping state into context in ContextProvider.
* Add generic function for creating state property which static type checking.
* Improve DeadlockError message.
* Remove redundant data value from DependenciesError messages.
