### PR TITLE
build: remove GRADLE_ENTERPRISE_ACCESS_KEY from workflows

### DIFF
--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -24,7 +24,6 @@ jobs:
     - name: Download flankScripts and add it to PATH
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       run: |
         ./gradlew :flank-scripts:download
         echo "./flank-scripts/bash" >> $GITHUB_PATH

--- a/.github/workflows/macos_workflow.yml
+++ b/.github/workflows/macos_workflow.yml
@@ -32,7 +32,6 @@ jobs:
     - name: Gradle clean build
       uses: eskatos/gradle-command-action@v1
       env:
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HEAD_REF: ${{ github.head_ref }}
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
     - name: Download flankScripts and add it to PATH
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       run: |
         ./gradlew :flank-scripts:download
         echo "./flank-scripts/bash" >> $GITHUB_PATH
@@ -56,7 +55,6 @@ jobs:
     - name: Gradle Build Flank
       uses: eskatos/gradle-command-action@v1
       env:
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HEAD_REF: ${{ github.head_ref }}
       with:
@@ -101,15 +99,12 @@ jobs:
       uses: eskatos/gradle-command-action@v1
       env:
         PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       with:
         arguments: :test_runner:publishMavenJavaPublicationToMavenCentralRepository -PMVN_CENTRAL_USER=${{ secrets.MVN_CENTRAL_USER }} -PMVN_CENTRAL_PASSWORD=${{ secrets.MVN_CENTRAL_PASSWORD }}
 
     - name: Gradle close staging on MavenCentral
       uses: eskatos/gradle-command-action@v1
       if: startsWith(github.ref, 'refs/tags/v')
-      env:
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       with:
         arguments: closeAndReleaseRepository -PMVN_CENTRAL_USER=${{ secrets.MVN_CENTRAL_USER }} -PMVN_CENTRAL_PASSWORD=${{ secrets.MVN_CENTRAL_PASSWORD }}
 
@@ -118,6 +113,5 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
       env:
         PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       with:
         arguments: ":test_runner:publishMavenJavaPublicationToGitHubPackagesRepository -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release_flank_scripts.yml
+++ b/.github/workflows/release_flank_scripts.yml
@@ -20,6 +20,5 @@ jobs:
       uses: eskatos/gradle-command-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       with:
         arguments: "flank-scripts:releaseFlankScripts -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release_flank_wrapper.yml
+++ b/.github/workflows/release_flank_wrapper.yml
@@ -20,6 +20,5 @@ jobs:
       uses: eskatos/gradle-command-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       with:
         arguments: "flank_wrapper:releaseFlankWrapper -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -119,7 +119,6 @@ jobs:
         uses: eskatos/gradle-command-action@v1.3.3
         id: run-it
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_REF: ${{ github.ref }}
         with:
@@ -150,7 +149,6 @@ jobs:
       - name: Download flankScripts and add it to PATH
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           ./gradlew :flank-scripts:download
           echo "./flank-scripts/bash" >> $GITHUB_PATH

--- a/.github/workflows/tag_next_release.yml
+++ b/.github/workflows/tag_next_release.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Download flankScripts and add it to PATH.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           ./gradlew :flank-scripts:download
           echo "./flank-scripts/bash" >> $GITHUB_PATH

--- a/.github/workflows/ubuntu_workflow.yml
+++ b/.github/workflows/ubuntu_workflow.yml
@@ -33,7 +33,6 @@ jobs:
         name: Gradle clean build
         uses: eskatos/gradle-command-action@v1
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_REF: ${{ github.head_ref }}
         with:

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Download flankScripts and add it to PATH
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           ./gradlew :flank-scripts:download
           echo "./flank-scripts/bash" >> $GITHUB_PATH
@@ -78,7 +77,6 @@ jobs:
       - name: Download flankScripts and add it to PATH
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           ./gradlew :flank-scripts:download
           echo "./flank-scripts/bash" >> $GITHUB_PATH
@@ -112,7 +110,6 @@ jobs:
       - name: Download flankScripts and add it to PATH
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           ./gradlew :flank-scripts:download
           echo "./flank-scripts/bash" >> $GITHUB_PATH

--- a/.github/workflows/windows_workflow.yml
+++ b/.github/workflows/windows_workflow.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Gradle clean build
       uses: eskatos/gradle-command-action@v1
       env:
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HEAD_REF: ${{ github.head_ref }}
       with:

--- a/.github/workflows/wsl_workflow.yml
+++ b/.github/workflows/wsl_workflow.yml
@@ -64,7 +64,6 @@ jobs:
       run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           export HEAD_REF=${{ github.ref }}
-          export GRADLE_ENTERPRISE_ACCESS_KEY=${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           ./gradlew clean build
 
     - name: Prepare Google Service Account
@@ -78,7 +77,6 @@ jobs:
       uses: eskatos/gradle-command-action@v1
       env:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       with:
         arguments: "--info :integration_tests:test --tests IntegrationTests.shouldMatchAndroidSuccessExitCodeAndPattern -Dflank-path=../test_runner/build/libs/flank.jar -Dyml-path=./src/test/resources/flank_android.yml"
 
@@ -86,6 +84,5 @@ jobs:
       uses: eskatos/gradle-command-action@v1
       env:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       with:
         arguments: "--info :integration_tests:test --tests IntegrationTests.shouldMatchIosSuccessExitCodeAndPattern -Dflank-path=../test_runner/build/libs/flank.jar -Dyml-path=./src/test/resources/flank_ios.yml"


### PR DESCRIPTION
Gradle Enterprise as removed in https://github.com/Flank/flank/pull/2324