### PR TITLE
ci: add GH_TOKEN to some ci steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
 
     - name: Release snapshot
       if: ${{ env.RELEASE_TAG == 'flank-snapshot' }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: flankScripts github make_release --input-file=./test_runner/build/libs/flank.jar --git-tag=$RELEASE_TAG --commit-hash=$GITHUB_SHA --snapshot
 
     - name: Release stable
@@ -91,7 +93,7 @@ jobs:
 
     - name: Append checksum to release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         sha256sum ./test_runner/build/libs/flank.jar > flank.sha256
         gh release upload $RELEASE_TAG flank.sha256


### PR DESCRIPTION
Fixes 
```
Run flankScripts github make_release --input-file=./test_runner/build/libs/flank.jar --git-tag=$RELEASE_TAG --commit-hash=$GITHUB_SHA --snapshot
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
Error: Process completed with exit code 4.

```
