### PR TITLE
docs: fix list formatting in "Authenticate with a service account" section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -927,6 +927,7 @@ to have a unique non-shared credential. A service account is still recommended f
 ## Authenticate with a service account
 
 Follow the [test lab docs](https://firebase.google.com/docs/test-lab/android/continuous) to create a service account.
+
 - Save the credential to `$HOME/.config/gcloud/application_default_credentials.json` or set `GOOGLE_APPLICATION_CREDENTIALS` when using a custom path.
 - Set the project id in flank.yml or set the `GOOGLE_CLOUD_PROJECT` environment variable.
 - (Since 21.01) if `projectId` is not set in a config yml file, flank uses the first available project ID among the following sources:


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/94930/201414092-ab108cf0-2430-46ee-9d5e-dfffcee566f9.png)

After:
![image](https://user-images.githubusercontent.com/94930/201414151-dc424d53-ddde-4c46-9c52-dbb8887e9874.png)
