### PR TITLE
feat: Support HTTP proxies with credentials.

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -36,6 +36,7 @@ object Dependencies {
     //endregion ktor
 
     const val LOGBACK = "ch.qos.logback:logback-classic:${Versions.LOGBACK}"
+    const val JBOSS_LOGGING = "org.jboss.logging:commons-logging-jboss-logging:${Versions.JBOSS_LOGGING}"
 
     const val WOODSTOX = "com.fasterxml.woodstox:woodstox-core:${Versions.WOODSTOX}"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -90,6 +90,8 @@ object Versions {
     const val COMMON_TEXT = "1.9"
 
     // https://github.com/jboss-logging/commons-logging-jboss-logging
+    // JBoss logging dep is used by the Google Auth library when configuring a proxy.
+    // https://github.com/googleapis/google-auth-library-java#configuring-a-proxy
     const val JBOSS_LOGGING = "1.0.0.Final"
 
     // https://github.com/fusesource/jansi/releases

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -89,6 +89,9 @@ object Versions {
     // https://commons.apache.org/proper/commons-text/
     const val COMMON_TEXT = "1.9"
 
+    // https://github.com/jboss-logging/commons-logging-jboss-logging
+    const val JBOSS_LOGGING = "1.0.0.Final"
+
     // https://github.com/fusesource/jansi/releases
     const val JANSI = "2.4.0"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1058,7 +1058,13 @@ and flank's example [gradle-export-api](https://github.com/Flank/flank/tree/mast
 6) > How can I find project id?
    
   Please check the [firebase documentation](https://firebase.google.com/docs/projects/learn-more?hl=en#find_the_project_id) about finding the project id
+
+7) > How do I run Flank with a proxy?
+  
+  `java -Dhttps.proxyHost=localhost -Dhttps.proxyPort=8080 -Dhttps.proxyUser=user -Dhttps.proxyPassword=pass -jar ./test_runner/build/libs/flank.jar firebase test android run`
    
+  See [google-auth-library-java](https://github.com/googleapis/google-auth-library-java#configuring-a-proxy) for details.
+  
 
 # Resources
 

--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -195,6 +195,7 @@ dependencies {
     implementation(Dependencies.KOTLIN_REFLECT)
 
     implementation(Dependencies.LOGBACK)
+    implementation(Dependencies.JBOSS_LOGGING)
 
     implementation(Dependencies.PICOCLI)
     annotationProcessor(Dependencies.PICOCLI_CODEGEN)


### PR DESCRIPTION
Fixes #2175. The addition of the Jboss logging dependency is required to avoid a missing class exception when the HTTP transport is created; it bridges the logback instance to the logging in use inside of the network-related code.

This implementation is based off of the model code in https://github.com/googleapis/google-auth-library-java#configuring-a-proxy.

## Test Plan
> How do we know the code works?

Following the steps described in #2175, I have validated that flank behaves the same when mitmproxy requires credentials as when it does not.

## Checklist

- [ ] Documented (I don't know where this should be documented)
- [ ] Unit tested (I have no idea how this is possible)
- [ ] Integration tests updated (I don't think this is relevant?)
