### PR TITLE
ci: update ubuntu_workfow to use GITHUB_STEP_SUMMARY instead of posting comments

### DIFF
--- a/.github/workflows/macos_workflow.yml
+++ b/.github/workflows/macos_workflow.yml
@@ -27,6 +27,7 @@ jobs:
     - uses: gradle/wrapper-validation-action@v3
     - uses: actions/setup-java@v4
       with:
+        distribution: 'adopt'
         java-version: 15
     - uses: actions/cache@v4
       with:
@@ -35,10 +36,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-2-gradle-
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
     - name: Gradle clean build
-      uses: gradle/gradle-build-action@v3.5.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HEAD_REF: ${{ github.head_ref }}
-      with:
-        arguments: "clean build"
+      run: ./gradlew clean build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,13 +59,14 @@ jobs:
           echo "$GITHUB_SHA" > ./test_runner/src/main/resources/revision.txt
           echo "$RELEASE_TAG" > ./test_runner/src/main/resources/version.txt
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
     - name: Gradle Build Flank
-      uses: gradle/gradle-build-action@v3.5.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HEAD_REF: ${{ github.head_ref }}
-      with:
-        arguments: "clean test_runner:build test_runner:shadowJar"
+      run: ./gradlew clean test_runner:build test_runner:shadowJar
 
     - name: Delete old release
       env:
@@ -98,22 +99,16 @@ jobs:
         gh release upload $RELEASE_TAG flank.sha256
 
     - name: Gradle Upload to MavenCentral
-      uses: gradle/gradle-build-action@v3.5.0
       env:
         PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
-      with:
-        arguments: :test_runner:publishMavenJavaPublicationToMavenCentralRepository -PMVN_CENTRAL_USER=${{ secrets.MVN_CENTRAL_USER }} -PMVN_CENTRAL_PASSWORD=${{ secrets.MVN_CENTRAL_PASSWORD }}
+      run: ./gradlew :test_runner:publishMavenJavaPublicationToMavenCentralRepository -PMVN_CENTRAL_USER=${{ secrets.MVN_CENTRAL_USER }} -PMVN_CENTRAL_PASSWORD=${{ secrets.MVN_CENTRAL_PASSWORD }}
 
     - name: Gradle close staging on MavenCentral
-      uses: gradle/gradle-build-action@v3.5.0
       if: startsWith(github.ref, 'refs/tags/v')
-      with:
-        arguments: closeAndReleaseRepository -PMVN_CENTRAL_USER=${{ secrets.MVN_CENTRAL_USER }} -PMVN_CENTRAL_PASSWORD=${{ secrets.MVN_CENTRAL_PASSWORD }}
+      run: ./gradlew closeAndReleaseRepository -PMVN_CENTRAL_USER=${{ secrets.MVN_CENTRAL_USER }} -PMVN_CENTRAL_PASSWORD=${{ secrets.MVN_CENTRAL_PASSWORD }}
 
     - name: Gradle Upload to GitHub packages
-      uses: gradle/gradle-build-action@v3.5.0
       if: startsWith(github.ref, 'refs/tags/v')
       env:
         PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
-      with:
-        arguments: ":test_runner:publishMavenJavaPublicationToGitHubPackagesRepository -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
+      run: ./gradlew :test_runner:publishMavenJavaPublicationToGitHubPackagesRepository -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,27 +69,25 @@ jobs:
       run: ./gradlew clean test_runner:build test_runner:shadowJar
 
     - name: Delete old release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh --version
         flankScripts github delete_release --git-tag=$RELEASE_TAG
 
     - name: Delete old tag
       if: ${{ env.RELEASE_TAG == 'flank-snapshot' }}
