### PR TITLE
Fixes missing HTTP header X-Goog-User-Project

### DIFF
--- a/test_runner/src/main/kotlin/ftl/client/google/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/AndroidCatalog.kt
@@ -1,9 +1,11 @@
 package ftl.client.google
 
+import com.google.api.client.http.HttpHeaders
 import com.google.testing.model.AndroidDevice
 import com.google.testing.model.AndroidDeviceCatalog
 import com.google.testing.model.AndroidModel
 import com.google.testing.model.Orientation
+import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.http.executeWithRetry
 import ftl.presentation.cli.firebase.test.reportmanager.ReportManagerState
 import ftl.presentation.publish
@@ -21,6 +23,7 @@ object AndroidCatalog {
         GcTesting.get.testEnvironmentCatalog()
             .get("android")
             .setProjectId(projectId)
+            .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
             .executeWithRetry()
             .androidDeviceCatalog
             .filterDevicesWithoutSupportedVersions()

--- a/test_runner/src/main/kotlin/ftl/client/google/GcTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/GcTestMatrix.kt
@@ -1,7 +1,9 @@
 package ftl.client.google
 
+import com.google.api.client.http.HttpHeaders
 import com.google.testing.model.CancelTestMatrixResponse
 import com.google.testing.model.TestMatrix
+import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.http.executeWithRetry
 import ftl.run.exception.FlankGeneralError
 import kotlinx.coroutines.Dispatchers
@@ -38,6 +40,7 @@ object GcTestMatrix {
     suspend fun refresh(testMatrixId: String, projectId: String): TestMatrix {
         val getMatrix = withContext(Dispatchers.IO) {
             GcTesting.get.projects().testMatrices().get(projectId, testMatrixId)
+                .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
         }
         var failed = 0
         val maxWait = ofHours(1).seconds
@@ -57,6 +60,7 @@ object GcTestMatrix {
     suspend fun cancel(testMatrixId: String, projectId: String): CancelTestMatrixResponse {
         val cancelMatrix = withContext(Dispatchers.IO) {
             GcTesting.get.projects().testMatrices().cancel(projectId, testMatrixId)
+                .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
         }
         var failed = 0
         val maxTries = 3

--- a/test_runner/src/main/kotlin/ftl/client/google/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/IosCatalog.kt
@@ -1,9 +1,11 @@
 package ftl.client.google
 
+import com.google.api.client.http.HttpHeaders
 import com.google.testing.model.IosDeviceCatalog
 import com.google.testing.model.IosModel
 import com.google.testing.model.Orientation
 import ftl.config.Device
+import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.environment.getLocaleDescription
 import ftl.environment.ios.getDescription
 import ftl.environment.ios.iosVersionsToCliTable
@@ -50,6 +52,7 @@ object IosCatalog {
             GcTesting.get.testEnvironmentCatalog()
                 .get("ios")
                 .setProjectId(projectId)
+                .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
                 .executeWithRetry()
                 .iosDeviceCatalog
                 .filterDevicesWithoutSupportedVersions()

--- a/test_runner/src/main/kotlin/ftl/client/google/OsVersion.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/OsVersion.kt
@@ -1,13 +1,16 @@
 package ftl.client.google
 
+import com.google.api.client.http.HttpHeaders
 import com.google.testing.model.AndroidVersion
 import com.google.testing.model.IosVersion
+import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.http.executeWithRetry
 
 fun androidOsVersions(projectId: String): List<AndroidVersion> =
     GcTesting.get.testEnvironmentCatalog()
         .get("android")
         .setProjectId(projectId)
+        .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
         .executeWithRetry()
         .androidDeviceCatalog
         .versions
@@ -17,6 +20,7 @@ fun iosOsVersions(projectId: String): List<IosVersion> =
     GcTesting.get.testEnvironmentCatalog()
         .get("ios")
         .setProjectId(projectId)
+        .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
         .executeWithRetry()
         .iosDeviceCatalog
         .versions

--- a/test_runner/src/main/kotlin/ftl/client/google/run/android/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/run/android/GcAndroidTestMatrix.kt
@@ -1,5 +1,6 @@
 package ftl.client.google.run.android
 
+import com.google.api.client.http.HttpHeaders
 import com.google.common.annotations.VisibleForTesting
 import com.google.testing.Testing
 import com.google.testing.model.Account
@@ -22,6 +23,7 @@ import ftl.api.TestMatrixAndroid
 import ftl.client.google.GcTesting
 import ftl.client.google.run.toClientInfoDetailList
 import ftl.client.google.run.toFileReference
+import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.http.executeWithRetry
 import ftl.run.exception.FlankGeneralError
 import ftl.util.timeoutToSeconds
@@ -45,7 +47,9 @@ private suspend fun executeAndroidTestMatrix(
 ): List<Deferred<TestMatrix>> = coroutineScope {
     (0 until config.repeatTests).map { runIndex ->
         async(Dispatchers.IO) {
-            createAndroidTestMatrix(type, config, typeIndex, runIndex).executeWithRetry()
+            createAndroidTestMatrix(type, config, typeIndex, runIndex)
+                .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, config.project))
+                .executeWithRetry()
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/client/google/run/ios/GcIosTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/run/ios/GcIosTestMatrix.kt
@@ -1,5 +1,6 @@
 package ftl.client.google.run.ios
 
+import com.google.api.client.http.HttpHeaders
 import com.google.testing.Testing
 import com.google.testing.model.ClientInfo
 import com.google.testing.model.EnvironmentMatrix
@@ -15,6 +16,7 @@ import ftl.client.google.run.mapGcsPathsToFileReference
 import ftl.client.google.run.mapToIosDeviceFiles
 import ftl.client.google.run.toClientInfoDetailList
 import ftl.client.google.run.toIosDeviceFile
+import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.http.executeWithRetry
 import ftl.run.exception.FlankGeneralError
 import ftl.util.timeoutToSeconds
@@ -37,7 +39,9 @@ private suspend fun executeIosTestMatrixAsync(
     config: TestMatrixIos.Config
 ): Deferred<TestMatrix> = coroutineScope {
     async(Dispatchers.IO) {
-        createIosTestMatrix(type, config).executeWithRetry()
+        createIosTestMatrix(type, config)
+            .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, config.project))
+            .executeWithRetry()
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
+++ b/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
@@ -25,6 +25,7 @@ object FtlConstants {
     const val indent = "  "
     const val matrixIdsFile = "matrix_ids.json"
     const val applicationName = "Flank"
+    const val GCS_PROJECT_HEADER = "x-goog-user-project"
     const val GCS_PREFIX = "gs://"
     const val GCS_STORAGE_LINK = "https://console.developers.google.com/storage/browser/"
     const val runTimeout = "-1"

--- a/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
@@ -47,6 +47,7 @@ class BillableMinutesTest {
                 .testEnvironmentCatalog()
                 .get(any())
                 .setProjectId(any())
+                .setRequestHeaders(any())
                 .executeWithRetry()
         } returns make {
             androidDeviceCatalog = make { models = androidModels }


### PR DESCRIPTION
Flank does not pass the the HTTP header flag X-Goog-user-Project with project Id when using end user credentials. This results in HTTP error 403 (PERMISSION_DENIED). This fix sets the flag so the tests can be run by the user.

Fixes #2347

## Test Plan
> How do we know the code works?

Before:
> ./gradlew runFlank
`
 "message": "Your application has authenticated using end user credentials from the Google Cloud SDK or Google Cloud Shell which are not supported by the testing.googleapis.com. We recommend configuring the billing/quota_project setting in gcloud or using a service account through the auth/impersonate_service_account setting. For more information about service accounts and how to use them in your application, see https://cloud.google.com/docs/authentication/. If you are getting this error with curl or similar tools, you may need to specify 'X-Goog-User-Project' HTTP header for quota and billing purposes. For more information regarding 'X-Goog-User-Project' header, please check https://cloud.google.com/apis/docs/system-parameters.",   "status": "PERMISSION_DENIED"
`
Refer to #2347  for full error log

After:
> ./gradlew runFlank

This fix will pass HTTP header `{"X-Goog-user-Project" : project Id}` with requests for testing

```
> Task :execFlank
version: local_snapshot
revision: 2eefd478acad85f36cff0c6a4fe9e905b8c7bd3e
.........
Smart Flank cache hit: 0% (0 / 3)
  Shard times: 360s

1 matrix ids created in 0m 2s
  Raw results will be stored in your GCS bucket

Matrices webLink
  matrix-1234 https://console.firebase.google.com/project/abc-123456789/testlab/histories/abc.12345/matrices/12345566/details
.
.
.
Total run duration: 3m 36s
        - Preparation: 0m 1s
        - Scheduling tests: 0m 4s
        - Executing matrices: 3m 27s

```

## Steps to build & test locally

1. Checkout the branch
   >  git checkout vinaypotluri/missing-X-Goog-User-Project-2347

2. Build the project
   > ./gradlew build

   This generates a jar inside `~/.m2/repository/com/github/flank`

3. Configure your android project's fladle extension to use the generated local SNAPSHOT
```
fladle {
   projectId = "abc-123456789"
   resultsBucket = "my-bucket"
   resultsHistoryname = "my-app"
   flankVersion = "local-SNAPSHOT"
   ...
}
```
4. Run tests in FTL using fladle
   > ./gradlew runFlank

## Summary of the Changes

2 client libraries are being used namely ToolResults.java (toolresults.googleapis.com) & Testing.java (testing.googleapis.com) to interact with Firebase / Google Client.
All the classes that use these client libraries need to pass in the required header while making a request, otherwise this will result in http error 403. Changes in this PR will make sure to set the header when the client libraries are called.

ex: `{"x-goog-user-project", "my-project-id"}`


### Workflow:
<img width="952" alt="Screen Shot 2023-03-08 at 2 49 30 PM" src="https://user-images.githubusercontent.com/3403313/223869141-82a1a61b-6e90-4f4a-b660-7ff344d3576f.png">

### ToolResults.java
<img width="674" alt="Screen Shot 2023-03-08 at 2 53 31 PM" src="https://user-images.githubusercontent.com/3403313/223869710-422ffc68-7558-4e5c-9881-d01e88bb42c6.png">

### Testing.java
<img width="500" alt="Screen Shot 2023-03-08 at 2 53 02 PM" src="https://user-images.githubusercontent.com/3403313/223869650-c43ed439-175b-49a0-ae6e-2b6d107f3fa6.png">

