### PR TITLE
feat: Added project ID to sentry

### DIFF
--- a/test_runner/src/main/kotlin/ftl/domain/RunTestAndroid.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/RunTestAndroid.kt
@@ -18,6 +18,7 @@ import ftl.reports.output.toOutputReportConfiguration
 import ftl.run.dumpShards
 import ftl.run.newTestRun
 import ftl.util.DEVICE_SYSTEM
+import ftl.util.PROJECT_ID
 import ftl.util.StopWatch
 import ftl.util.TEST_TYPE
 import ftl.util.loadFile
@@ -52,6 +53,7 @@ operator fun RunTestAndroid.invoke() {
         outputReport.configure(toOutputReportConfiguration())
         outputReport.log(this)
         setCrashReportTag(
+            PROJECT_ID to project,
             DEVICE_SYSTEM to "android",
             TEST_TYPE to type?.name.orEmpty()
         )

--- a/test_runner/src/main/kotlin/ftl/domain/RunTestIos.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/RunTestIos.kt
@@ -18,6 +18,7 @@ import ftl.reports.output.toOutputReportConfiguration
 import ftl.run.dumpShards
 import ftl.run.newTestRun
 import ftl.util.DEVICE_SYSTEM
+import ftl.util.PROJECT_ID
 import ftl.util.StopWatch
 import ftl.util.TEST_TYPE
 import ftl.util.loadFile
@@ -52,6 +53,7 @@ operator fun RunIosTest.invoke() {
         outputReport.configure(toOutputReportConfiguration())
         outputReport.log(this)
         setCrashReportTag(
+            PROJECT_ID to project,
             DEVICE_SYSTEM to "ios",
             TEST_TYPE to type?.name.orEmpty()
         )

--- a/test_runner/src/main/kotlin/ftl/util/CrashReporter.kt
+++ b/test_runner/src/main/kotlin/ftl/util/CrashReporter.kt
@@ -17,6 +17,7 @@ const val FLANK_VERSION = "flank.version"
 const val FLANK_REVISION = "flank.revision"
 const val DEVICE_SYSTEM = "device.system"
 const val TEST_TYPE = "test.type"
+const val PROJECT_ID = "project.id"
 
 private val configureCrashReporter by lazy { initCrashReporter() }
 


### PR DESCRIPTION
Fixes #2071

There's currently no way to identify which companies need help when flank crashes. this ticket will solve that.

## Test Plan
> How do we know the code works?

Each Sentry reported crash will contain information about the project id

