### PR TITLE
feat: Adapt new iOS xml structure

### DIFF
--- a/test_runner/src/main/kotlin/ftl/client/junit/JUnitXmlParser.kt
+++ b/test_runner/src/main/kotlin/ftl/client/junit/JUnitXmlParser.kt
@@ -26,6 +26,8 @@ internal fun getDeviceString(deviceString: String): String {
 
 private fun JUnitTest.Result.updateTestSuites(deviceName: String) = apply {
     testsuites?.forEach { testSuite ->
-        testSuite.name = "$deviceName#${testSuite.name}"
+        val classNamePrefix = "$deviceName#${testSuite.name}"
+        testSuite.testcases = testSuite.testcases?.map { it.copy(classname = "$classNamePrefix.${it.classname}") }?.toMutableList()
+        testSuite.name = ""
     }
 }


### PR DESCRIPTION
Fixes #2144

## Test Plan
> How do we know the code works?

iOS XML report is changed:
- Test suite is now empty
- Previous testsuite name is added as a prefix to the classname

1. Run iOS tests without option `async: true`
2. Check generated XML report

Before:
```xml
<?xml version='1.0' encoding='UTF-8' ?>
<testsuites>
  <testsuite name="iphone8-11.4-en_US-portrait#EarlGreyExampleSwiftTests" tests="1" failures="0" errors="0" skipped="0" time="1.969" hostname="localhost">
    <testcase name="testLayout()" classname="EarlGreyExampleSwiftTests" time="1.968">
      <webLink>https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.a3b607c9bb6d0088/matrices/7816289963561003834/executions/bs.4bace0b897feb88b</webLink>
    </testcase>
  </testsuite>
</testsuites>

```

After
```xml
<?xml version='1.0' encoding='UTF-8' ?>
<testsuites>
  <testsuite name="" tests="1" failures="0" errors="0" skipped="0" time="1.958" hostname="localhost">
    <testcase name="testLayout()" classname="iphone8-11.4-en_US-portrait#EarlGreyExampleSwiftTests.EarlGreyExampleSwiftTests" time="1.957">
      <webLink>https://console.firebase.google.com/project/flank-open-source/testlab/histories/bh.a3b607c9bb6d0088/matrices/8549684621728392308/executions/bs.1e34a280d8b442cd</webLink>
    </testcase>
  </testsuite>
</testsuites>

```

