### PR TITLE
ci: pass full commit sha through release command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,6 @@ jobs:
             else
               echo "RELEASE_TAG=flank-snapshot" >> $GITHUB_ENV
               echo "MVN_VERSION=master-SNAPSHOT" >> $GITHUB_ENV
-              git_short_hash=$(git rev-parse --short "$GITHUB_SHA")
-              echo "GIT_SHORT_HASH=$(echo $git_short_hash)" >> $GITHUB_ENV
           fi;
 
     - name: Store version variables to file
@@ -84,7 +82,7 @@ jobs:
       if: ${{ env.RELEASE_TAG == 'flank-snapshot' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: flankScripts github make_release --input-file=./test_runner/build/libs/flank.jar --git-tag=$RELEASE_TAG --commit-hash=$GIT_SHORT_HASH --snapshot
+      run: flankScripts github make_release --input-file=./test_runner/build/libs/flank.jar --git-tag=$RELEASE_TAG --commit-hash=$GITHUB_SHA --snapshot
 
     - name: Release stable
       if: startsWith(github.ref, 'refs/tags/v')

--- a/flank-scripts/src/main/kotlin/flank/scripts/ops/github/ReleaseFlank.kt
+++ b/flank-scripts/src/main/kotlin/flank/scripts/ops/github/ReleaseFlank.kt
@@ -50,7 +50,7 @@ private fun hubStableSnapshotCommand(path: String, gitTag: String, commitHash: S
         "-p", // create a prerelease
         "-t", "Flank $gitTag",
         "-n", "Snapshot release for commit $commitHash",
-
+        "--target", "$commitHash",
     )
 
 private fun hubStableReleaseCommand(path: String, gitTag: String, token: String) =


### PR DESCRIPTION
`GIT_SHORT_HASH` and its resulting usage seems to only be used in places where it becomes a human readable description. The release was recently switched to the `gh` command instead of `hub`, which seems to require a full sha rather than the short version.
