### PR TITLE
fix: Revert "Fixes missing HTTP header X-Goog-User-Project"

### DIFF
--- a/test_runner/src/main/kotlin/ftl/client/google/AndroidCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/AndroidCatalog.kt
@@ -1,11 +1,9 @@
 package ftl.client.google
 
-import com.google.api.client.http.HttpHeaders
 import com.google.testing.model.AndroidDevice
 import com.google.testing.model.AndroidDeviceCatalog
 import com.google.testing.model.AndroidModel
 import com.google.testing.model.Orientation
-import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.http.executeWithRetry
 import ftl.presentation.cli.firebase.test.reportmanager.ReportManagerState
 import ftl.presentation.publish
@@ -23,7 +21,6 @@ object AndroidCatalog {
         GcTesting.get.testEnvironmentCatalog()
             .get("android")
             .setProjectId(projectId)
-            .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
             .executeWithRetry()
             .androidDeviceCatalog
             .filterDevicesWithoutSupportedVersions()

--- a/test_runner/src/main/kotlin/ftl/client/google/GcTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/GcTestMatrix.kt
@@ -1,9 +1,7 @@
 package ftl.client.google
 
-import com.google.api.client.http.HttpHeaders
 import com.google.testing.model.CancelTestMatrixResponse
 import com.google.testing.model.TestMatrix
-import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.http.executeWithRetry
 import ftl.run.exception.FlankGeneralError
 import kotlinx.coroutines.Dispatchers
@@ -40,7 +38,6 @@ object GcTestMatrix {
     suspend fun refresh(testMatrixId: String, projectId: String): TestMatrix {
         val getMatrix = withContext(Dispatchers.IO) {
             GcTesting.get.projects().testMatrices().get(projectId, testMatrixId)
-                .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
         }
         var failed = 0
         val maxWait = ofHours(1).seconds
@@ -60,7 +57,6 @@ object GcTestMatrix {
     suspend fun cancel(testMatrixId: String, projectId: String): CancelTestMatrixResponse {
         val cancelMatrix = withContext(Dispatchers.IO) {
             GcTesting.get.projects().testMatrices().cancel(projectId, testMatrixId)
-                .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
         }
         var failed = 0
         val maxTries = 3

--- a/test_runner/src/main/kotlin/ftl/client/google/GcToolResults.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/GcToolResults.kt
@@ -1,6 +1,5 @@
 package ftl.client.google
 
-import com.google.api.client.http.HttpHeaders
 import com.google.api.services.toolresults.ToolResults
 import com.google.api.services.toolresults.model.Environment
 import com.google.api.services.toolresults.model.Execution
@@ -17,7 +16,6 @@ import com.google.testing.model.ToolResultsHistory
 import com.google.testing.model.ToolResultsStep
 import ftl.args.IArgs
 import ftl.config.FtlConstants
-import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.config.FtlConstants.JSON_FACTORY
 import ftl.config.FtlConstants.applicationName
 import ftl.config.FtlConstants.httpTransport
@@ -46,7 +44,6 @@ object GcToolResults {
             .histories()
             .list(args.project)
             .setFilterByName(args.resultsHistoryName)
-            .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, args.project))
             .executeWithRetry()
         return result?.histories ?: emptyList()
     }
@@ -59,7 +56,6 @@ object GcToolResults {
             .projects()
             .histories()
             .create(args.project, history)
-            .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, args.project))
             .execute()
     }
 
@@ -94,7 +90,6 @@ object GcToolResults {
                 toolResultsStep.historyId,
                 toolResultsStep.executionId
             )
-            .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, testExecution.projectId))
             .executeWithRetry()
     }
 
@@ -110,7 +105,6 @@ object GcToolResults {
                 toolResultsStep.executionId,
                 toolResultsStep.stepId
             )
-            .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, toolResultsStep.projectId))
             .executeWithRetry()
     }
 
@@ -127,7 +121,6 @@ object GcToolResults {
             toolResultsStep.executionId,
             toolResultsStep.stepId
         )
-        .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, toolResultsStep.projectId))
         .executeWithRetry()
 
     // Lists Test Cases attached to a Step
@@ -148,7 +141,6 @@ object GcToolResults {
                 toolResultsStep.stepId
             )
             .setPageToken(pageToken)
-            .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, toolResultsStep.projectId))
             .executeWithRetry()
     }
 
@@ -163,26 +155,12 @@ object GcToolResults {
     }
 
     fun getDefaultBucket(projectId: String, source: String? = null): String? = try {
-        service.Projects().initializeSettings(projectId)
-            .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
-            .executeWithRetry()
-            .defaultBucket
+        service.Projects().initializeSettings(projectId).executeWithRetry().defaultBucket
     } catch (ftlProjectError: FTLProjectError) {
         // flank needs to rewrap the exception with additional info about project
         when (ftlProjectError) {
-            is PermissionDenied -> throw FlankGeneralError(
-                permissionDeniedErrorMessage(
-                    projectId,
-                    source,
-                    ftlProjectError.message
-                )
-            )
-            is ProjectNotFound -> throw FlankGeneralError(
-                projectNotFoundErrorMessage(
-                    projectId,
-                    ftlProjectError.message
-                )
-            )
+            is PermissionDenied -> throw FlankGeneralError(permissionDeniedErrorMessage(projectId, source, ftlProjectError.message))
+            is ProjectNotFound -> throw FlankGeneralError(projectNotFoundErrorMessage(projectId, ftlProjectError.message))
             is FailureToken -> UserAuth.throwAuthenticationError()
         }
     }
@@ -212,7 +190,6 @@ object GcToolResults {
         )
         .setPageToken(pageToken)
         .setPageSize(100)
