### PR TITLE
Revert "chore: Update create_new_release workflow to be manually run"

### DIFF
--- a/.github/workflows/create_new_release.yml
+++ b/.github/workflows/create_new_release.yml
@@ -2,10 +2,13 @@ name: Create new release
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [ closed ]
 
 jobs:
   create_release:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') && contains(github.event.pull_request.user.login, 'google-flank-bot[bot]') && contains(github.event.pull_request.title, 'release notes for')
     steps:
       - uses: actions/checkout@v2
       - uses: tibdex/github-app-token@v1


### PR DESCRIPTION
Reverts Flank/flank#2315.

Switching back to automatic releases when the `release_notes_generation` PR is generated and merged.