### PR TITLE
Fix markdown formatting on github pages

### DIFF
--- a/docs/feature/summary_output.md
+++ b/docs/feature/summary_output.md
@@ -17,18 +17,22 @@ Gcloud prints summary output in the table. It looks nice and is readable. Why we
 
 ## Possible outputs
 Numbers represent the `OUTCOME` column, and bullet points represent the `TEST DETAILS` column.
+
 1. success | flaky
    - `${1} test cases passed | ${2} skipped | ${3} flakes | (Native crash) | ---`
+
 2. failure
    - `${1} test cases failed | ${2} errors | ${3} passed | ${4} skipped | ${4} flakes | (Native crash)`
    - `Application crashed | (Native crash)`
    - `Test timed out | (Native crash)`
    - `App failed to install | (Native crash)`
    - `Unknown failure | (Native crash)`
+
 3. inconclusive
    - `Infrastructure failure`
    - `Test run aborted by user`
    - `Unknown reason`
+
 4. skipped
    - `Incompatible device/OS combination`
    - `App does not support the device architecture`

--- a/docs/feature/summary_output.md
+++ b/docs/feature/summary_output.md
@@ -16,7 +16,6 @@ As a user I want to see finely formatted summary result at the end of execution 
 Gcloud prints summary output in the table. It looks nice and is readable. Why we wouldn't have same in flank?
 
 ## Possible outputs
-
 Numbers represent the `OUTCOME` column, and bullet points represent the `TEST DETAILS` column.
 
 1. success | flaky

--- a/docs/feature/summary_output.md
+++ b/docs/feature/summary_output.md
@@ -16,24 +16,24 @@ As a user I want to see finely formatted summary result at the end of execution 
 Gcloud prints summary output in the table. It looks nice and is readable. Why we wouldn't have same in flank?
 
 ## Possible outputs
-Numbers are representing `OUTCOME` column, points are representing `TEST DETAILS` column.
-1. `success | flaky`
-    * `${1} test cases passed | ${2} skipped | ${3} flakes | (Native crash) | ---`
-2. `failure`
-    * `${1} test cases failed | ${2} errors | ${3} passed | ${4} skipped |  ${4} flakes  | (Native crash)`
-    * `Application crashed | (Native crash)`
-    * `Test timed out | (Native crash)`
-    * `App failed to install | (Native crash)`
-    * `Unknown failure | (Native crash)`
-3. `inconclusive`
-    * `Infrastructure failure`
-    * `Test run aborted by user`
-    * `Unknown reason`
-4. `skipped`
-    * `Incompatible device/OS combination`
-    * `App does not support the device architecture`
-    * `App does not support the OS version`
-    * `Unknown reason`
+Numbers represent the `OUTCOME` column, and bullet points represent the `TEST DETAILS` column.
+1. success | flaky
+   - `${1} test cases passed | ${2} skipped | ${3} flakes | (Native crash) | ---`
+2. failure
+   - `${1} test cases failed | ${2} errors | ${3} passed | ${4} skipped | ${4} flakes | (Native crash)`
+   - `Application crashed | (Native crash)`
+   - `Test timed out | (Native crash)`
+   - `App failed to install | (Native crash)`
+   - `Unknown failure | (Native crash)`
+3. inconclusive
+   - `Infrastructure failure`
+   - `Test run aborted by user`
+   - `Unknown reason`
+4. skipped
+   - `Incompatible device/OS combination`
+   - `App does not support the device architecture`
+   - `App does not support the OS version`
+   - `Unknown reason`
 
 ## Implementation details
 

--- a/docs/feature/summary_output.md
+++ b/docs/feature/summary_output.md
@@ -16,6 +16,7 @@ As a user I want to see finely formatted summary result at the end of execution 
 Gcloud prints summary output in the table. It looks nice and is readable. Why we wouldn't have same in flank?
 
 ## Possible outputs
+
 Numbers represent the `OUTCOME` column, and bullet points represent the `TEST DETAILS` column.
 
 1. success | flaky

--- a/docs/feature/summary_output.md
+++ b/docs/feature/summary_output.md
@@ -19,25 +19,25 @@ Gcloud prints summary output in the table. It looks nice and is readable. Why we
 Numbers represent the `OUTCOME` column, and bullet points represent the `TEST DETAILS` column.
 
 1. success | flaky
-   - `${1} test cases passed | ${2} skipped | ${3} flakes | (Native crash) | ---`
+    - `${1} test cases passed | ${2} skipped | ${3} flakes | (Native crash) | ---`
 
 2. failure
-   - `${1} test cases failed | ${2} errors | ${3} passed | ${4} skipped | ${4} flakes | (Native crash)`
-   - `Application crashed | (Native crash)`
-   - `Test timed out | (Native crash)`
-   - `App failed to install | (Native crash)`
-   - `Unknown failure | (Native crash)`
+    - `${1} test cases failed | ${2} errors | ${3} passed | ${4} skipped | ${4} flakes | (Native crash)`
+    - `Application crashed | (Native crash)`
+    - `Test timed out | (Native crash)`
+    - `App failed to install | (Native crash)`
+    - `Unknown failure | (Native crash)`
 
 3. inconclusive
-   - `Infrastructure failure`
-   - `Test run aborted by user`
-   - `Unknown reason`
+    - `Infrastructure failure`
+    - `Test run aborted by user`
+    - `Unknown reason`
 
 4. skipped
-   - `Incompatible device/OS combination`
-   - `App does not support the device architecture`
-   - `App does not support the OS version`
-   - `Unknown reason`
+    - `Incompatible device/OS combination`
+    - `App does not support the device architecture`
+    - `App does not support the OS version`
+    - `Unknown reason`
 
 
 ## Implementation details

--- a/docs/feature/summary_output.md
+++ b/docs/feature/summary_output.md
@@ -1,4 +1,4 @@
-# Formatted summary output 
+# Formatted summary output
 ```
 ┌─────────┬──────────────────────┬──────────────────────────┬─────────────────────────────────────────┐
 │ OUTCOME │      MATRIX ID       │     TEST AXIS VALUE      │              TEST DETAILS               │
@@ -38,6 +38,7 @@ Numbers represent the `OUTCOME` column, and bullet points represent the `TEST DE
    - `App does not support the device architecture`
    - `App does not support the OS version`
    - `Unknown reason`
+
 
 ## Implementation details
 


### PR DESCRIPTION
## Description
Fixed formatting in the `summary_output.md` file to ensure the "Possible outputs" section renders correctly in HTML.

fixes https://github.com/Flank/flank/issues/2371

## Test Plan
Visit https://flank.github.io/flank/feature/summary_output/ to verify the fix.

## Checklist

- [ ] Documented
- [ ] Unit tested
- [ ] Integration tests updated