-      run: flankScripts github delete_old_tag --git-tag=$RELEASE_TAG --username=$GITHUB_ACTOR --token=${{ secrets.GITHUB_TOKEN }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: flankScripts github delete_old_tag --git-tag=$RELEASE_TAG --username=$GITHUB_ACTOR --token="$GH_TOKEN"
 
     - name: Release snapshot
       if: ${{ env.RELEASE_TAG == 'flank-snapshot' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: flankScripts github make_release --input-file=./test_runner/build/libs/flank.jar --git-tag=$RELEASE_TAG --commit-hash=$GITHUB_SHA --snapshot
 
     - name: Release stable
       if: startsWith(github.ref, 'refs/tags/v')
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: flankScripts github make_release --input-file=./test_runner/build/libs/flank.jar --git-tag=$RELEASE_TAG --token=${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: flankScripts github make_release --input-file=./test_runner/build/libs/flank.jar --git-tag=$RELEASE_TAG --token="$GH_TOKEN"
 
     - name: Append checksum to release
       env:
@@ -101,14 +99,20 @@ jobs:
     - name: Gradle Upload to MavenCentral
       env:
         PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
-      run: ./gradlew :test_runner:publishMavenJavaPublicationToMavenCentralRepository -PMVN_CENTRAL_USER=${{ secrets.MVN_CENTRAL_USER }} -PMVN_CENTRAL_PASSWORD=${{ secrets.MVN_CENTRAL_PASSWORD }}
+        MVN_CENTRAL_USER: ${{ secrets.MVN_CENTRAL_USER }}
+        PMVN_CENTRAL_PASSWORD: ${{ secrets.MVN_CENTRAL_PASSWORD }}
+      run: ./gradlew :test_runner:publishMavenJavaPublicationToMavenCentralRepository -PMVN_CENTRAL_USER="$MVN_CENTRAL_USER" -PMVN_CENTRAL_PASSWORD="$MVN_CENTRAL_PASSWORD"
 
     - name: Gradle close staging on MavenCentral
       if: startsWith(github.ref, 'refs/tags/v')
-      run: ./gradlew closeAndReleaseRepository -PMVN_CENTRAL_USER=${{ secrets.MVN_CENTRAL_USER }} -PMVN_CENTRAL_PASSWORD=${{ secrets.MVN_CENTRAL_PASSWORD }}
+      env: 
+        MVN_CENTRAL_USER: ${{ secrets.MVN_CENTRAL_USER }}
+        MVN_CENTRAL_PASSWORD: ${{ secrets.MVN_CENTRAL_PASSWORD }}
+      run: ./gradlew closeAndReleaseRepository -PMVN_CENTRAL_USER="$MVN_CENTRAL_USER" -PMVN_CENTRAL_PASSWORD="$MVN_CENTRAL_PASSWORD"
 
     - name: Gradle Upload to GitHub packages
       if: startsWith(github.ref, 'refs/tags/v')
       env:
         PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
-      run: ./gradlew :test_runner:publishMavenJavaPublicationToGitHubPackagesRepository -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./gradlew :test_runner:publishMavenJavaPublicationToGitHubPackagesRepository -PGITHUB_TOKEN="$GH_TOKEN"

--- a/.github/workflows/release_flank_scripts.yml
+++ b/.github/workflows/release_flank_scripts.yml
@@ -30,5 +30,5 @@ jobs:
 
     - name: Gradle Upload to Github packages and Github release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ./gradlew flank-scripts:releaseFlankScripts -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./gradlew flank-scripts:releaseFlankScripts -PGITHUB_TOKEN="$GH_TOKEN"

--- a/.github/workflows/release_flank_scripts.yml
+++ b/.github/workflows/release_flank_scripts.yml
@@ -25,9 +25,10 @@ jobs:
     - uses: actions/checkout@v4
     - uses: gradle/wrapper-validation-action@v3
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
     - name: Gradle Upload to Github packages and Github release
-      uses: gradle/gradle-build-action@v3.5.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        arguments: "flank-scripts:releaseFlankScripts -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
+      run: ./gradlew flank-scripts:releaseFlankScripts -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_flank_wrapper.yml
+++ b/.github/workflows/release_flank_wrapper.yml
@@ -25,9 +25,10 @@ jobs:
     - uses: actions/checkout@v4
     - uses: gradle/wrapper-validation-action@v3
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
     - name: Gradle Upload to Github packages and Github release
-      uses: gradle/gradle-build-action@v3.5.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        arguments: "flank_wrapper:releaseFlankWrapper -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}"
+      run: ./gradlew flank-wrapper:releaseFlankWrapper -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_flank_wrapper.yml
+++ b/.github/workflows/release_flank_wrapper.yml
@@ -30,5 +30,5 @@ jobs:
 
     - name: Gradle Upload to Github packages and Github release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: ./gradlew flank-wrapper:releaseFlankWrapper -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./gradlew flank-wrapper:releaseFlankWrapper -PGITHUB_TOKEN="$GH_TOKEN"

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -118,11 +118,13 @@ jobs:
           echo "./flank-scripts/bash" >> $GITHUB_PATH
 
       - name: Process IT results
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           flankScripts integration_tests process_results \
           --global-result=${{ needs.run-it-full-suite.outputs.job_status }} \
           --run-result='${{ toJSON(env) }}' \
-          --github-token=${{ secrets.GITHUB_TOKEN }} \
+          --github-token="$GH_TOKEN" \
           --run-id=${{ github.run_id }}
 
   trigger-pointer:

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -79,14 +79,15 @@ jobs:
             fi
         shell: bash
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Gradle integration tests
-        uses: gradle/gradle-build-action@v3.5.0
         id: run-it
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_REF: ${{ github.ref }}
-        with:
-          arguments: "integrationTests"
+        run: ./gradlew integrationTests
 
       - name: Export Variables for FlankScripts
         if: ${{ always() }}

--- a/.github/workflows/tag_next_release.yml
+++ b/.github/workflows/tag_next_release.yml
@@ -34,8 +34,10 @@ jobs:
           ./gradlew :flank-scripts:download
           echo "./flank-scripts/bash" >> $GITHUB_PATH
       - name: Set next release tag variable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG=$(flankScripts release next_tag --token=${{ secrets.GITHUB_TOKEN }})
+          TAG=$(flankScripts release next_tag --token="$GH_TOKEN")
           echo "NEXT_RELEASE_TAG=$(echo $TAG)" >> $GITHUB_ENV
 
       - name: Push tag

--- a/.github/workflows/ubuntu_workflow.yml
+++ b/.github/workflows/ubuntu_workflow.yml
@@ -52,7 +52,8 @@ jobs:
         run: ./gradlew clean build
       
   publish-scan-url:
-    needs: [build]
+    needs: 
+      - build
     permissions:
       pull-requests: write # to allow creating or updating a comment
     if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ubuntu_workflow.yml
+++ b/.github/workflows/ubuntu_workflow.yml
@@ -41,14 +41,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - id: build
         name: Gradle clean build
-        uses: gradle/gradle-build-action@v3.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_REF: ${{ github.head_ref }}
-        with:
-          arguments: "clean build"
+        run: ./gradlew clean build
 
   publish-scan-url:
     needs: [build]

--- a/.github/workflows/ubuntu_workflow.yml
+++ b/.github/workflows/ubuntu_workflow.yml
@@ -78,4 +78,3 @@ jobs:
           echo "**Buildscan URL for ubuntu-workflow run:**" >> $GITHUB_STEP_SUMMARY
           echo "[${{ github.run_id }}](https://github.com/Flank/flank/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
           echo "${{ needs.build.outputs.build-scan-url }}" >> $GITHUB_STEP_SUMMARY
-      

--- a/.github/workflows/ubuntu_workflow.yml
+++ b/.github/workflows/ubuntu_workflow.yml
@@ -6,16 +6,16 @@ on:
       - master
   pull_request:
     branches:
-      - "*"
+      - '*'
 
-permissions: # limit the permissions of the GITHIUB_TOKEN to reading repository contents
+permissions:  # limit the permissions of the GITHIUB_TOKEN to reading repository contents
   contents: read
 
 jobs:
   build:
     permissions:
-      actions: write # for styfle/cancel-workflow-action to cancel/stop running workflows
-      contents: read # for actions/checkout to fetch code
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     outputs:
       build-scan-url: ${{ steps.build.outputs.build-scan-url }}
@@ -41,16 +41,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - id: build
-        name: Gradle clean build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REF: ${{ github.head_ref }}
-        run: ./gradlew clean build
-
+              - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v4
+      
+            - id: build
+              name: Gradle clean build
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                HEAD_REF: ${{ github.head_ref }}
+              run: ./gradlew clean build
+      
   publish-scan-url:
     needs: [build]
     permissions:
@@ -77,3 +77,4 @@ jobs:
           echo "**Buildscan URL for ubuntu-workflow run:**" >> $GITHUB_STEP_SUMMARY
           echo "[${{ github.run_id }}](https://github.com/Flank/flank/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
           echo "${{ needs.build.outputs.build-scan-url }}" >> $GITHUB_STEP_SUMMARY
+      

--- a/.github/workflows/ubuntu_workflow.yml
+++ b/.github/workflows/ubuntu_workflow.yml
@@ -6,16 +6,16 @@ on:
       - master
   pull_request:
     branches:
-      - '*'
+      - "*"
 
-permissions:  # limit the permissions of the GITHIUB_TOKEN to reading repository contents
+permissions: # limit the permissions of the GITHIUB_TOKEN to reading repository contents
   contents: read
 
 jobs:
   build:
     permissions:
-      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
-      contents: read  # for actions/checkout to fetch code
+      actions: write # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     outputs:
       build-scan-url: ${{ steps.build.outputs.build-scan-url }}
@@ -51,7 +51,7 @@ jobs:
           arguments: "clean build"
 
   publish-scan-url:
-    needs: [ build ]
+    needs: [build]
     permissions:
       pull-requests: write # to allow creating or updating a comment
     if: ${{ github.event_name == 'pull_request' }}
@@ -67,34 +67,12 @@ jobs:
         uses: 1466587594/get-current-time@v2
         id: current-time
         with:
-          format: 'YYYY-MM-DD HH:mm:ss'
+          format: "YYYY-MM-DD HH:mm:ss"
           utcOffset: "+00:00"
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v3
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Buildscan url for ubuntu-workflow run
-
-      - name: Create comment
-        if: ${{ steps.fc.outputs.comment-id == 0 }}
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            **Timestamp:** ${{ steps.current-time.outputs.formattedTime }}
-            **Buildscan url for ubuntu-workflow run [${{ github.run_id }}](https://github.com/Flank/flank/actions/runs/${{ github.run_id }})**
-            ${{ needs.build.outputs.build-scan-url }}
-
-      - name: Update comment
-        if: ${{ steps.fc.outputs.comment-id != 0 }}
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          edit-mode: replace
-          body: |
-            **Timestamp:** ${{ steps.current-time.outputs.formattedTime }}
-            **Buildscan url for ubuntu-workflow run [${{ github.run_id }}](https://github.com/Flank/flank/actions/runs/${{ github.run_id }})**
-            ${{ needs.build.outputs.build-scan-url }}
+      - name: Write Buildscan URL to Summary
+        run: |
+          echo "**Timestamp:** ${{ steps.current-time.outputs.formattedTime }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Buildscan URL for ubuntu-workflow run:**" >> $GITHUB_STEP_SUMMARY
+          echo "[${{ github.run_id }}](https://github.com/Flank/flank/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+          echo "${{ needs.build.outputs.build-scan-url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ubuntu_workflow.yml
+++ b/.github/workflows/ubuntu_workflow.yml
@@ -41,15 +41,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-              - name: Setup Gradle
-              uses: gradle/actions/setup-gradle@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       
-            - id: build
-              name: Gradle clean build
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                HEAD_REF: ${{ github.head_ref }}
-              run: ./gradlew clean build
+      - id: build
+        name: Gradle clean build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: ./gradlew clean build
       
   publish-scan-url:
     needs: [build]

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -28,10 +28,11 @@ jobs:
           app_id: ${{ secrets.FLANK_RELEASE_APP_ID }}
           private_key: ${{ secrets.FLANK_RELEASE_PRIVATE_KEY }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Gradle dependency updates raport
-        uses: gradle/gradle-build-action@v3.5.0
-        with:
-          arguments: dependencyUpdates -DoutputFormatter=json -DoutputDir=.
+        run: ./gradlew dependencyUpdates -DoutputFormatter=json -DoutputDir=.
 
       - name: Download flankScripts and add it to PATH
         env:

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -118,9 +118,11 @@ jobs:
           echo "./flank-scripts/bash" >> $GITHUB_PATH
 
       - name: Run SDK check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           flankScripts firebase check_for_sdk_updates \
-          --github-token=${{ secrets.GITHUB_TOKEN }} \
+          --github-token="$GH_TOKEN" \
 
   trigger-pointer:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows_workflow.yml
+++ b/.github/workflows/windows_workflow.yml
@@ -29,10 +29,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-2-gradle-
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
     - name: Gradle clean build
-      uses: gradle/gradle-build-action@v3.5.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HEAD_REF: ${{ github.head_ref }}
-      with:
-        arguments: "clean build"
+      run: ./gradlew clean build

--- a/.github/workflows/wsl_workflow.yml
+++ b/.github/workflows/wsl_workflow.yml
@@ -57,17 +57,18 @@ jobs:
           GCLOUD_DIR="$HOME/.config/gcloud/"
           mkdir -p "$GCLOUD_DIR"
           echo "$GCLOUD_KEY" | base64 --ignore-garbage --decode > "$GCLOUD_DIR/application_default_credentials.json"
+          
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Gradle Integration Tests Android
-      uses: gradle/gradle-build-action@v3.5.0
       env:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-      with:
-        arguments: "--info :integration_tests:test --tests IntegrationTests.shouldMatchAndroidSuccessExitCodeAndPattern -Dflank-path=../test_runner/build/libs/flank.jar -Dyml-path=./src/test/resources/flank_android.yml"
+      run: |
+          ./gradlew --info :integration_tests:test --tests IntegrationTests.shouldMatchAndroidSuccessExitCodeAndPattern -Dflank-path=../test_runner/build/libs/flank.jar -Dyml-path=./src/test/resources/flank_android.yml
 
     - name: Gradle Integration Tests iOS
-      uses: gradle/gradle-build-action@v3.5.0
       env:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-      with:
-        arguments: "--info :integration_tests:test --tests IntegrationTests.shouldMatchIosSuccessExitCodeAndPattern -Dflank-path=../test_runner/build/libs/flank.jar -Dyml-path=./src/test/resources/flank_ios.yml"
+      run: |
+          ./gradlew --info :integration_tests:test --tests IntegrationTests.shouldMatchIosSuccessExitCodeAndPattern -Dflank-path=../test_runner/build/libs/flank.jar -Dyml-path=./src/test/resources/flank_ios.yml


### PR DESCRIPTION
Also updates gradle action according to this: https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle

Fixes #https://github.com/Flank/flank/issues/2544

