### PR TITLE
fix: Fix flaky flag

### DIFF
--- a/test_runner/src/main/kotlin/ftl/api/JUnitTestResult.kt
+++ b/test_runner/src/main/kotlin/ftl/api/JUnitTestResult.kt
@@ -105,15 +105,13 @@ object JUnitTest {
 
         @JsonInclude(JsonInclude.Include.CUSTOM, valueFilter = FilterNotNull::class)
         val skipped: String? = "absent", // used by FilterNotNull to filter out absent `skipped` values
-    ) {
 
         @JacksonXmlProperty(isAttribute = true)
-        var flaky: Boolean? = null // use null instead of false
+        var flaky: Boolean? = null, // use null instead of false
 
-        // Consider to move all properties to constructor if will doesn't conflict with parser
         @JsonInclude(JsonInclude.Include.NON_NULL)
         var webLink: String? = null
-    }
+    )
 
     @Suppress("UnusedPrivateClass")
     private class FilterNotNull {

--- a/test_runner/src/test/kotlin/ftl/domain/junit/StackTraceRemoverTest.kt
+++ b/test_runner/src/test/kotlin/ftl/domain/junit/StackTraceRemoverTest.kt
@@ -15,7 +15,7 @@ class StackTraceRemoverTest {
     fun `Should remove stack traces for flaky tests`() {
         // given
         val testcases = mutableListOf(
-            JUnitTest.Case("name", "class", "time", failures = listOf("fail"), errors = listOf("error")),
+            JUnitTest.Case("name", "class", "time", failures = listOf("fail"), errors = listOf("error"), flaky = true),
             JUnitTest.Case("name2", "class2", "time2", failures = listOf("fail2"), errors = listOf("error2")),
         )
         val junitTestResult = testResultsFor(testcases, flaky = true)
@@ -27,6 +27,7 @@ class StackTraceRemoverTest {
         actual.testsuites?.forEach { suite ->
             assertThat(suite.testcases?.all { testCase -> testCase.failures == null }).isTrue()
             assertThat(suite.testcases?.all { testCase -> testCase.errors == null }).isTrue()
+            assertThat(suite.testcases?.any { testCase -> testCase.flaky == true }).isTrue()
         }
     }
 


### PR DESCRIPTION
Fixes #2145

## Test Plan
> How do we know the code works?

1. run `./gradlew flankFullRun`
2. build finish normally
3. start flank run with flaky tests
4. observe the `flaky` flag being added to the flaky cases (previously missing)

## Checklist

- [x] Unit tested
