### PR TITLE
fix: Replace single backslash doublequote with triple backslash doublequote in HTML report

### DIFF
--- a/test_runner/src/main/kotlin/ftl/reports/HtmlErrorReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/HtmlErrorReport.kt
@@ -78,5 +78,5 @@ private fun JUnitTest.Case.stackTrace(): String {
 private fun List<HtmlErrorReport.Group>.createHtmlReport(): String =
     readTextResource("inline.html").replace(
         oldValue = "\"INJECT-DATA-HERE\"",
-        newValue = "`${Gson().toJson(this)}`"
+        newValue = "`${Gson().toJson(this).toString().replace("\"", "\\\"")}`"
     )


### PR DESCRIPTION
Fixes #2169 

## Test Plan
> How do we know the code works?
Paste 
```
[
  {
    "label": "deviceName com.myApp.tests.SomeTest#exampleTest",
    "items": [
      {
        "label": "Error in 'single quotes \"Double quotes\"'",
        "url": "https://console.firebase.google.com/project/"
      }
    ]
  }
]
```
into `INJECT-DATA-HERE` field in Inline.html and observe broken html file

then paste 
```
[
  {
    "label": "deviceName com.myApp.tests.SomeTest#exampleTest",
    "items": [
      {
        "label": "Error in 'single quotes \\\"Double quotes\\\"'",
        "url": "https://console.firebase.google.com/project/"
      }
    ]
  }
]
``` 
and verify html is not broken

## Checklist

- [ ] Documented
- [ ] Unit tested
- [ ] Integration tests updated
