### PR TITLE
fix: Add retry and silent crash to mixpanel send method

### DIFF
--- a/flank_wrapper/.gitignore
+++ b/flank_wrapper/.gitignore
@@ -3,3 +3,5 @@
 
 # Ignore Gradle build output directory
 build
+
+src/main/resources/version.txt

--- a/flank_wrapper/build.gradle.kts
+++ b/flank_wrapper/build.gradle.kts
@@ -24,7 +24,7 @@ shadowJar.apply {
     }
 }
 // <breaking change>.<feature added>.<fix/minor change>
-version = "1.2.3"
+version = "1.2.4"
 group = "com.github.flank"
 
 repositories {

--- a/tool/analytics/mixpanel/build.gradle.kts
+++ b/tool/analytics/mixpanel/build.gradle.kts
@@ -8,6 +8,11 @@ repositories {
     mavenCentral()
 }
 
+tasks.test {
+    maxHeapSize = "2048m"
+    minHeapSize = "512m"
+}
+
 tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
 
 dependencies {
@@ -20,4 +25,5 @@ dependencies {
     implementation(project(Modules.ANALYTICS))
 
     testImplementation(Dependencies.JUNIT)
+    testImplementation(Dependencies.MOCKK)
 }

--- a/tool/analytics/mixpanel/src/main/kotlin/flank/tool/analytics/mixpanel/internal/Send.kt
+++ b/tool/analytics/mixpanel/src/main/kotlin/flank/tool/analytics/mixpanel/internal/Send.kt
@@ -16,7 +16,7 @@ internal fun sendReport(
     listOf(
         createUser(Report.projectName),
         createEvent(Report.projectName, eventName, Report.data),
-    ).forEach(apiClient::sendMessage)
+    ).forEach(::send)
 }
 
 private fun createUser(
@@ -42,6 +42,10 @@ private fun createEvent(
         eventName,
         JSONObject(data + (SESSION_ID to sessionId))
     )
+
+private fun send(message: JSONObject) {
+    retryWithSilentFailure { apiClient.sendMessage(message) }
+}
 
 private val messageBuilder by lazy { MessageBuilder(MIXPANEL_API_TOKEN) }
 private val apiClient by lazy { MixpanelAPI() }

--- a/tool/analytics/mixpanel/src/main/kotlin/flank/tool/analytics/mixpanel/internal/Utils.kt
+++ b/tool/analytics/mixpanel/src/main/kotlin/flank/tool/analytics/mixpanel/internal/Utils.kt
@@ -1,0 +1,7 @@
+package flank.tool.analytics.mixpanel.internal
+
+import kotlin.math.max
+
+internal fun retryWithSilentFailure(times: Int = 1, block: () -> Unit) {
+    (0..max(0, times)).onEach { runCatching { block() }.onSuccess { return } }
+}

--- a/tool/analytics/mixpanel/src/test/kotlin/flank/tool/analytics/mixpanel/internal/UtilsTest.kt
+++ b/tool/analytics/mixpanel/src/test/kotlin/flank/tool/analytics/mixpanel/internal/UtilsTest.kt
@@ -1,0 +1,39 @@
+package flank.tool.analytics.mixpanel.internal
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class UtilsTest {
+
+    @Test
+    fun `should not retry succeed code`() {
+        // given
+        val mockedRun = mockk<Runnable>()
+        every { mockedRun.run() } returns Unit
+
+        // when
+        retryWithSilentFailure(5) {
+            mockedRun.run()
+        }
+
+        // then
+        verify(exactly = 1) { mockedRun.run() }
+    }
+
+    @Test
+    fun `should retry given times`() {
+        // given
+        val mockedRun = mockk<Runnable>()
+        every { mockedRun.run() } throws IllegalStateException("test")
+
+        // when
+        retryWithSilentFailure(5) {
+            mockedRun.run()
+        }
+
+        // then
+        verify(exactly = 5 + 1) { mockedRun.run() }
+    }
+}


### PR DESCRIPTION
Fixes #2141 

## Test Plan
> How do we know the code works?

When mixpanel send failed then you will not see any crash and also it will try to retry the request once

## Checklist

- [x] Unit tested
