### PR TITLE
Fix integration tests, broken because FlankNoTestsError with Exit code 3

### DIFF
--- a/integration_tests/src/test/kotlin/integration/AllTestFilteredIT.kt
+++ b/integration_tests/src/test/kotlin/integration/AllTestFilteredIT.kt
@@ -35,7 +35,7 @@ class AllTestFilteredIT {
             testSuite = name
         )
 
-        assertExitCode(result, 1)
+        assertExitCode(result, 3)
 
         val resOutput = result.output.removeUnicode()
 


### PR DESCRIPTION
Fixes #2251 

## Test Plan
> How do we know the code works?
It's just fixing an integration test

## Checklist

- [ ] Documented
- [ ] Unit tested
- [x] Integration tests updated
