### PR TITLE
fix: Replace hub with GitHub CLI 'gh' for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,20 +69,11 @@ jobs:
       with:
         arguments: "clean test_runner:build test_runner:shadowJar"
 
-    - name: Authenticate to hub
-      run: |
-            mkdir -p ~/.config/
-
-            cat << EOF > ~/.config/hub
-            github.com:
-            - user: $GITHUB_ACTOR
-              oauth_token: ${{ secrets.GITHUB_TOKEN }}
-              protocol: https
-            EOF
-
     - name: Delete old release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        hub version
+        gh --version
         flankScripts github delete_release --git-tag=$RELEASE_TAG
 
     - name: Delete old tag
@@ -91,10 +82,14 @@ jobs:
 
     - name: Release snapshot
       if: ${{ env.RELEASE_TAG == 'flank-snapshot' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: flankScripts github make_release --input-file=./test_runner/build/libs/flank.jar --git-tag=$RELEASE_TAG --commit-hash=$GIT_SHORT_HASH --snapshot
 
     - name: Release stable
       if: startsWith(github.ref, 'refs/tags/v')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: flankScripts github make_release --input-file=./test_runner/build/libs/flank.jar --git-tag=$RELEASE_TAG --token=${{ secrets.GITHUB_TOKEN }}
 
     - name: Append checksum to release

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -5,7 +5,7 @@
 1. A release process should be run withing macOS environment
 2. The machine should contain:
     `homebrew` - Package manager
-    `hub` - Github CLI tool
+    `gh` - Github CLI tool
 
 ## Current setup
 

--- a/flank-scripts/src/main/kotlin/flank/scripts/ops/github/DeleteOldRelease.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/ops/github/DeleteOldRelease.kt
@@ -4,4 +4,4 @@ import flank.scripts.utils.runCommand
 
 fun deleteOldRelease(tag: String) = "$DELETE_RELEASE_COMMAND $tag".runCommand()
 
-private const val DELETE_RELEASE_COMMAND = "hub release delete"
+private const val DELETE_RELEASE_COMMAND = "gh release delete"

--- a/flank-scripts/src/main/kotlin/flank/scripts/ops/github/ReleaseFlank.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/ops/github/ReleaseFlank.kt
@@ -41,23 +41,23 @@ private fun moveFlankToReleaseDirectory(inputPath: Path) =
     if (inputPath.toFile().renameTo(File(RELEASE_DIRECTORY))) RELEASE_DIRECTORY else inputPath.toAbsolutePath()
         .toString()
 
+/**
+ * See more details: https://cli.github.com/manual/gh_release_create
+  */
 private fun hubStableSnapshotCommand(path: String, gitTag: String, commitHash: String) =
     listOf(
-        "hub", "release", "create",
-        "-p",
-        "-a", path,
-        "-m", "Flank $gitTag",
-        "-m", "Snapshot release for commit $commitHash",
-        gitTag
+        "gh", "release", "create", gitTag, path,
+        "-p", // create a prerelease
+        "-t", "Flank $gitTag",
+        "-n", "Snapshot release for commit $commitHash",
+
     )
 
 private fun hubStableReleaseCommand(path: String, gitTag: String, token: String) =
     listOf(
-        "hub", "release", "create",
-        "-a", path,
-        "-m", "Flank $gitTag",
-        "-m", generateReleaseNotes(token).asString(gitTag),
-        gitTag
+        "gh", "release", "create", gitTag, path,
+        "-t", "Flank $gitTag",
+        "-n", generateReleaseNotes(token).asString(gitTag),
     )
 
 private const val RELEASE_DIRECTORY = "./RELEASE/flank.jar"


### PR DESCRIPTION
hub was removed as part of https://github.com/actions/runner-images/issues/8362

This change removes our dependency on hub and replaces all references with gh.

## Test Plan
Github Actions are broken, so we will know this is working when we can release in an automated fashion.

## Checklist

- [X] Documented
- [ ] Unit tested
- [ ] Integration tests updated
