### PR TITLE
fix: Envs from additional apks not override default values

### DIFF
--- a/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
@@ -41,10 +41,11 @@ private fun AndroidArgs.mainApkContext() = appApk?.let { appApk ->
 private fun AndroidArgs.additionalApksContexts() = additionalAppTestApks.map {
     val appApk = (it.app ?: appApk)
         ?: throw FlankGeneralError("Cannot create app-test apks pair for instrumentation tests, missing app apk for test ${it.test}")
+    val envs = it.environmentVariables.takeIf { envs -> envs.isNotEmpty() } ?: environmentVariables
     InstrumentationTestContext(
         app = appApk.asFileReference(),
         test = it.test.asFileReference(),
-        environmentVariables = it.environmentVariables.takeIf { envs -> envs.isNotEmpty() } ?: environmentVariables,
+        environmentVariables = envs,
         testTargetsForShard = testTargetsForShard,
         args = copy(
             commonArgs = commonArgs.copy(
@@ -55,7 +56,7 @@ private fun AndroidArgs.additionalApksContexts() = additionalAppTestApks.map {
             testApk = it.test,
             testTargets = it.testTargets ?: testTargets,
             parameterizedTests = it.parameterizedTests ?: parameterizedTests,
-            environmentVariables = it.environmentVariables.takeIf { envs -> envs.isNotEmpty() } ?: environmentVariables,
+            environmentVariables = envs
         )
     )
 }.toTypedArray()

--- a/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
+++ b/test_runner/src/main/kotlin/ftl/run/platform/android/ResolveApks.kt
@@ -44,7 +44,7 @@ private fun AndroidArgs.additionalApksContexts() = additionalAppTestApks.map {
     InstrumentationTestContext(
         app = appApk.asFileReference(),
         test = it.test.asFileReference(),
-        environmentVariables = it.environmentVariables,
+        environmentVariables = it.environmentVariables.takeIf { envs -> envs.isNotEmpty() } ?: environmentVariables,
         testTargetsForShard = testTargetsForShard,
         args = copy(
             commonArgs = commonArgs.copy(
@@ -52,8 +52,10 @@ private fun AndroidArgs.additionalApksContexts() = additionalAppTestApks.map {
                 devices = it.devices ?: devices,
                 clientDetails = it.clientDetails ?: clientDetails
             ),
+            testApk = it.test,
             testTargets = it.testTargets ?: testTargets,
-            parameterizedTests = it.parameterizedTests ?: parameterizedTests
+            parameterizedTests = it.parameterizedTests ?: parameterizedTests,
+            environmentVariables = it.environmentVariables.takeIf { envs -> envs.isNotEmpty() } ?: environmentVariables,
         )
     )
 }.toTypedArray()

--- a/test_runner/src/test/kotlin/ftl/run/platform/android/CreateAndroidTestContextKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/android/CreateAndroidTestContextKtTest.kt
@@ -56,14 +56,24 @@ class CreateAndroidTestContextKtTest {
                 test = should { local.endsWith("app-single-success-debug-androidTest.apk") },
                 shards = should { size == 1 },
                 ignoredTestCases = should { size == 2 },
-                args = should { maxTestShards == 1 }
+                environmentVariables = should { equals(args.environmentVariables) },
+                args = should {
+                    maxTestShards == 1 &&
+                        testApk?.endsWith("app-single-success-debug-androidTest.apk") == true &&
+                        environmentVariables == args.environmentVariables
+                }
             ),
             InstrumentationTestContext(
                 app = should { local.endsWith("app-debug.apk") },
                 test = should { local.endsWith("app-multiple-flaky-debug-androidTest.apk") },
                 shards = should { size == 2 },
                 ignoredTestCases = should { size == 2 },
-                args = should { testTargets == listOf("class com.example.test_app.InstrumentedTest") }
+                environmentVariables = should { equals(args.environmentVariables) },
+                args = should {
+                    testTargets == listOf("class com.example.test_app.InstrumentedTest") &&
+                        testApk?.endsWith("app-multiple-flaky-debug-androidTest.apk") == true &&
+                        environmentVariables == args.environmentVariables
+                }
             )
         )
 

--- a/test_runner/src/test/kotlin/ftl/run/platform/android/ResolveApksKtTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/platform/android/ResolveApksKtTest.kt
@@ -58,7 +58,7 @@ class ResolveApksKtTest {
                 InstrumentationTestContext(
                     app = "app".asFileReference(),
                     test = "test".asFileReference(),
-                    args = args
+                    args = args.copy(testApk = "test")
                 )
             ),
             args.resolveApks().toTypedArray()


### PR DESCRIPTION
Fixes #2111 

## Test Plan
> How do we know the code works?

1. run `./gradlew flankFullRun`
2. create config with
    ```
    additional-app-test-apks:
      - test: [...].apk
        environment-variables:
           someVariable: true
    ```
3. Your app from `additional` should see overridden variables

## Checklist

- [x] Unit tested
