### PR TITLE
fix: Detect iOS devices as physical

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.jmailen.gradle.kotlinter.tasks.LintTask
@@ -86,10 +85,16 @@ val resolveArtifacts by tasks.registering {
             "flankScripts.bat" else "flankScripts"
         val flankScriptsPath = Paths.get("flank-scripts", "bash", flankScriptsRunnerName).toString()
         val rootFlankScriptsPath = rootDir.resolve(flankScriptsPath).absolutePath
-        println(rootFlankScriptsPath)
-        exec {
-            commandLine(rootFlankScriptsPath, "testArtifacts", "-p", rootDir.absolutePath, "resolve")
-            workingDir = rootDir
+        try {
+            exec {
+                val cmd = listOf(rootFlankScriptsPath, "testArtifacts", "-p", rootDir.absolutePath, "resolve")
+                println(cmd.joinToString(" "))
+                commandLine(cmd)
+                workingDir = rootDir
+            }
+        } catch (e: Exception) {
+            // avoid breaking all gradle builds if github has rate limited us by not throwing the exception
+            e.printStackTrace()
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ValidateIosArgs.kt
@@ -84,7 +84,7 @@ private fun IosArgs.assertXcodeSupported() = when {
 
 private fun IosArgs.assertDevicesSupported() = devices.forEach { device ->
     if (!isDeviceSupported(device.model, device.version, this.project))
-        throw IncompatibleTestDimensionError("iOS ${device.version} on ${device.model} is not a supported\nSupported version ids for '${device.model}': ${device.getSupportedVersionId(project).joinToString()}")
+        throw IncompatibleTestDimensionError("iOS ${device.version} on ${device.model} is not supported\nSupported version ids for '${device.model}': ${device.getSupportedVersionId(project).joinToString()}")
 }
 
 @VisibleForTesting

--- a/test_runner/src/main/kotlin/ftl/client/google/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/AndroidCatalog.kt
@@ -48,9 +48,7 @@ object AndroidCatalog {
         ?: false
 
     fun isVirtualDevice(modelId: String, projectId: String): Boolean {
-        // iOS catalog raises errors due to FTL backend blocking access from non-white listed project ids
-        // work around this by manually looking for iphone/ipad in the model id.
-        val isIos = listOf("ipad", "iphone").any { modelId.contains(it, ignoreCase = true) }
+        val isIos = IosCatalog.getModels(projectId).any { it.id.equals(modelId, ignoreCase = true) }
         if (isIos) return false
 
         val form = androidDeviceCatalog(projectId).models

--- a/test_runner/src/main/kotlin/ftl/client/google/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/IosCatalog.kt
@@ -55,19 +55,7 @@ object IosCatalog {
                 .filterDevicesWithoutSupportedVersions()
         }
     } catch (e: java.lang.Exception) {
-        throw java.lang.RuntimeException(
-            """
-Unable to access the test environment catalogMap. Firebase Test Lab for iOS is currently in beta.
-Request access for your project via the following form:
-  https://goo.gl/forms/wAxbiNEP2pxeIRG82
-
-If this project has already been granted access, please make sure you are using a project
-on the Blaze or Flame billing plans, and that you have run
-gcloud config set billing/quota_project project
-
-If you are still having issues, please email ftl-ios-feedback@google.com for support.""",
-            e
-        )
+        throw java.lang.RuntimeException(e)
     }
 
     private fun IosDeviceCatalog.filterDevicesWithoutSupportedVersions() =

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -137,7 +137,7 @@ flank:
 
     @Test
     fun `args invalidDeviceExits`() {
-        assertThrowsWithMessage(Throwable::class, "iOS 11.2 on iphonexsmax is not a supported\nSupported version ids for 'iphonexsmax': 12.1, 12.3") {
+        assertThrowsWithMessage(Throwable::class, "iOS 11.2 on iphonexsmax is not supported\nSupported version ids for 'iphonexsmax': 12.1") {
             val invalidDevice = mutableListOf(Device("iphonexsmax", "11.2"))
             createIosArgs(
                 config = defaultIosConfig().apply {

--- a/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
@@ -7,6 +7,7 @@ import ftl.client.google.DeviceType
 import ftl.client.google.GcTesting
 import ftl.client.google.calculateAndroidBillableMinutes
 import ftl.http.executeWithRetry
+import ftl.test.util.FlankTestRunner
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
@@ -16,7 +17,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemOutRule
+import org.junit.runner.RunWith
 
+@RunWith(FlankTestRunner::class)
 class BillableMinutesTest {
 
     @get:Rule

--- a/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
@@ -2,12 +2,12 @@ package ftl.reports.outcome
 
 import com.google.api.services.toolresults.model.Step
 import com.google.testing.model.AndroidModel
+import com.google.testing.model.IosModel
 import ftl.client.google.BillableMinutes
 import ftl.client.google.DeviceType
 import ftl.client.google.GcTesting
 import ftl.client.google.calculateAndroidBillableMinutes
 import ftl.http.executeWithRetry
-import ftl.test.util.FlankTestRunner
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
@@ -17,9 +17,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemOutRule
-import org.junit.runner.RunWith
 
-@RunWith(FlankTestRunner::class)
 class BillableMinutesTest {
 
     @get:Rule
@@ -32,6 +30,11 @@ class BillableMinutesTest {
         make { id = "sailfish"; form = DeviceType.PHYSICAL.name; supportedVersionIds = listOf("26", "27", "28", "29") },
         make { id = "noVersions"; form = DeviceType.PHYSICAL.name; supportedVersionIds = emptyList<String>() },
         make { id = "nullVersions"; form = DeviceType.PHYSICAL.name; supportedVersionIds = null }
+    )
+
+    private val iosModels = listOf<IosModel>(
+        make { id = "iphone11"; supportedVersionIds = listOf("13.3", "13.6") },
+        make { id = "ipad5"; supportedVersionIds = listOf("14.1") }
     )
 
     @Before
@@ -47,6 +50,7 @@ class BillableMinutesTest {
                 .executeWithRetry()
         } returns make {
             androidDeviceCatalog = make { models = androidModels }
+            iosDeviceCatalog = make { models = iosModels }
         }
     }
 


### PR DESCRIPTION
Fixes #2179

## Test Plan
> How do we know the code works?

Ran reduced test case via `Debug.kt` Verified ` PHYSICAL used as fallback` message does not appear. Checked that the cost calculation is correct.

```
gcloud:
  test: "./test_runner/src/test/kotlin/ftl/fixtures/tmp/ios/EarlGreyExample/EarlGreyExample.zip"
  xctestrun-file: "./test_runner/src/test/kotlin/ftl/fixtures/tmp/ios/EarlGreyExample/EarlGreyExampleSwiftTests.xctestrun"
  device:
  - model: "iphone11pro"
    version: "14.7"
    locale: "en"
    orientation: "portrait"
```

```
CostReport
  Physical devices
    $0.08 for 1m
```

