### PR TITLE
test: Update app_many_tests to AndroidX libraries

### DIFF
--- a/test_projects/android/app_many_tests/build.gradle
+++ b/test_projects/android/app_many_tests/build.gradle
@@ -13,7 +13,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -27,10 +27,9 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/test_projects/android/app_many_tests/src/main/java/com/example/app/many/tests/MainActivity.kt
+++ b/test_projects/android/app_many_tests/src/main/java/com/example/app/many/tests/MainActivity.kt
@@ -1,6 +1,6 @@
 package com.example.app.many.tests
 
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 
 class MainActivity : AppCompatActivity() {

--- a/test_projects/android/app_many_tests/src/main/res/layout/activity_main.xml
+++ b/test_projects/android/app_many_tests/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -15,4 +15,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
FTL is deprecating support for the Android Test Orchestrator that is
part of the legacy/deprecated Android Test Support libraries.

This CL updates the app_many_tests test app to the new AndroidX
libraries, as this app is used in integration tests that enable Test
Orchestrator.

Note, users can still use Android Support and Android Test Support
libraries. They just cannot use the legacy Test Orchestrator.

Fixes #

## Test Plan
> How do we know the code works?

.

## Checklist

- [ ] Documented
- [ ] Unit tested
- [ ] Integration tests updated
