### PR TITLE
fix: set isRoboTest to true for robo tests

### DIFF
--- a/test_runner/src/main/kotlin/ftl/domain/testmatrix/UpdateTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/domain/testmatrix/UpdateTestMatrix.kt
@@ -45,7 +45,8 @@ private fun TestMatrix.Data.updateProperties(newMatrix: TestMatrix.Data) = copy(
     testFileName = newMatrix.testFileName,
     isCompleted = MatrixState.completed(state) &&
         newMatrix.testExecutions.all { MatrixState.completed(it.state) },
-    testExecutions = newMatrix.testExecutions
+    testExecutions = newMatrix.testExecutions,
+    isRoboTest = newMatrix.isRoboTest,
 )
 
 private fun TestMatrix.Data.updateBillableMinutes(billableMinutes: TestMatrix.BillableMinutes) = copy(

--- a/test_runner/src/test/kotlin/ftl/api/TestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/api/TestMatrixTest.kt
@@ -334,11 +334,12 @@ class TestMatrixTest {
         ftlTestMatrix.testExecutions = testExecutions
 
         var testMatrix = ftlTestMatrix.toApiModel()
+        assert(!testMatrix.isRoboTest)
+
         val newTestMatrix = ftlTestMatrix.toApiModel().copy(isRoboTest = true)
-
         testMatrix = testMatrix.copy(state = FINISHED)
-
         testMatrix = testMatrix.updateWithMatrix(newTestMatrix)
+
         assert(testMatrix.isRoboTest) { "isRoboTest was not updated" }
     }
 }

--- a/test_runner/src/test/kotlin/ftl/api/TestMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/api/TestMatrixTest.kt
@@ -318,6 +318,29 @@ class TestMatrixTest {
         val updatedMatrix = testMatrix.updateWithMatrix(ftlTestMatrix.toApiModel())
         assertEquals("N/A", updatedMatrix.appFileName)
     }
+
+    @Test
+    fun `isRoboTest property should update to true for Robo Test matrices`() {
+        val testExecutions = listOf(
+            createStepExecution(1, "shamu"),
+            createStepExecution(1, "NexusLowRes")
+        )
+
+        val matrixId = "123"
+        val ftlTestMatrix = ftlTestMatrix()
+        ftlTestMatrix.testMatrixId = matrixId
+        ftlTestMatrix.state = PENDING
+        ftlTestMatrix.resultStorage = createResultsStorage()
+        ftlTestMatrix.testExecutions = testExecutions
+
+        var testMatrix = ftlTestMatrix.toApiModel()
+        val newTestMatrix = ftlTestMatrix.toApiModel().copy(isRoboTest = true)
+
+        testMatrix = testMatrix.copy(state = FINISHED)
+
+        testMatrix = testMatrix.updateWithMatrix(newTestMatrix)
+        assert(testMatrix.isRoboTest) { "isRoboTest was not updated" }
+    }
 }
 
 private inline fun ref(path: () -> String) = FileReference().apply { gcsPath = path() }


### PR DESCRIPTION
## Description
This PR fixes the issue where `isRoboTest` was initially set to false by default, and was not being updated for Robo test matrices. The fix adds `isRoboTest = newMatrix.isRoboTest` to the updateProperties function, ensuring that the `isRoboTest` field is correctly set when the matrix properties are updated.

## Related issues
fixes https://github.com/Flank/flank/issues/2497

.

## Checklist

- [ ] Documented
- [ ] Unit tested
- [ ] Integration tests updated
