### PR TITLE
feat: Output cost report as JSON

### DIFF
--- a/integration_tests/src/test/resources/compare/GameloopIT-android-compare
+++ b/integration_tests/src/test/resources/compare/GameloopIT-android-compare
@@ -89,6 +89,7 @@ MatrixResultsReport
   1 \/ 1 \(100\.00\%\)
 [\s\S]*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 

--- a/integration_tests/src/test/resources/compare/GameloopIT-android-compare
+++ b/integration_tests/src/test/resources/compare/GameloopIT-android-compare
@@ -84,12 +84,12 @@ CostReport
     \$\d{1,2}.\d{1,2} for \d{1,2}m
 
   Uploading \[CostReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[CostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 \s*
 MatrixResultsReport
   1 \/ 1 \(100\.00\%\)
 [\s\S]*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
-  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 

--- a/integration_tests/src/test/resources/compare/GameloopIT-ios-compare
+++ b/integration_tests/src/test/resources/compare/GameloopIT-ios-compare
@@ -85,6 +85,7 @@ MatrixResultsReport
 │ success │ matrix-[a-zA-Z0-9]* │.* │ 0 test cases passed │
 └─────────┴──────────────────────┴──────────────────────────────┴─────────────────────┘
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 
 FetchArtifacts

--- a/integration_tests/src/test/resources/compare/GameloopIT-ios-compare
+++ b/integration_tests/src/test/resources/compare/GameloopIT-ios-compare
@@ -76,6 +76,7 @@ CostReport
     \$\d{1,2}.\d{1,2} for \d{1,2}m
 
   Uploading \[CostReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[CostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 
 MatrixResultsReport
   1 \/ 1 \(100.00%\)
@@ -85,7 +86,6 @@ MatrixResultsReport
 │ success │ matrix-[a-zA-Z0-9]* │.* │ 0 test cases passed │
 └─────────┴──────────────────────┴──────────────────────────────┴─────────────────────┘
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
-  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 
 FetchArtifacts

--- a/integration_tests/src/test/resources/compare/MultipleApksIT-compare
+++ b/integration_tests/src/test/resources/compare/MultipleApksIT-compare
@@ -102,6 +102,7 @@ CostReport
     \$\d{1,2}.\d{1,2} for \d{1,2}m
 [\s\S]*
   Uploading \[CostReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[CostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 
 MatrixResultsReport
   3 \/ 4 \(75\.00\%\)
@@ -111,7 +112,6 @@ More details are available at:
 https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
 \s*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
-  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[HtmlErrorReport.html\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/integration_tests/src/test/resources/compare/MultipleApksIT-compare
+++ b/integration_tests/src/test/resources/compare/MultipleApksIT-compare
@@ -111,6 +111,7 @@ More details are available at:
 https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
 \s*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[HtmlErrorReport.html\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/integration_tests/src/test/resources/compare/MultipleDevicesIT-android-compare
+++ b/integration_tests/src/test/resources/compare/MultipleDevicesIT-android-compare
@@ -120,6 +120,7 @@ More details are available at:
 https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
 \s*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[HtmlErrorReport.html\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/integration_tests/src/test/resources/compare/MultipleDevicesIT-android-compare
+++ b/integration_tests/src/test/resources/compare/MultipleDevicesIT-android-compare
@@ -111,6 +111,7 @@ CostReport
     \$\d{1,2}.\d{1,2} for \d{1,2}m
 \s*
   Uploading \[CostReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[CostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 
 MatrixResultsReport
   2 \/ 3 \(66\.67\%\)
@@ -120,7 +121,6 @@ More details are available at:
 https:\/\/console.firebase.google.com\/project\/flank-open-source\/testlab\/histories\/[.a-zA-Z0-9_-]*\/matrices\/[.a-zA-Z0-9_-]*(\/executions\/[.a-zA-Z0-9_-]*)?
 \s*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
-  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[HtmlErrorReport.html\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*

--- a/integration_tests/src/test/resources/compare/SanityRoboIT-compare
+++ b/integration_tests/src/test/resources/compare/SanityRoboIT-compare
@@ -81,12 +81,12 @@ CostReport
     \$\d{1,2}.\d{1,2} for \d{1,2}m
 \s*
   Uploading \[CostReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[CostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 
 MatrixResultsReport
   1 \/ 1 \(100\.00\%\)
 [\s\S]*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
-  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 

--- a/integration_tests/src/test/resources/compare/SanityRoboIT-compare
+++ b/integration_tests/src/test/resources/compare/SanityRoboIT-compare
@@ -86,6 +86,7 @@ MatrixResultsReport
   1 \/ 1 \(100\.00\%\)
 [\s\S]*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 

--- a/integration_tests/src/test/resources/compare/TestFilteringIT-compare
+++ b/integration_tests/src/test/resources/compare/TestFilteringIT-compare
@@ -89,12 +89,12 @@ CostReport
     \$\d{1,2}.\d{1,2} for \d{1,2}m
 \s*
   Uploading \[CostReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[CostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 
 MatrixResultsReport
   1 \/ 1 \(100\.00\%\)
 [\s\S]*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
-  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 

--- a/integration_tests/src/test/resources/compare/TestFilteringIT-compare
+++ b/integration_tests/src/test/resources/compare/TestFilteringIT-compare
@@ -94,6 +94,7 @@ MatrixResultsReport
   1 \/ 1 \(100\.00\%\)
 [\s\S]*
   Uploading \[MatrixResultsReport.txt\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
+  Uploading \[JsonCostReport.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[JUnitReport.xml\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
   Uploading \[matrix_ids.json\] to https:\/\/console.developers.google.com\/storage\/browser\/test-lab-[a-zA-Z0-9_-]*\/[.a-zA-Z0-9_-]*\/\.*
 

--- a/test_runner/src/main/kotlin/ftl/reports/JsonCostReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/JsonCostReport.kt
@@ -1,0 +1,56 @@
+package ftl.reports
+
+import ftl.api.JUnitTest
+import ftl.args.IArgs
+import ftl.json.MatrixMap
+import ftl.reports.util.IReport
+import ftl.reports.util.ReportManager
+import ftl.run.common.prettyPrint
+import ftl.util.calculatePhysicalCost
+import ftl.util.calculateTotalCost
+import ftl.util.calculateVirtualCost
+
+/** Calculates cost based on the matrix map. Always run. */
+object JsonCostReport : IReport {
+
+    override val extension = ".json"
+
+    private fun estimate(matrices: MatrixMap): Map<String, Any> {
+        var totalBillableVirtualMinutes = 0L
+        var totalBillablePhysicalMinutes = 0L
+
+        matrices.map.values.forEach {
+            totalBillableVirtualMinutes += it.billableMinutes.virtual
+            totalBillablePhysicalMinutes += it.billableMinutes.physical
+        }
+        val virtualCost = calculateVirtualCost(totalBillableVirtualMinutes.toBigDecimal())
+        val physicalCost = calculatePhysicalCost(totalBillablePhysicalMinutes.toBigDecimal())
+        val total = calculateTotalCost(virtualCost, physicalCost)
+
+        return mapOf(
+            "currency" to "USD",
+            "cost" to mapOf(
+                "virtual" to virtualCost,
+                "physical" to physicalCost,
+                "total" to total
+            ),
+            "billable-time" to mapOf(
+                "virtual" to totalBillableVirtualMinutes,
+                "physical" to totalBillablePhysicalMinutes,
+                "total" to totalBillableVirtualMinutes + totalBillablePhysicalMinutes
+            )
+        )
+    }
+
+    private fun generate(matrices: MatrixMap): String {
+        val cost = estimate(matrices)
+        return prettyPrint.toJson(cost)
+    }
+
+    override fun run(matrices: MatrixMap, result: JUnitTest.Result?, printToStdout: Boolean, args: IArgs) {
+        val output = generate(matrices)
+        if (printToStdout) print(output)
+        write(matrices, output, args)
+        ReportManager.uploadReportResult(output, args, fileName())
+    }
+}

--- a/test_runner/src/main/kotlin/ftl/reports/JsonCostReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/JsonCostReport.kt
@@ -34,7 +34,7 @@ object JsonCostReport : IReport {
                 "physical" to physicalCost,
                 "total" to total
             ),
-            "billable-time" to mapOf(
+            "billable-minutes" to mapOf(
                 "virtual" to totalBillableVirtualMinutes,
                 "physical" to totalBillablePhysicalMinutes,
                 "total" to totalBillableVirtualMinutes + totalBillablePhysicalMinutes

--- a/test_runner/src/main/kotlin/ftl/reports/JsonCostReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/JsonCostReport.kt
@@ -13,6 +13,10 @@ import ftl.util.calculateVirtualCost
 /** Calculates cost based on the matrix map. Always run. */
 object JsonCostReport : IReport {
 
+    override fun reportName(): String {
+        return CostReport::class.java.simpleName
+    }
+
     override val extension = ".json"
 
     private fun estimate(matrices: MatrixMap): Map<String, Any> {

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -25,6 +25,7 @@ import ftl.reports.CostReport
 import ftl.reports.FullJUnitReport
 import ftl.reports.HtmlErrorReport
 import ftl.reports.JUnitReport
+import ftl.reports.JsonCostReport
 import ftl.reports.MatrixResultsReport
 import ftl.reports.api.utcDateFormat
 import ftl.reports.toXmlString
@@ -54,6 +55,8 @@ object ReportManager {
         }
         listOf(CostReport, MatrixResultsReport)
             .map { it.run(matrices, testSuite, printToStdout = true, args = args) }
+
+        JsonCostReport.run(matrices, testSuite, printToStdout = false, args = args)
 
         if (!matrices.isAllSuccessful()) {
             listOf(

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -53,10 +53,9 @@ object ReportManager {
             val useFlakyTests = args.flakyTestAttempts > 0
             if (useFlakyTests) JUnitDedupe.modify(testSuite)
         }
-        listOf(CostReport, MatrixResultsReport)
-            .map { it.run(matrices, testSuite, printToStdout = true, args = args) }
-
+        CostReport.run(matrices, testSuite, printToStdout = true, args = args)
         JsonCostReport.run(matrices, testSuite, printToStdout = false, args = args)
+        MatrixResultsReport.run(matrices, testSuite, printToStdout = true, args = args)
 
         if (!matrices.isAllSuccessful()) {
             listOf(

--- a/test_runner/src/test/kotlin/ftl/fixtures/empty_result/matrix_ids.json
+++ b/test_runner/src/test/kotlin/ftl/fixtures/empty_result/matrix_ids.json
@@ -5,8 +5,10 @@
     "gcsPath": "test-lab-jwwvtzdh5d20w-yyju9fnudnpts/2018-09-09_00:38:10.110000_UQjK/shard_0",
     "webLink": "https://console.firebase.google.com/project/delta-essence-114723/testlab/histories/bh.58317d9cd7ab9ba2/matrices/6385582924491679444/executions/bs.bb41d8a3f63489be",
     "downloaded": false,
-    "billableVirtualMinutes": 1,
-    "billablePhysicalMinutes": 0,
+    "billableMinutes": {
+      "virtual": 1,
+      "physical": 0
+    },
     "outcome": "inconclusive"
   }
 }

--- a/test_runner/src/test/kotlin/ftl/fixtures/error_result/matrix_ids.json
+++ b/test_runner/src/test/kotlin/ftl/fixtures/error_result/matrix_ids.json
@@ -5,8 +5,10 @@
     "gcsPath": "test-lab-jwwvtzdh5d20w-yyju9fnudnpts/2018-09-09_00:14:41.810000_bKxI/shard_1",
     "webLink": "https://console.firebase.google.com/project/delta-essence-114723/testlab/histories/bh.58317d9cd7ab9ba2/matrices/7994869754124771736/executions/bs.795779ba6b096d51",
     "downloaded": true,
-    "billableVirtualMinutes": 2,
-    "billablePhysicalMinutes": 0,
+    "billableMinutes": {
+      "virtual": 2,
+      "physical": 0
+    },
     "outcome": "failure",
     "outcomeAdditionalDetails": "Mock Failed Reason"
   },
@@ -16,8 +18,10 @@
     "gcsPath": "test-lab-jwwvtzdh5d20w-yyju9fnudnpts/2018-09-09_00:14:41.810000_bKxI/shard_0",
     "webLink": "https://console.firebase.google.com/project/delta-essence-114723/testlab/histories/bh.58317d9cd7ab9ba2/matrices/6325378892669071099/executions/bs.b6517c0e72b114f1",
     "downloaded": true,
-    "billableVirtualMinutes": 2,
-    "billablePhysicalMinutes": 0,
+    "billableMinutes": {
+      "virtual": 2,
+      "physical": 0
+    },
     "outcome": "failure"
   },
   "matrix-teex1a295m1ty": {
@@ -26,8 +30,10 @@
     "gcsPath": "test-lab-jwwvtzdh5d20w-yyju9fnudnpts/2018-09-09_00:14:41.810000_bKxI/shard_1",
     "webLink": "https://console.firebase.google.com/project/delta-essence-114723/testlab/histories/bh.58317d9cd7ab9ba2/matrices/7994869754124771736/executions/bs.795779ba6b096d51",
     "downloaded": true,
-    "billableVirtualMinutes": 2,
-    "billablePhysicalMinutes": 0,
+    "billableMinutes": {
+      "virtual": 0,
+      "physical": 3
+    },
     "outcome": "inconclusive",
     "outcomeAdditionalDetails": "abortedByUser"
   }

--- a/test_runner/src/test/kotlin/ftl/fixtures/ios_exit_code/matrix_ids.json
+++ b/test_runner/src/test/kotlin/ftl/fixtures/ios_exit_code/matrix_ids.json
@@ -5,8 +5,10 @@
     "gcsPath": "test-lab-jwwvtzdh5d20w-yyju9fnudnpts/2018-09-09_00:14:41.810000_bKxI/shard_1",
     "webLink": "https://console.firebase.google.com/project/delta-essence-114723/testlab/histories/bh.58317d9cd7ab9ba2/matrices/7994869754124771736/executions/bs.795779ba6b096d51",
     "downloaded": true,
-    "billableVirtualMinutes": 2,
-    "billablePhysicalMinutes": 0,
+    "billableMinutes": {
+      "virtual": 0,
+      "physical": 4
+    },
     "outcome": "failure",
     "outcomeAdditionalDetails": "Mock Failed Reason"
   }

--- a/test_runner/src/test/kotlin/ftl/fixtures/success_result/matrix_ids.json
+++ b/test_runner/src/test/kotlin/ftl/fixtures/success_result/matrix_ids.json
@@ -5,8 +5,10 @@
     "gcsPath": "test-lab-jwwvtzdh5d20w-yyju9fnudnpts/2018-09-09_00:38:10.110000_UQjK/shard_0",
     "webLink": "https://console.firebase.google.com/project/delta-essence-114723/testlab/histories/bh.58317d9cd7ab9ba2/matrices/6385582924491679444/executions/bs.bb41d8a3f63489be",
     "downloaded": false,
-    "billableVirtualMinutes": 1,
-    "billablePhysicalMinutes": 0,
+    "billableMinutes": {
+      "virtual": 1,
+      "physical": 0
+    },
     "outcome": "success",
     "testAxises": [
       {

--- a/test_runner/src/test/kotlin/ftl/reports/CostReportTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/CostReportTest.kt
@@ -1,0 +1,88 @@
+package ftl.reports
+
+import com.google.common.truth.Truth.assertThat
+import ftl.args.AndroidArgs
+import ftl.run.common.matrixPathToObj
+import ftl.test.util.FlankTestRunner
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(FlankTestRunner::class)
+class CostReportTest {
+
+    @Test
+    fun `run fromEmptyResult`() {
+        val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/empty_result", AndroidArgs.default())
+        val mockArgs = mockk<AndroidArgs>(relaxed = true)
+        CostReport.run(matrix, null, printToStdout = false, args = mockArgs)
+
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/empty_result/CostReport.txt").readText()
+        val expectedReport = """
+CostReport
+  Virtual devices
+    $0.02 for 1m
+
+""".trimStart()
+
+        assertThat(actualReport).isEqualTo(expectedReport)
+    }
+
+    @Test
+    fun `run fromErrorResult`() {
+        val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/error_result", AndroidArgs.default())
+        val mockArgs = mockk<AndroidArgs>(relaxed = true)
+        CostReport.run(matrix, null, printToStdout = false, args = mockArgs)
+
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/error_result/CostReport.txt").readText()
+        val expectedReport = """
+CostReport
+  Physical devices
+    $0.25 for 3m
+  
+  Virtual devices
+    $0.07 for 4m
+  
+  Total
+    $0.32 for 7m
+
+""".trimStart()
+
+        assertThat(actualReport).isEqualTo(expectedReport)
+    }
+
+    @Test
+    fun `run fromIosExitCode`() {
+        val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/ios_exit_code", AndroidArgs.default())
+        val mockArgs = mockk<AndroidArgs>(relaxed = true)
+        CostReport.run(matrix, null, printToStdout = false, args = mockArgs)
+
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/ios_exit_code/CostReport.txt").readText()
+        val expectedReport = """
+CostReport
+  Physical devices
+    $0.33 for 4m
+
+""".trimStart()
+
+        assertThat(actualReport).isEqualTo(expectedReport)
+    }
+
+    @Test
+    fun `run fromSuccessResult`() {
+        val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/success_result", AndroidArgs.default())
+        val mockArgs = mockk<AndroidArgs>(relaxed = true)
+        CostReport.run(matrix, null, printToStdout = false, args = mockArgs)
+
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/success_result/CostReport.txt").readText()
+        val expectedReport = """
+CostReport
+  Virtual devices
+    $0.02 for 1m
+
+""".trimStart()
+
+        assertThat(actualReport).isEqualTo(expectedReport)
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/reports/JsonCostReportTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/JsonCostReportTest.kt
@@ -27,7 +27,7 @@ class JsonCostReportTest {
     "physical": 0.00,
     "total": 0.02
   },
-  "billable-time": {
+  "billable-minutes": {
     "virtual": 1,
     "physical": 0,
     "total": 1
@@ -53,7 +53,7 @@ class JsonCostReportTest {
     "physical": 0.25,
     "total": 0.32
   },
-  "billable-time": {
+  "billable-minutes": {
     "virtual": 4,
     "physical": 3,
     "total": 7
@@ -79,7 +79,7 @@ class JsonCostReportTest {
     "physical": 0.33,
     "total": 0.33
   },
-  "billable-time": {
+  "billable-minutes": {
     "virtual": 0,
     "physical": 4,
     "total": 4
@@ -105,7 +105,7 @@ class JsonCostReportTest {
     "physical": 0.00,
     "total": 0.02
   },
-  "billable-time": {
+  "billable-minutes": {
     "virtual": 1,
     "physical": 0,
     "total": 1

--- a/test_runner/src/test/kotlin/ftl/reports/JsonCostReportTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/JsonCostReportTest.kt
@@ -18,7 +18,7 @@ class JsonCostReportTest {
         val mockArgs = mockk<AndroidArgs>(relaxed = true)
         JsonCostReport.run(matrix, null, printToStdout = false, args = mockArgs)
 
-        val actualReport = File("./src/test/kotlin/ftl/fixtures/empty_result/JsonCostReport.json").readText()
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/empty_result/CostReport.json").readText()
         val expectedReport = """
 {
   "currency": "USD",
@@ -44,7 +44,7 @@ class JsonCostReportTest {
         val mockArgs = mockk<AndroidArgs>(relaxed = true)
         JsonCostReport.run(matrix, null, printToStdout = false, args = mockArgs)
 
-        val actualReport = File("./src/test/kotlin/ftl/fixtures/error_result/JsonCostReport.json").readText()
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/error_result/CostReport.json").readText()
         val expectedReport = """
 {
   "currency": "USD",
@@ -70,7 +70,7 @@ class JsonCostReportTest {
         val mockArgs = mockk<AndroidArgs>(relaxed = true)
         JsonCostReport.run(matrix, null, printToStdout = false, args = mockArgs)
 
-        val actualReport = File("./src/test/kotlin/ftl/fixtures/ios_exit_code/JsonCostReport.json").readText()
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/ios_exit_code/CostReport.json").readText()
         val expectedReport = """
 {
   "currency": "USD",
@@ -96,7 +96,7 @@ class JsonCostReportTest {
         val mockArgs = mockk<AndroidArgs>(relaxed = true)
         JsonCostReport.run(matrix, null, printToStdout = false, args = mockArgs)
 
-        val actualReport = File("./src/test/kotlin/ftl/fixtures/success_result/JsonCostReport.json").readText()
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/success_result/CostReport.json").readText()
         val expectedReport = """
 {
   "currency": "USD",

--- a/test_runner/src/test/kotlin/ftl/reports/JsonCostReportTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/JsonCostReportTest.kt
@@ -1,0 +1,118 @@
+package ftl.reports
+
+import com.google.common.truth.Truth.assertThat
+import ftl.args.AndroidArgs
+import ftl.run.common.matrixPathToObj
+import ftl.test.util.FlankTestRunner
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(FlankTestRunner::class)
+class JsonCostReportTest {
+
+    @Test
+    fun `run fromEmptyResult`() {
+        val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/empty_result", AndroidArgs.default())
+        val mockArgs = mockk<AndroidArgs>(relaxed = true)
+        JsonCostReport.run(matrix, null, printToStdout = false, args = mockArgs)
+
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/empty_result/JsonCostReport.json").readText()
+        val expectedReport = """
+{
+  "currency": "USD",
+  "cost": {
+    "virtual": 0.02,
+    "physical": 0.00,
+    "total": 0.02
+  },
+  "billable-time": {
+    "virtual": 1,
+    "physical": 0,
+    "total": 1
+  }
+}
+""".trim()
+
+        assertThat(actualReport).isEqualTo(expectedReport)
+    }
+
+    @Test
+    fun `run fromErrorResult`() {
+        val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/error_result", AndroidArgs.default())
+        val mockArgs = mockk<AndroidArgs>(relaxed = true)
+        JsonCostReport.run(matrix, null, printToStdout = false, args = mockArgs)
+
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/error_result/JsonCostReport.json").readText()
+        val expectedReport = """
+{
+  "currency": "USD",
+  "cost": {
+    "virtual": 0.07,
+    "physical": 0.25,
+    "total": 0.32
+  },
+  "billable-time": {
+    "virtual": 4,
+    "physical": 3,
+    "total": 7
+  }
+}
+""".trim()
+
+        assertThat(actualReport).isEqualTo(expectedReport)
+    }
+
+    @Test
+    fun `run fromIosExitCode`() {
+        val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/ios_exit_code", AndroidArgs.default())
+        val mockArgs = mockk<AndroidArgs>(relaxed = true)
+        JsonCostReport.run(matrix, null, printToStdout = false, args = mockArgs)
+
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/ios_exit_code/JsonCostReport.json").readText()
+        val expectedReport = """
+{
+  "currency": "USD",
+  "cost": {
+    "virtual": 0.00,
+    "physical": 0.33,
+    "total": 0.33
+  },
+  "billable-time": {
+    "virtual": 0,
+    "physical": 4,
+    "total": 4
+  }
+}
+""".trim()
+
+        assertThat(actualReport).isEqualTo(expectedReport)
+    }
+
+    @Test
+    fun `run fromSuccessResult`() {
+        val matrix = matrixPathToObj("./src/test/kotlin/ftl/fixtures/success_result", AndroidArgs.default())
+        val mockArgs = mockk<AndroidArgs>(relaxed = true)
+        JsonCostReport.run(matrix, null, printToStdout = false, args = mockArgs)
+
+        val actualReport = File("./src/test/kotlin/ftl/fixtures/success_result/JsonCostReport.json").readText()
+        val expectedReport = """
+{
+  "currency": "USD",
+  "cost": {
+    "virtual": 0.02,
+    "physical": 0.00,
+    "total": 0.02
+  },
+  "billable-time": {
+    "virtual": 1,
+    "physical": 0,
+    "total": 1
+  }
+}
+""".trim()
+
+        assertThat(actualReport).isEqualTo(expectedReport)
+    }
+}

--- a/tool/junit/src/main/kotlin/flank/junit/JUnit.kt
+++ b/tool/junit/src/main/kotlin/flank/junit/JUnit.kt
@@ -210,5 +210,4 @@ object JUnit {
     internal val dateFormat = SimpleDateFormat(ISO8601_DATETIME_PATTERN)
 
     const val REPORT_FILE_NAME = "JUnitReport.xml"
-    const val COST_REPORT_FILE_NAME = "CostReport.json"
 }


### PR DESCRIPTION
Fixes #2197

`CostReport.txt` is unstructured, making it difficult to parse it. Add a new report `CostReport.json` with this structure:
```
{
  "currency": "USD",
  "cost": {
    "virtual": 0.07,
    "physical": 0.25,
    "total": 0.32
  },
  "billable-minutes": {
    "virtual": 4,
    "physical": 3,
    "total": 7
  }
}
```

## Test Plan
> How do we know the code works?

A new report named `CostReport.json` should be generated.

## Checklist

- [x] Documented
- [x] Unit tested
- [x] Integration tests updated
