### PR TITLE
chore: Remove schedule from update_dependencies

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -1,9 +1,7 @@
 name: "[Code Health] Run update dependencies"
 
 on:
-  schedule:
-    - cron: '0 5 * * 1' # At 05:00 on Monday
-  workflow_dispatch:    # or manually
+  workflow_dispatch:
 
 jobs:
   get_date:


### PR DESCRIPTION
No need to auto-run this for now.