-        .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, results.projectId))
         .executeWithRetry()
 
     fun listAllSteps(results: ToolResultsExecution): MutableList<Step> {
@@ -240,7 +217,6 @@ object GcToolResults {
         )
         .setPageToken(pageToken)
         .setPageSize(100)
-        .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, results.projectId))
         .executeWithRetry()
 }
 

--- a/test_runner/src/main/kotlin/ftl/client/google/IosCatalog.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/IosCatalog.kt
@@ -1,11 +1,9 @@
 package ftl.client.google
 
-import com.google.api.client.http.HttpHeaders
 import com.google.testing.model.IosDeviceCatalog
 import com.google.testing.model.IosModel
 import com.google.testing.model.Orientation
 import ftl.config.Device
-import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.environment.getLocaleDescription
 import ftl.environment.ios.getDescription
 import ftl.environment.ios.iosVersionsToCliTable
@@ -52,7 +50,6 @@ object IosCatalog {
             GcTesting.get.testEnvironmentCatalog()
                 .get("ios")
                 .setProjectId(projectId)
-                .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
                 .executeWithRetry()
                 .iosDeviceCatalog
                 .filterDevicesWithoutSupportedVersions()

--- a/test_runner/src/main/kotlin/ftl/client/google/OsVersion.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/OsVersion.kt
@@ -1,16 +1,13 @@
 package ftl.client.google
 
-import com.google.api.client.http.HttpHeaders
 import com.google.testing.model.AndroidVersion
 import com.google.testing.model.IosVersion
-import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.http.executeWithRetry
 
 fun androidOsVersions(projectId: String): List<AndroidVersion> =
     GcTesting.get.testEnvironmentCatalog()
         .get("android")
         .setProjectId(projectId)
-        .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
         .executeWithRetry()
         .androidDeviceCatalog
         .versions
@@ -20,7 +17,6 @@ fun iosOsVersions(projectId: String): List<IosVersion> =
     GcTesting.get.testEnvironmentCatalog()
         .get("ios")
         .setProjectId(projectId)
-        .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, projectId))
         .executeWithRetry()
         .iosDeviceCatalog
         .versions

--- a/test_runner/src/main/kotlin/ftl/client/google/run/android/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/run/android/GcAndroidTestMatrix.kt
@@ -1,6 +1,5 @@
 package ftl.client.google.run.android
 
-import com.google.api.client.http.HttpHeaders
 import com.google.common.annotations.VisibleForTesting
 import com.google.testing.Testing
 import com.google.testing.model.Account
@@ -23,7 +22,6 @@ import ftl.api.TestMatrixAndroid
 import ftl.client.google.GcTesting
 import ftl.client.google.run.toClientInfoDetailList
 import ftl.client.google.run.toFileReference
-import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.http.executeWithRetry
 import ftl.run.exception.FlankGeneralError
 import ftl.util.timeoutToSeconds
@@ -47,9 +45,7 @@ private suspend fun executeAndroidTestMatrix(
 ): List<Deferred<TestMatrix>> = coroutineScope {
     (0 until config.repeatTests).map { runIndex ->
         async(Dispatchers.IO) {
-            createAndroidTestMatrix(type, config, typeIndex, runIndex)
-                .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, config.project))
-                .executeWithRetry()
+            createAndroidTestMatrix(type, config, typeIndex, runIndex).executeWithRetry()
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/client/google/run/ios/GcIosTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/client/google/run/ios/GcIosTestMatrix.kt
@@ -1,6 +1,5 @@
 package ftl.client.google.run.ios
 
-import com.google.api.client.http.HttpHeaders
 import com.google.testing.Testing
 import com.google.testing.model.ClientInfo
 import com.google.testing.model.EnvironmentMatrix
@@ -16,7 +15,6 @@ import ftl.client.google.run.mapGcsPathsToFileReference
 import ftl.client.google.run.mapToIosDeviceFiles
 import ftl.client.google.run.toClientInfoDetailList
 import ftl.client.google.run.toIosDeviceFile
-import ftl.config.FtlConstants.GCS_PROJECT_HEADER
 import ftl.http.executeWithRetry
 import ftl.run.exception.FlankGeneralError
 import ftl.util.timeoutToSeconds
@@ -39,9 +37,7 @@ private suspend fun executeIosTestMatrixAsync(
     config: TestMatrixIos.Config
 ): Deferred<TestMatrix> = coroutineScope {
     async(Dispatchers.IO) {
-        createIosTestMatrix(type, config)
-            .setRequestHeaders(HttpHeaders().set(GCS_PROJECT_HEADER, config.project))
-            .executeWithRetry()
+        createIosTestMatrix(type, config).executeWithRetry()
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
+++ b/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
@@ -25,7 +25,6 @@ object FtlConstants {
     const val indent = "  "
     const val matrixIdsFile = "matrix_ids.json"
     const val applicationName = "Flank"
-    const val GCS_PROJECT_HEADER = "x-goog-user-project"
     const val GCS_PREFIX = "gs://"
     const val GCS_STORAGE_LINK = "https://console.developers.google.com/storage/browser/"
     const val runTimeout = "-1"

--- a/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/outcome/BillableMinutesTest.kt
@@ -47,7 +47,6 @@ class BillableMinutesTest {
                 .testEnvironmentCatalog()
                 .get(any())
                 .setProjectId(any())
-                .setRequestHeaders(any())
                 .executeWithRetry()
         } returns make {
             androidDeviceCatalog = make { models = androidModels }


### PR DESCRIPTION
Reverts Flank/flank#2348

Unfortunately, this has unintended consequences for authorization with service accounts. Reverting/releasing a new version to limit the spread of the versions containing this change.