### PR TITLE
fix: Update shard limit for Arm devices to 200

### DIFF
--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -96,8 +96,8 @@ interface IArgs {
         // num_shards must be >= 1, and <= 500 for non-Arm virtual devices
         val AVAILABLE_VIRTUAL_SHARD_COUNT_RANGE = 1..500
 
-        // num_shards must be >= 1, and <= 100 for Arm virtual devices
-        val AVAILABLE_VIRTUAL_ARM_SHARD_COUNT_RANGE = 1..100
+        // num_shards must be >= 1, and <= 200 for Arm virtual devices
+        val AVAILABLE_VIRTUAL_ARM_SHARD_COUNT_RANGE = 1..200
     }
 
     interface ICompanion {


### PR DESCRIPTION
Fixes #

## Test Plan
Client configuration only. Already has unit tests.

## Checklist

- [X] Documented
- [X] Unit tested
- [X] Integration tests updated
