### PR TITLE
update action to support macOS

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
     - id: output_paths
       run: |
-        file_path=$(find -name "flank-links.log")
+        file_path=$(find . -name "flank-links.log")
         local_directory_file=$(sed -n '1p' < $file_path)
         echo "local_results_directory=$(dirname $local_directory_file)" >> $GITHUB_OUTPUT
         echo "gcloud_results_directory=$(sed -n '2p' < $file_path)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
use an invocation of `find` that works on macOS as well as ubuntu

Fixes #2332 

## Test Plan
macOS before:
```
$ find -name "flank-links.log"
find: illegal option -- n
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
```

macOS after:
```
$ find . -name "flank-links.log"
./test_runner/flank-links.log
./integration_tests/flank-links.log
```

ubuntu:
```
$ find . -name "flank-links.log"
./test_runner/flank-links.log
```

The important bit is that the find command succeeds.

## Checklist

- [ ] Documented
- [ ] Unit tested
- [ ] Integration tests updated
