### PR TITLE
update google-auth-library-oauth2-http version to 1.17.0

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -40,7 +40,7 @@ object Versions {
     // https://github.com/googleapis/google-auth-library-java/releases
     // NOTE: https://github.com/googleapis/google-oauth-java-client is End of Life and replaced by google-auth-library-java
     // https://github.com/googleapis/google-oauth-java-client/issues/251#issuecomment-504565533
-    const val GOOGLE_AUTH = "1.8.0"
+    const val GOOGLE_AUTH = "1.17.0"
 
     // https://search.maven.org/search?q=a:google-cloud-nio%20g:com.google.cloud
     const val GOOGLE_NIO = "0.124.7"


### PR DESCRIPTION
Fixes #

## Test Plan
> How do we know the code works?
Unit and Integration tests still passing
.

## Checklist

- [ ] Documented
- [ ] Unit tested
- [ ] Integration tests updated
