### PR TITLE
fix: set correct max test shards when arm devices are configured

### DIFF
--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -70,6 +70,9 @@ interface IArgs {
     val inVirtualRange: Boolean
         get() = maxTestShards in AVAILABLE_VIRTUAL_SHARD_COUNT_RANGE
 
+    val inArmRange: Boolean
+        get() = maxTestShards in AVAILABLE_VIRTUAL_ARM_SHARD_COUNT_RANGE
+
     val defaultTestTime: Double
     val defaultClassTestTime: Double
     val useAverageTestTimeForNewTests: Boolean
@@ -87,10 +90,14 @@ interface IArgs {
     fun useLocalResultDir() = localResultDir != defaultLocalResultsDir
 
     companion object {
-        // num_shards must be >= 1, and <= 50
+        // num_shards must be >= 1, and <= 50 for physical devices
         val AVAILABLE_PHYSICAL_SHARD_COUNT_RANGE = 1..50
 
+        // num_shards must be >= 1, and <= 500 for non-Arm virtual devices
         val AVAILABLE_VIRTUAL_SHARD_COUNT_RANGE = 1..500
+
+        // num_shards must be >= 1, and <= 100 for Arm virtual devices
+        val AVAILABLE_VIRTUAL_ARM_SHARD_COUNT_RANGE = 1..100
     }
 
     interface ICompanion {

--- a/test_runner/src/main/kotlin/ftl/config/Device.kt
+++ b/test_runner/src/main/kotlin/ftl/config/Device.kt
@@ -43,3 +43,7 @@ fun Map<String, String>.asDevice(android: Boolean) =
 fun List<Device>.containsVirtualDevices() = any { it.isVirtual }
 
 fun List<Device>.containsPhysicalDevices() = any { !it.isVirtual }
+
+fun List<Device>.containsArmDevices() = any { it.model.endsWith(".arm") }
+
+fun List<Device>.containsNonArmDevices() = any { !it.model.endsWith(".arm") }


### PR DESCRIPTION
Current correct behavior:
* If max-test-shards is set to `-1`, **AND ONLY** physical devices are configured, Flank will adjust max-test-shards to the upper limit for physical devices
* If max-test-shards is set to `-1`, **AND ONLY** virtual devices are configured, Flank will adjust max-test-shards to the upper limit for virtual devices
* If max-test-shards is set to a value higher than the upper limit for physical devices **AND ONLY** physical devices are configured, Flank will throw a configuration error
* If max-test-shards is set to a value higher than the upper limit for physical devices **AND BOTH** physical and virtual devices are configured, Flank will adjust max-test-shards to the upper limit for physical devices
* If max-test-shards is set to a value higher than the upper limit for virtual devices, Flank will throw a configuration error

Current incorrect behavior:
* If max-test-shards is set to `-1`, and ARM devices are configured, Flank will adjust max-test-shards to the upper limit for virtual devices, which is currently higher than the documented upper limit for ARM devices
* If max-test-shards is set to a value higher than the upper limit for ARM devices and ARM devices are configured, Flank will adjust max-test-shards to the upper limit for virtual devices, which is currently higher than the documented upper limit for ARM devices


New behavior:
* If max-test-shards is set to `-1`, and ARM devices are configured, Flank will adjust max-test-shards to the upper limit for ARM devices
* If max-test-shards is set to a value higher than the upper limit for ARM devices **AND ONLY** ARM devices are configured, Flank will throw a configuration error
* If max-test-shards is set to a value higher than the upper limit for ARM devices **AND BOTH** ARM and non-ARM devices are configured, Flank will adjust max-test-shards to the upper limit for ARM devices

Fixes #2401

- [ ] Documented
- [X] Unit tested
- [ ] Integration tests updated
