### PR TITLE
remove check_approve_count job in wsl workflow

### DIFF
--- a/.github/workflows/wsl_workflow.yml
+++ b/.github/workflows/wsl_workflow.yml
@@ -4,28 +4,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  check_approve_count:
-    permissions:
-      pull-requests: read
-    runs-on: ubuntu-latest
-    outputs:
-      approve_count: ${{ steps.reviews.outputs.approved }}
-    steps:
-      - name: Check pull request is approved
-        id: 'reviews'
-        uses: jrylan/github-action-reviews-counter@main
-        with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
-
-      - name: Print current approve count
-        run: echo "Current Approve count ${{ steps.reviews.outputs.approved }}"
-
   integration-tests-wsl:
-    needs: [check_approve_count]
     permissions:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
       contents: read  # for actions/checkout to fetch code
-    if: 'needs.check_approve_count.outputs.approve_count >= 2'
     runs-on: windows-2019
     defaults:
       run:


### PR DESCRIPTION
It's not documented why this is necessary, but it blocks running the workflow manually when trying to validate dependabot PR's related to updating the workflow dependencies.
